### PR TITLE
Touch event handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+A fork to try adding inputevent handling of touches
 # gst-wayland-display
 
 A micro Wayland compositor that can be used as a Gstreamer plugin. Based

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-A fork to try adding inputevent handling of touches
 # gst-wayland-display
 
 A micro Wayland compositor that can be used as a Gstreamer plugin. Based

--- a/c-bindings/src/capi.rs
+++ b/c-bindings/src/capi.rs
@@ -139,6 +139,36 @@ pub extern "C" fn display_pointer_axis(dpy: *mut WaylandDisplay, x: f64, y: f64)
 }
 
 #[no_mangle]
+pub extern "C" fn display_touch_down(dpy: *mut WaylandDisplay, id: c_uint, x: f64, y: f64) {
+    let display = unsafe { &mut *dpy };
+    display.touch_down(id, x, y);
+}
+
+#[no_mangle]
+pub extern "C" fn display_touch_up(dpy: *mut WaylandDisplay, id: c_uint) {
+    let display = unsafe { &mut *dpy };
+    display.touch_up(id);
+}
+
+#[no_mangle]
+pub extern "C" fn display_touch_motion(dpy: *mut WaylandDisplay, id: c_uint, x: f64, y: f64) {
+    let display = unsafe { &mut *dpy };
+    display.touch_motion(id, x, y);
+}
+
+#[no_mangle]
+pub extern "C" fn display_touch_cancel(dpy: *mut WaylandDisplay) {
+    let display = unsafe { &mut *dpy };
+    display.touch_cancel();
+}
+
+#[no_mangle]
+pub extern "C" fn display_touch_frame(dpy: *mut WaylandDisplay) {
+    let display = unsafe { &mut *dpy };
+    display.touch_frame();
+}
+
+#[no_mangle]
 pub extern "C" fn display_get_frame(dpy: *mut WaylandDisplay) -> *mut GstBuffer {
     let display = unsafe { &mut *dpy };
     let _span = match display.tracer.as_ref() {

--- a/c-bindings/src/capi.rs
+++ b/c-bindings/src/capi.rs
@@ -139,9 +139,9 @@ pub extern "C" fn display_pointer_axis(dpy: *mut WaylandDisplay, x: f64, y: f64)
 }
 
 #[no_mangle]
-pub extern "C" fn display_touch_down(dpy: *mut WaylandDisplay, id: c_uint, x: f64, y: f64) {
+pub extern "C" fn display_touch_down(dpy: *mut WaylandDisplay, id: c_uint, rel_x: f64, rel_y: f64) {
     let display = unsafe { &mut *dpy };
-    display.touch_down(id, x, y);
+    display.touch_down(id, rel_x, rel_y);
 }
 
 #[no_mangle]
@@ -151,9 +151,9 @@ pub extern "C" fn display_touch_up(dpy: *mut WaylandDisplay, id: c_uint) {
 }
 
 #[no_mangle]
-pub extern "C" fn display_touch_motion(dpy: *mut WaylandDisplay, id: c_uint, x: f64, y: f64) {
+pub extern "C" fn display_touch_motion(dpy: *mut WaylandDisplay, id: c_uint, rel_x: f64, rel_y: f64) {
     let display = unsafe { &mut *dpy };
-    display.touch_motion(id, x, y);
+    display.touch_motion(id, rel_x, rel_y);
 }
 
 #[no_mangle]

--- a/wayland-display-core/src/comp/input.rs
+++ b/wayland-display-core/src/comp/input.rs
@@ -7,7 +7,7 @@ use smithay::{
         input::{
             Axis, AxisSource, ButtonState, Event, InputEvent, KeyState, KeyboardKeyEvent,
             PointerAxisEvent, PointerButtonEvent, PointerMotionEvent, TouchEvent, TouchSlot,
-            AbsolutePositionEvent, DeviceCapability,
+            AbsolutePositionEvent,
         },
         libinput::LibinputInputBackend,
     },
@@ -449,16 +449,11 @@ impl State {
                     self.touch_motion(event.time_msec(), event.slot(), location);
                 }
             }
-            InputEvent::TouchCancel { event, .. } => {
+            InputEvent::TouchCancel { .. } => {
                 self.touch_cancel();
             }
             InputEvent::TouchFrame { .. } => {
                 self.touch_frame();
-            }
-            InputEvent::DeviceAdded { device } => {
-                if device.has_capability(DeviceCapability::Touch.into()) && self.seat.get_touch().is_none() {
-                    self.seat.add_touch();
-                }
             }
             _ => {}
         }

--- a/wayland-display-core/src/comp/input.rs
+++ b/wayland-display-core/src/comp/input.rs
@@ -294,8 +294,6 @@ impl State {
         location: Point<f64, Logical>,
     ) {
         let serial = SERIAL_COUNTER.next_serial();
-        self.last_pointer_movement = Instant::now();
-    
         let touch = self.seat.get_touch().unwrap();
         let under = self
             .space
@@ -304,13 +302,13 @@ impl State {
     
         touch.down(
             self,
+            under,
             &TouchDownEvent {
-                slot,
-                location,
+                slot: slot,
+                location: location,
                 serial,
                 time: event_time_msec,
             },
-            under,
         );
         touch.frame(self);
     }
@@ -326,7 +324,7 @@ impl State {
         touch.up(
             self,
             &TouchUpEvent {
-                slot,
+                slot: slot,
                 serial,
                 time: event_time_msec,
             },
@@ -341,9 +339,14 @@ impl State {
         location: Point<f64, Logical>,
     ) {
         let touch = self.seat.get_touch().unwrap();
+        let under = self
+            .space
+            .element_under(location)
+            .map(|(w, pos)| (w.clone().into(), pos));
     
         touch.motion(
             self,
+            under,
             &TouchMotionEvent {
                 slot,
                 location,

--- a/wayland-display-core/src/comp/input.rs
+++ b/wayland-display-core/src/comp/input.rs
@@ -6,14 +6,15 @@ use smithay::{
     backend::{
         input::{
             Axis, AxisSource, ButtonState, Event, InputEvent, KeyState, KeyboardKeyEvent,
-            PointerAxisEvent, PointerButtonEvent, PointerMotionEvent, TouchEvent,
+            PointerAxisEvent, PointerButtonEvent, PointerMotionEvent, TouchEvent, TouchSlot,
+            AbsolutePositionEvent,
         },
         libinput::LibinputInputBackend,
     },
     input::{
         keyboard::{keysyms, FilterResult},
         pointer::{AxisFrame, ButtonEvent, MotionEvent, RelativeMotionEvent},
-        touch::{DownEvent, UpEvent},
+        touch::{DownEvent, UpEvent, MotionEvent as TouchMotionEvent},
     },
     reexports::{
         input::LibinputInterface,
@@ -286,11 +287,31 @@ impl State {
         pointer.axis(self, frame);
         pointer.frame(self);
     }
+
+    fn touch_location_transformed<B: smithay::backend::input::InputBackend, E: AbsolutePositionEvent<B>>(
+        &self,
+        evt: &E,
+    ) -> Option<Point<f64, Logical>> {
+        let output = self
+            .space
+            .outputs()
+            .find(|output| output.name().starts_with("eDP"))
+            .or_else(|| self.space.outputs().next())?;
+
+        let output_geometry = self.space.output_geometry(output)?;
+        let transform = output.current_transform();
+        let size = transform.invert().transform_size(output_geometry.size);
+
+        Some(
+            transform.transform_point_in(evt.position_transformed(size), &size.to_f64())
+                + output_geometry.loc.to_f64(),
+        )
+    }
     
     pub fn touch_down(
         &mut self,
         event_time_msec: u32,
-        slot: u32,
+        slot: TouchSlot,
         location: Point<f64, Logical>,
     ) {
         let serial = SERIAL_COUNTER.next_serial();
@@ -298,7 +319,7 @@ impl State {
         let under = self
             .space
             .element_under(location)
-            .map(|(w, pos)| (w.clone().into(), pos));
+            .map(|(w, pos)| (w.clone().into(), pos.to_f64()));
     
         touch.down(
             self,
@@ -316,7 +337,7 @@ impl State {
     pub fn touch_up(
         &mut self,
         event_time_msec: u32,
-        slot: u32,
+        slot: TouchSlot,
     ) {
         let serial = SERIAL_COUNTER.next_serial();
         let touch = self.seat.get_touch().unwrap();
@@ -335,14 +356,14 @@ impl State {
     pub fn touch_motion(
         &mut self,
         event_time_msec: u32,
-        slot: u32,
+        slot: TouchSlot,
         location: Point<f64, Logical>,
     ) {
         let touch = self.seat.get_touch().unwrap();
         let under = self
             .space
             .element_under(location)
-            .map(|(w, pos)| (w.clone().into(), pos));
+            .map(|(w, pos)| (w.clone().into(), pos.to_f64()));
     
         touch.motion(
             self,
@@ -356,10 +377,9 @@ impl State {
         touch.frame(self);
     }
 
-    pub fn touch_cancel(&mut self, event_time_msec: u32) {
+    pub fn touch_cancel(&mut self) {
         let touch = self.seat.get_touch().unwrap();
-        touch.cancel(self, event_time_msec);
-        touch.frame(self);
+        touch.cancel(self);
     }
     
     pub fn touch_frame(&mut self) {
@@ -417,42 +437,20 @@ impl State {
                 );
             }
             InputEvent::TouchDown { event, .. } => {
-                if let Some(output) = self.output.as_ref() {
-                    let output_size = output
-                        .current_mode()
-                        .unwrap()
-                        .size
-                        .to_f64()
-                        .to_logical(output.current_scale().fractional_scale())
-                        .to_i32_round();
-            
-                    let x = event.absolute_x_transformed(output_size.w);
-                    let y = event.absolute_y_transformed(output_size.h);
-            
-                    self.touch_down(event.time_msec(), event.slot(), (x, y).into());
+                if let Some(location) = self.touch_location_transformed(&event) {
+                    self.touch_down(event.time_msec(), event.slot(), location);
                 }
             }
             InputEvent::TouchUp { event, .. } => {
                 self.touch_up(event.time_msec(), event.slot());
             }
             InputEvent::TouchMotion { event, .. } => {
-                if let Some(output) = self.output.as_ref() {
-                    let output_size = output
-                        .current_mode()
-                        .unwrap()
-                        .size
-                        .to_f64()
-                        .to_logical(output.current_scale().fractional_scale())
-                        .to_i32_round();
-            
-                    let x = event.absolute_x_transformed(output_size.w);
-                    let y = event.absolute_y_transformed(output_size.h);
-            
-                    self.touch_motion(event.time_msec(), event.slot(), (x, y).into());
+                if let Some(location) = self.touch_location_transformed(&event) {
+                    self.touch_motion(event.time_msec(), event.slot(), location);
                 }
             }
             InputEvent::TouchCancel { event, .. } => {
-                self.touch_cancel(event.time_msec());
+                self.touch_cancel();
             }
             InputEvent::TouchFrame { .. } => {
                 self.touch_frame();

--- a/wayland-display-core/src/comp/input.rs
+++ b/wayland-display-core/src/comp/input.rs
@@ -13,6 +13,7 @@ use smithay::{
     input::{
         keyboard::{keysyms, FilterResult},
         pointer::{AxisFrame, ButtonEvent, MotionEvent, RelativeMotionEvent},
+        touch::{TouchDownEvent, TouchMotionEvent, TouchUpEvent},
     },
     reexports::{
         input::LibinputInterface,
@@ -285,6 +286,83 @@ impl State {
         pointer.axis(self, frame);
         pointer.frame(self);
     }
+    
+    pub fn touch_down(
+        &mut self,
+        event_time_msec: u32,
+        slot: u32,
+        location: Point<f64, Logical>,
+    ) {
+        let serial = SERIAL_COUNTER.next_serial();
+        self.last_pointer_movement = Instant::now();
+    
+        let touch = self.seat.get_touch().unwrap();
+        let under = self
+            .space
+            .element_under(location)
+            .map(|(w, pos)| (w.clone().into(), pos));
+    
+        touch.down(
+            self,
+            &TouchDownEvent {
+                slot,
+                location,
+                serial,
+                time: event_time_msec,
+            },
+            under,
+        );
+        touch.frame(self);
+    }
+
+    pub fn touch_up(
+        &mut self,
+        event_time_msec: u32,
+        slot: u32,
+    ) {
+        let serial = SERIAL_COUNTER.next_serial();
+        let touch = self.seat.get_touch().unwrap();
+    
+        touch.up(
+            self,
+            &TouchUpEvent {
+                slot,
+                serial,
+                time: event_time_msec,
+            },
+        );
+        touch.frame(self);
+    }
+    
+    pub fn touch_motion(
+        &mut self,
+        event_time_msec: u32,
+        slot: u32,
+        location: Point<f64, Logical>,
+    ) {
+        let touch = self.seat.get_touch().unwrap();
+    
+        touch.motion(
+            self,
+            &TouchMotionEvent {
+                slot,
+                location,
+                time: event_time_msec,
+            },
+        );
+        touch.frame(self);
+    }
+
+    pub fn touch_cancel(&mut self, event_time_msec: u32) {
+        let touch = self.seat.get_touch().unwrap();
+        touch.cancel(self, event_time_msec);
+        touch.frame(self);
+    }
+    
+    pub fn touch_frame(&mut self) {
+        let touch = self.seat.get_touch().unwrap();
+        touch.frame(self);
+    }
 
     pub fn process_input_event(&mut self, event: InputEvent<LibinputInputBackend>) {
         match event {
@@ -334,6 +412,47 @@ impl State {
                     horizontal_amount_discrete,
                     vertical_amount_discrete,
                 );
+            }
+            InputEvent::TouchDown { event, .. } => {
+                if let Some(output) = self.output.as_ref() {
+                    let output_size = output
+                        .current_mode()
+                        .unwrap()
+                        .size
+                        .to_f64()
+                        .to_logical(output.current_scale().fractional_scale())
+                        .to_i32_round();
+            
+                    let x = event.absolute_x_transformed(output_size.w);
+                    let y = event.absolute_y_transformed(output_size.h);
+            
+                    self.touch_down(event.time_msec(), event.slot(), (x, y).into());
+                }
+            }
+            InputEvent::TouchUp { event, .. } => {
+                self.touch_up(event.time_msec(), event.slot());
+            }
+            InputEvent::TouchMotion { event, .. } => {
+                if let Some(output) = self.output.as_ref() {
+                    let output_size = output
+                        .current_mode()
+                        .unwrap()
+                        .size
+                        .to_f64()
+                        .to_logical(output.current_scale().fractional_scale())
+                        .to_i32_round();
+            
+                    let x = event.absolute_x_transformed(output_size.w);
+                    let y = event.absolute_y_transformed(output_size.h);
+            
+                    self.touch_motion(event.time_msec(), event.slot(), (x, y).into());
+                }
+            }
+            InputEvent::TouchCancel { event, .. } => {
+                self.touch_cancel(event.time_msec());
+            }
+            InputEvent::TouchFrame { .. } => {
+                self.touch_frame();
             }
             _ => {}
         }

--- a/wayland-display-core/src/comp/input.rs
+++ b/wayland-display-core/src/comp/input.rs
@@ -307,6 +307,32 @@ impl State {
                 + output_geometry.loc.to_f64(),
         )
     }
+
+    pub fn relative_touch_to_logical(
+        &mut self,                
+        relative_pos: Point<f64, Logical>,                           // 0.0 to 1.0
+    ) -> Option<Point<f64, Logical>> {
+        let output = self.space
+            .outputs()
+            .find(|output| output.name().starts_with("eDP"))
+            .or_else(|| self.space.outputs().next())?;
+
+        let output_geometry = self.space.output_geometry(output)?;
+        let transform = output.current_transform();
+
+        // Size before transform
+        let untransformed_size = transform.invert().transform_size(output_geometry.size);
+        let size_f64 = untransformed_size.to_f64();
+
+        // Scaled raw position in untransformed space
+        let pos = Point::from((relative_pos.x * size_f64.w, relative_pos.y * size_f64.h));
+
+        // Now apply the output transform
+        let transformed_pos = transform.transform_point_in(pos, &size_f64);
+
+        // Map to global logical coordinates
+        Some(transformed_pos + output_geometry.loc.to_f64())
+    }
     
     pub fn touch_down(
         &mut self,

--- a/wayland-display-core/src/comp/input.rs
+++ b/wayland-display-core/src/comp/input.rs
@@ -7,7 +7,7 @@ use smithay::{
         input::{
             Axis, AxisSource, ButtonState, Event, InputEvent, KeyState, KeyboardKeyEvent,
             PointerAxisEvent, PointerButtonEvent, PointerMotionEvent, TouchEvent, TouchSlot,
-            AbsolutePositionEvent,
+            AbsolutePositionEvent, DeviceCapability,
         },
         libinput::LibinputInputBackend,
     },
@@ -454,6 +454,11 @@ impl State {
             }
             InputEvent::TouchFrame { .. } => {
                 self.touch_frame();
+            }
+            InputEvent::DeviceAdded { device } => {
+                if device.has_capability(DeviceCapability::Touch.into()) && self.seat.get_touch().is_none() {
+                    self.seat.add_touch();
+                }
             }
             _ => {}
         }

--- a/wayland-display-core/src/comp/input.rs
+++ b/wayland-display-core/src/comp/input.rs
@@ -6,14 +6,14 @@ use smithay::{
     backend::{
         input::{
             Axis, AxisSource, ButtonState, Event, InputEvent, KeyState, KeyboardKeyEvent,
-            PointerAxisEvent, PointerButtonEvent, PointerMotionEvent,
+            PointerAxisEvent, PointerButtonEvent, PointerMotionEvent, TouchEvent,
         },
         libinput::LibinputInputBackend,
     },
     input::{
         keyboard::{keysyms, FilterResult},
         pointer::{AxisFrame, ButtonEvent, MotionEvent, RelativeMotionEvent},
-        touch::{TouchDownEvent, TouchMotionEvent, TouchUpEvent},
+        touch::{DownEvent, UpEvent},
     },
     reexports::{
         input::LibinputInterface,
@@ -303,7 +303,7 @@ impl State {
         touch.down(
             self,
             under,
-            &TouchDownEvent {
+            &DownEvent {
                 slot: slot,
                 location: location,
                 serial,
@@ -323,7 +323,7 @@ impl State {
     
         touch.up(
             self,
-            &TouchUpEvent {
+            &UpEvent {
                 slot: slot,
                 serial,
                 time: event_time_msec,

--- a/wayland-display-core/src/comp/mod.rs
+++ b/wayland-display-core/src/comp/mod.rs
@@ -502,9 +502,9 @@ pub(crate) fn init(
                     let time: Duration = state.clock.now().into();
                     state.pointer_axis(time.as_millis() as u32, AxisSource::Wheel, horizontal_amount * 3.0 / 120.0, vertical_amount * 3.0 / 120.0, Some(horizontal_amount), Some(vertical_amount));
                 }
-                Event::Msg(Command::TouchDown(id, position)) => {
+                Event::Msg(Command::TouchDown(id, rel_position)) => {
                     let time: Duration = state.clock.now().into();
-                    let logical_position = state.relative_touch_to_logical(position)
+                    let logical_position = state.relative_touch_to_logical(rel_position)
                         .expect("Failed to convert relative touch position to logical coordinates");
                     state.touch_down(time.as_millis() as u32, TouchSlot::from(Some(id)), logical_position);
                 }
@@ -512,9 +512,9 @@ pub(crate) fn init(
                     let time: Duration = state.clock.now().into();
                     state.touch_up(time.as_millis() as u32, TouchSlot::from(Some(id)));
                 }
-                Event::Msg(Command::TouchMotion(id, position)) => {
+                Event::Msg(Command::TouchMotion(id, rel_position)) => {
                     let time: Duration = state.clock.now().into();
-                    let logical_position = state.relative_touch_to_logical(position)
+                    let logical_position = state.relative_touch_to_logical(rel_position)
                         .expect("Failed to convert relative touch position to logical coordinates");
                     state.touch_motion(time.as_millis() as u32, TouchSlot::from(Some(id)), logical_position);
                 }

--- a/wayland-display-core/src/comp/mod.rs
+++ b/wayland-display-core/src/comp/mod.rs
@@ -60,6 +60,7 @@ use smithay::{
     },
 };
 use smithay::backend::input::AxisSource;
+use smithay::backend::input::TouchSlot;
 use tracing::debug;
 
 mod focus;
@@ -237,6 +238,7 @@ pub(crate) fn init(
     seat.add_keyboard(XkbConfig::default(), 200, 25)
         .expect("Failed to add keyboard to seat");
     seat.add_pointer();
+    seat.add_touch();
 
     let mut event_loop =
         EventLoop::<State>::try_new().expect("Unable to create event_loop");
@@ -499,6 +501,24 @@ pub(crate) fn init(
                 Event::Msg(Command::PointerAxis(horizontal_amount, vertical_amount)) => {
                     let time: Duration = state.clock.now().into();
                     state.pointer_axis(time.as_millis() as u32, AxisSource::Wheel, horizontal_amount * 3.0 / 120.0, vertical_amount * 3.0 / 120.0, Some(horizontal_amount), Some(vertical_amount));
+                }
+                Event::Msg(Command::TouchDown(id, position)) => {
+                    let time: Duration = state.clock.now().into();
+                    state.touch_down(time.as_millis() as u32, TouchSlot::from(Some(id)), position);
+                }
+                Event::Msg(Command::TouchUp(id)) => {
+                    let time: Duration = state.clock.now().into();
+                    state.touch_up(time.as_millis() as u32, TouchSlot::from(Some(id)));
+                }
+                Event::Msg(Command::TouchMotion(id, position)) => {
+                    let time: Duration = state.clock.now().into();
+                    state.touch_motion(time.as_millis() as u32, TouchSlot::from(Some(id)), position);
+                }
+                Event::Msg(Command::TouchCancel) => {
+                    state.touch_cancel();
+                }
+                Event::Msg(Command::TouchFrame) => {
+                    state.touch_frame();
                 }
             };
         })

--- a/wayland-display-core/src/comp/mod.rs
+++ b/wayland-display-core/src/comp/mod.rs
@@ -504,7 +504,9 @@ pub(crate) fn init(
                 }
                 Event::Msg(Command::TouchDown(id, position)) => {
                     let time: Duration = state.clock.now().into();
-                    state.touch_down(time.as_millis() as u32, TouchSlot::from(Some(id)), position);
+                    let logical_position = state.relative_touch_to_logical(position)
+                        .expect("Failed to convert relative touch position to logical coordinates");
+                    state.touch_down(time.as_millis() as u32, TouchSlot::from(Some(id)), logical_position);
                 }
                 Event::Msg(Command::TouchUp(id)) => {
                     let time: Duration = state.clock.now().into();
@@ -512,7 +514,9 @@ pub(crate) fn init(
                 }
                 Event::Msg(Command::TouchMotion(id, position)) => {
                     let time: Duration = state.clock.now().into();
-                    state.touch_motion(time.as_millis() as u32, TouchSlot::from(Some(id)), position);
+                    let logical_position = state.relative_touch_to_logical(position)
+                        .expect("Failed to convert relative touch position to logical coordinates");
+                    state.touch_motion(time.as_millis() as u32, TouchSlot::from(Some(id)), logical_position);
                 }
                 Event::Msg(Command::TouchCancel) => {
                     state.touch_cancel();

--- a/wayland-display-core/src/lib.rs
+++ b/wayland-display-core/src/lib.rs
@@ -25,6 +25,11 @@ pub(crate) enum Command {
     PointerMotionAbsolute(Point<f64, Logical>),
     PointerButton(u32, ButtonState),
     PointerAxis(f64, f64),
+    TouchDown(u32, Point<f64, Logical>),
+    TouchUp(u32),
+    TouchMotion(u32, Point<f64, Logical>),
+    TouchCancel,
+    TouchFrame,
     Quit,
 }
 
@@ -165,6 +170,26 @@ impl WaylandDisplay {
 
     pub fn pointer_axis(&self, x: f64, y: f64) {
         let _ = self.command_tx.send(Command::PointerAxis(x, y));
+    }
+
+    pub fn touch_down(&self, id: u32, x: f64, y: f64) {
+        let _ = self.command_tx.send(Command::TouchDown(id, (x, y).into()));
+    }
+
+    pub fn touch_up(&self, id: u32) {
+        let _ = self.command_tx.send(Command::TouchUp(id));
+    }
+    
+    pub fn touch_motion(&self, id: u32, x: f64, y: f64) {
+        let _ = self.command_tx.send(Command::TouchMotion(id, (x, y).into()));
+    }
+
+    pub fn touch_cancel(&self) {
+        let _ = self.command_tx.send(Command::TouchCancel);
+    }
+
+    pub fn touch_frame(&self) {
+        let _ = self.command_tx.send(Command::TouchFrame);
     }
 
     pub fn frame(&self) -> Result<gst::Buffer, gst::FlowError> {

--- a/wayland-display-core/src/lib.rs
+++ b/wayland-display-core/src/lib.rs
@@ -172,16 +172,16 @@ impl WaylandDisplay {
         let _ = self.command_tx.send(Command::PointerAxis(x, y));
     }
 
-    pub fn touch_down(&self, id: u32, x: f64, y: f64) {
-        let _ = self.command_tx.send(Command::TouchDown(id, (x, y).into()));
+    pub fn touch_down(&self, id: u32, rel_x: f64, rel_y: f64) {
+        let _ = self.command_tx.send(Command::TouchDown(id, (rel_x, rel_y).into()));
     }
 
     pub fn touch_up(&self, id: u32) {
         let _ = self.command_tx.send(Command::TouchUp(id));
     }
     
-    pub fn touch_motion(&self, id: u32, x: f64, y: f64) {
-        let _ = self.command_tx.send(Command::TouchMotion(id, (x, y).into()));
+    pub fn touch_motion(&self, id: u32, rel_x: f64, rel_y: f64) {
+        let _ = self.command_tx.send(Command::TouchMotion(id, (rel_x, rel_y).into()));
     }
 
     pub fn touch_cancel(&self) {


### PR DESCRIPTION
The current InputEvent handling do not handle touch related events. Here is my attempt to add the support, which I have tested on the wolf dev-container.

P.S. I found that the smithay anvil has more complete support to all kinds of events. Maybe worth porting the input_handler from there at some point. https://github.com/Smithay/smithay/blob/master/anvil/src/input_handler.rs