### PR TITLE
fix: workaround i915 modifier issue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "c-bindings"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "gstreamer",
  "gstreamer-video",
@@ -448,7 +448,7 @@ dependencies = [
 
 [[package]]
 name = "gst-plugin-wayland-display"
-version = "0.2.0"
+version = "0.4.0"
 dependencies = [
  "gst-plugin-version-helper",
  "gstreamer",
@@ -1055,6 +1055,7 @@ dependencies = [
  "appendlist",
  "bitflags 2.4.1",
  "calloop",
+ "cc",
  "cgmath",
  "cursor-icon",
  "downcast-rs",
@@ -1070,6 +1071,7 @@ dependencies = [
  "libc",
  "libloading",
  "once_cell",
+ "pkg-config",
  "profiling",
  "rand",
  "rustix",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,12 +18,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.75"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
-
-[[package]]
 name = "appendlist"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -58,9 +52,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.1"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "bumpalo"
@@ -85,7 +79,7 @@ checksum = "965ab7eb5f8f97d2a083c799f3a1b994fc397b2fe2da5d1da1626ce15a39f2b1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn",
 ]
 
 [[package]]
@@ -105,7 +99,7 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c58a38167d6fba8c67cce63c4a91f2a73ca42cbdaf6fb9ba164f1e07b43ecc10"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.6.0",
  "log",
  "polling",
  "rustix",
@@ -123,9 +117,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-expr"
-version = "0.15.5"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03915af431787e6ffdcc74c645077518c6b6e01f80b761e0fbbfa288536311b3"
+checksum = "c360837f8f19e2e4468275138f1c0dec1647d1e17bb7c0215fe3cd7530e93c25"
 dependencies = [
  "smallvec",
  "target-lexicon",
@@ -207,7 +201,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98888c4bbd601524c11a7ed63f814b8825f420514f78e96f752c437ae9cbb5d1"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.6.0",
  "bytemuck",
  "drm-ffi",
  "drm-fourcc",
@@ -239,6 +233,12 @@ dependencies = [
  "libc",
  "linux-raw-sys 0.6.4",
 ]
+
+[[package]]
+name = "either"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "equivalent"
@@ -296,7 +296,7 @@ checksum = "53b153fd91e4b0147f4aced87be237c98248656bb01050b96bf3ee89220a8ddb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn",
 ]
 
 [[package]]
@@ -325,7 +325,7 @@ version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45bf55ba6dd53ad0ac115046ff999c5324c283444ee6e0be82454c4e8eb2f36a"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.6.0",
  "drm",
  "drm-fourcc",
  "gbm-sys",
@@ -356,15 +356,15 @@ dependencies = [
 
 [[package]]
 name = "gio-sys"
-version = "0.17.10"
+version = "0.20.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ccf87c30a12c469b6d958950f6a9c09f2be20b7773f7e70d20b867fdf2628c3"
+checksum = "b965df6f3534c84816b5c1a7d9efcb5671ae790822de5abe8e299797039529bc"
 dependencies = [
  "glib-sys",
  "gobject-sys",
  "libc",
  "system-deps",
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -380,11 +380,11 @@ dependencies = [
 
 [[package]]
 name = "glib"
-version = "0.17.10"
+version = "0.20.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3fad45ba8d4d2cea612b432717e834f48031cd8853c8aaf43b2c79fec8d144b"
+checksum = "86bd3e4ee7998ab5a135d900db56930cc19ad16681adf245daff54f618b9d5e1"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.6.0",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -396,31 +396,27 @@ dependencies = [
  "gobject-sys",
  "libc",
  "memchr",
- "once_cell",
  "smallvec",
- "thiserror",
 ]
 
 [[package]]
 name = "glib-macros"
-version = "0.17.10"
+version = "0.20.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eca5c79337338391f1ab8058d6698125034ce8ef31b72a442437fa6c8580de26"
+checksum = "e7d21ca27acfc3e91da70456edde144b4ac7c36f78ee77b10189b3eb4901c156"
 dependencies = [
- "anyhow",
  "heck",
  "proc-macro-crate",
- "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
 name = "glib-sys"
-version = "0.17.10"
+version = "0.20.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d80aa6ea7bba0baac79222204aa786a6293078c210abe69ef1336911d4bdc4f0"
+checksum = "3d0b1827e8621fc42c0dfb228e5d57ff6a71f9699e666ece8113f979ad87c2de"
 dependencies = [
  "libc",
  "system-deps",
@@ -428,9 +424,9 @@ dependencies = [
 
 [[package]]
 name = "gobject-sys"
-version = "0.17.10"
+version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd34c3317740a6358ec04572c1bcfd3ac0b5b6529275fae255b237b314bb8062"
+checksum = "a4c674d2ff8478cf0ec29d2be730ed779fef54415a2fb4b565c52def62696462"
 dependencies = [
  "glib-sys",
  "libc",
@@ -452,6 +448,7 @@ version = "0.4.0"
 dependencies = [
  "gst-plugin-version-helper",
  "gstreamer",
+ "gstreamer-allocators",
  "gstreamer-base",
  "gstreamer-video",
  "once_cell",
@@ -462,17 +459,17 @@ dependencies = [
 
 [[package]]
 name = "gstreamer"
-version = "0.20.7"
+version = "0.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0a4150420d4aa1caf6fa15f0dba7a5007d4116380633bd1253acce206098fc9"
+checksum = "680006694e79692f831ca4f3ba6e147b8c23db289b2df1d33a4a97fd038145d7"
 dependencies = [
- "bitflags 1.3.2",
  "cfg-if",
  "futures-channel",
  "futures-core",
  "futures-util",
  "glib",
  "gstreamer-sys",
+ "itertools",
  "libc",
  "muldiv",
  "num-integer",
@@ -480,32 +477,56 @@ dependencies = [
  "once_cell",
  "option-operations",
  "paste",
- "pretty-hex",
+ "pin-project-lite",
  "smallvec",
  "thiserror",
 ]
 
 [[package]]
-name = "gstreamer-base"
-version = "0.20.7"
+name = "gstreamer-allocators"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0896c4acff303dd21d6a96a7ea4cc9339f7096230fe1433720c9f0bed203985"
+checksum = "edb98199904472782fc426827e3ada0bd5b92b7625f97c51649ec83b2f060019"
 dependencies = [
- "atomic_refcell",
- "bitflags 1.3.2",
- "cfg-if",
  "glib",
  "gstreamer",
- "gstreamer-base-sys",
+ "gstreamer-allocators-sys",
  "libc",
  "once_cell",
 ]
 
 [[package]]
-name = "gstreamer-base-sys"
-version = "0.20.0"
+name = "gstreamer-allocators-sys"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26114ed96f6668380f5a1554128159e98e06c3a7a8460f216d7cd6dce28f928c"
+checksum = "286b83db9cf0aa2322993302e2439e8f9cbe42f34b81573ecf758b024b9e0f7f"
+dependencies = [
+ "glib-sys",
+ "gobject-sys",
+ "gstreamer-sys",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
+name = "gstreamer-base"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a11df90e3abf1d9747111c41902338fc1bd13b1c23b27fb828d43e57bd190134"
+dependencies = [
+ "atomic_refcell",
+ "cfg-if",
+ "glib",
+ "gstreamer",
+ "gstreamer-base-sys",
+ "libc",
+]
+
+[[package]]
+name = "gstreamer-base-sys"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d691b2bb51a9e5727fb33c3b53fb64ee5b80c40cbbd250941a6d44b142f7a6a0"
 dependencies = [
  "glib-sys",
  "gobject-sys",
@@ -516,9 +537,9 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-sys"
-version = "0.20.0"
+version = "0.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e56fe047adef7d47dbafa8bc1340fddb53c325e16574763063702fc94b5786d2"
+checksum = "db89964774a97d5b092e2d124debc6bbcaf34b5c7cdef1759f4a9e1e3f8326ef"
 dependencies = [
  "glib-sys",
  "gobject-sys",
@@ -528,11 +549,10 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-video"
-version = "0.20.7"
+version = "0.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b69a9554795d3791b8467a30b35ed40ef279aa41c857e6f414ffd6a182a20225"
+checksum = "e94193e7e4c07ba97f1627bd9907bd187e90cdac8849bb78479d744e9121893b"
 dependencies = [
- "bitflags 1.3.2",
  "cfg-if",
  "futures-channel",
  "glib",
@@ -541,13 +561,14 @@ dependencies = [
  "gstreamer-video-sys",
  "libc",
  "once_cell",
+ "thiserror",
 ]
 
 [[package]]
 name = "gstreamer-video-sys"
-version = "0.20.0"
+version = "0.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66ddb6112d438aac0004d2db6053a572f92b1c5e0e9d6ff6c71d9245f7f73e46"
+checksum = "f81660cfa5a7b9973a51229785581d029da1681bf5aceffd5a4f32021db85ac0"
 dependencies = [
  "glib-sys",
  "gobject-sys",
@@ -559,15 +580,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.2"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156"
+checksum = "3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3"
 
 [[package]]
 name = "heck"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -600,9 +621,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.1.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
+checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -614,7 +635,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7911ce3db9c10c5ab4a35c49af778a5f9a827bd0f7371d9be56175d8dd2740d0"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.6.0",
  "input-sys",
  "io-lifetimes 1.0.11",
  "libc",
@@ -643,6 +664,15 @@ name = "io-lifetimes"
 version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a611371471e98973dbcab4e0ec66c31a10bc356eeb4d54a0e05eac8158fe38c"
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "js-sys"
@@ -711,9 +741,9 @@ checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "memchr"
-version = "2.6.4"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "memmap2"
@@ -845,50 +875,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
-name = "pretty-hex"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6fa0831dd7cc608c38a5e323422a0077678fa5744aa2be4ad91c4ece8eec8d5"
-
-[[package]]
 name = "proc-macro-crate"
-version = "1.3.1"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
+checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
 dependencies = [
- "once_cell",
- "toml_edit 0.19.15",
-]
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
+ "toml_edit 0.22.22",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.69"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
+checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
 dependencies = [
  "unicode-ident",
 ]
@@ -909,7 +908,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8021cf59c8ec9c432cfc2526ac6b8aa508ecaf29cd415f271b8406c1b851c3fd"
 dependencies = [
  "quote",
- "syn 2.0.39",
+ "syn",
 ]
 
 [[package]]
@@ -923,9 +922,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
@@ -975,7 +974,7 @@ version = "0.38.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc99bc2d4f1fed22595588a013687477aedf3cdcfb26558c559edb67b4d9b22e"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.6.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.11",
@@ -1011,7 +1010,7 @@ checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn",
 ]
 
 [[package]]
@@ -1043,9 +1042,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.2"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "smithay"
@@ -1053,7 +1052,7 @@ version = "0.3.0"
 source = "git+https://github.com/games-on-whales/smithay?rev=ef9782b#ef9782b8548c6e876bc61052e4e09351e4071a35"
 dependencies = [
  "appendlist",
- "bitflags 2.4.1",
+ "bitflags 2.6.0",
  "calloop",
  "cc",
  "cgmath",
@@ -1092,20 +1091,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.109"
+version = "2.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
-version = "2.0.39"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
+checksum = "44d46482f1c1c87acd84dea20c1bf5ebff4c757009ed6bf19cfd36fb10e92c4e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1114,9 +1102,9 @@ dependencies = [
 
 [[package]]
 name = "system-deps"
-version = "6.2.0"
+version = "7.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a2d580ff6a20c55dfb86be5f9c238f67835d0e81cbdea8bf5680e0897320331"
+checksum = "66d23aaf9f331227789a99e8de4c91bf46703add012bdfd45fdecdfb2975a005"
 dependencies = [
  "cfg-expr",
  "heck",
@@ -1127,9 +1115,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.12"
+version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c39fd04924ca3a864207c66fc2cd7d22d7c016007f9ce846cbb9326331930a"
+checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tempfile"
@@ -1161,7 +1149,7 @@ checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn",
 ]
 
 [[package]]
@@ -1188,22 +1176,11 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.5"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.19.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
-dependencies = [
- "indexmap",
- "toml_datetime",
- "winnow",
 ]
 
 [[package]]
@@ -1216,7 +1193,18 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow",
+ "winnow 0.5.19",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "winnow 0.6.20",
 ]
 
 [[package]]
@@ -1238,7 +1226,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn",
 ]
 
 [[package]]
@@ -1302,15 +1290,9 @@ checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "version-compare"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "579a42fc0b8e0c63b76519a339be31bed574929511fa53c1a3acae26eb258f29"
-
-[[package]]
-name = "version_check"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+checksum = "852e951cb7832cb45cb1169900d19760cfa39b82bc0ea9c0e5a14ae88411c98b"
 
 [[package]]
 name = "wasi"
@@ -1339,7 +1321,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -1361,7 +1343,7 @@ checksum = "c5353b8dab669f5e10f5bd76df26a9360c748f054f862ff5f3f8aae0c7fb3907"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1391,6 +1373,7 @@ name = "wayland-display-core"
 version = "0.2.0"
 dependencies = [
  "gstreamer",
+ "gstreamer-allocators",
  "gstreamer-video",
  "once_cell",
  "smithay",
@@ -1405,7 +1388,7 @@ version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1794d82d869f38439d15c24b26f06f6c8603d27d47b4f786d5197c99044de415"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.6.0",
  "wayland-backend",
  "wayland-scanner",
  "wayland-server",
@@ -1417,7 +1400,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28b497d7edd777ca365f2cce3837046b7832365b2a0b32f9c913b4e6f8d99839"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.6.0",
  "wayland-backend",
  "wayland-protocols",
  "wayland-scanner",
@@ -1430,7 +1413,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa43c961473aed713d44c1f616f775186249dfca657f256d8841ca0690366aba"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.6.0",
  "wayland-backend",
  "wayland-protocols",
  "wayland-scanner",
@@ -1454,7 +1437,7 @@ version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a29060303e79e4c3d44936efdcf00941a78c86850bf67a88078dd1d6c99702b9"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.6.0",
  "downcast-rs",
  "io-lifetimes 2.0.3",
  "rustix",
@@ -1650,6 +1633,15 @@ name = "winnow"
 version = "0.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829846f3e3db426d4cee4510841b71a8e58aa2a76b1132579487ae430ccd9c7b"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "0.6.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1378,6 +1378,7 @@ dependencies = [
  "once_cell",
  "smithay",
  "tracing",
+ "tracing-subscriber",
  "wayland-backend",
  "wayland-scanner",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.dependencies]
-gst = { version = "0.20", package = "gstreamer", features = ["v1_18"] }
-gst-video = { version = "0.20", package = "gstreamer-video", features = ["v1_18"] }
+gst = { version = "0.23.2", package = "gstreamer", features = ["v1_24"] }
+gst-video = { version = "0.23.2", package = "gstreamer-video", features = ["v1_24"] }
 tracing = "0.1.37"
 once_cell = "1.17.0"

--- a/c-bindings/Cargo.toml
+++ b/c-bindings/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "c-bindings"
 authors = ["Victoria Brekenfeld <git@drakulix.de>", "Alessandro Beltramo <github.com/ABeltramo>"]
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 license = "MIT"
 description = "Wayland Compositor producing GStreamer buffers"

--- a/c-bindings/src/capi.rs
+++ b/c-bindings/src/capi.rs
@@ -105,7 +105,7 @@ pub extern "C" fn display_set_video_info(dpy: *mut WaylandDisplay, info: *const 
     }
     let video_info = unsafe { VideoInfo::from_glib_none(info) };
 
-    display.set_video_info(video_info);
+    display.set_video_info(video_info.into());
 }
 
 #[no_mangle]

--- a/gst-plugin-wayland-display/Cargo.toml
+++ b/gst-plugin-wayland-display/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "gst-plugin-wayland-display"
 authors = ["Victoria Brekenfeld <git@drakulix.de>", "Alessandro Beltramo <github.com/ABeltramo>"]
-version = "0.2.0"
+version = "0.4.0"
 edition = "2021"
 license = "MIT"
 description = "GStreamer Wayland Compositor Src"

--- a/gst-plugin-wayland-display/Cargo.toml
+++ b/gst-plugin-wayland-display/Cargo.toml
@@ -20,7 +20,9 @@ doc = []
 
 [dependencies]
 gst.workspace = true
-gst-base = { version = "0.20", package = "gstreamer-base", features = ["v1_18"] }
+gst-base = { version = "0.23.2", package = "gstreamer-base", features = ["v1_24"] }
+gstreamer-allocators = { version = "0.23.2", package = "gstreamer-allocators", features = ["v1_24"] }
+
 gst-video.workspace = true
 wayland-display-core = { path = "../wayland-display-core" }
 tracing.workspace = true

--- a/gst-plugin-wayland-display/src/lib.rs
+++ b/gst-plugin-wayland-display/src/lib.rs
@@ -14,7 +14,7 @@ gst::plugin_define!(
     env!("CARGO_PKG_DESCRIPTION"),
     plugin_init,
     concat!(env!("CARGO_PKG_VERSION"), "-", env!("COMMIT_ID")),
-    "MIT",
+    "MIT/X11", // https://gitlab.freedesktop.org/gstreamer/gstreamer/-/blob/master/gst/gstplugin.c#L95
     env!("CARGO_PKG_NAME"),
     env!("CARGO_PKG_NAME"),
     env!("CARGO_PKG_REPOSITORY"),

--- a/gst-plugin-wayland-display/src/waylandsrc/imp.rs
+++ b/gst-plugin-wayland-display/src/waylandsrc/imp.rs
@@ -14,7 +14,7 @@ use gst_base::subclass::prelude::*;
 use once_cell::sync::Lazy;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::Registry;
-use waylanddisplaycore::{DrmFormat, DrmModifier, DrmVendor, Fourcc, GstVideoInfo, WaylandDisplay};
+use waylanddisplaycore::{DrmFormat, DrmModifier, GstVideoInfo, WaylandDisplay};
 
 use crate::utils::{GstLayer, CAT};
 
@@ -227,16 +227,12 @@ impl BaseSrcImpl for WaylandDisplaySrc {
         let gst_dma_formats: Vec<String> = match state.as_ref() {
             None => Default::default(),
             Some(state) => {
-                let dma_formats = state
-                    .display
-                    .get_supported_dma_formats()
-                    .unwrap_or(Default::default());
-
+                let dma_formats = state.display.get_supported_dma_formats();
                 dma_formats.iter().filter_map(drm_to_gst_format).collect()
             }
         };
 
-        gst::info!(CAT, "Supported DMA formats: {:?}", gst_dma_formats);
+        gst::debug!(CAT, "Supported DMA formats: {:?}", gst_dma_formats);
 
         if gst_dma_formats.is_empty() {
             let dmabuf_caps = gst_video::VideoCapsBuilder::new()
@@ -441,55 +437,19 @@ impl PushSrcImpl for WaylandDisplaySrc {
     }
 }
 
-fn drm_to_video_format(format: &DrmFormat) -> Option<VideoFormat> {
-    let format = match format.code {
-        // see: https://gitlab.freedesktop.org/gstreamer/gstreamer/-/blob/main/subprojects/gst-plugins-base/gst-libs/gst/video/video-info-dma.c#L702-742
-        Fourcc::Abgr8888 => VideoFormat::Rgba,
-        Fourcc::Argb8888 => VideoFormat::Bgra,
-        Fourcc::Bgra8888 => VideoFormat::Argb,
-        Fourcc::Bgrx8888 => VideoFormat::Xrgb,
-        Fourcc::Rgba8888 => VideoFormat::Abgr,
-        Fourcc::Rgbx8888 => VideoFormat::Xbgr,
-        Fourcc::Xbgr8888 => VideoFormat::Rgbx,
-        Fourcc::Xrgb8888 => VideoFormat::Bgrx,
-        _ => {
-            gst::debug!(CAT, "Unsupported format {:?}", format.code);
-            return None;
-        }
-    };
-    Some(format)
-}
-
 fn drm_to_gst_format(format: &DrmFormat) -> Option<String> {
-    let video_format = drm_to_video_format(format)?;
+    let video_format = format.code.to_string();
+    let video_format = video_format.trim();
     if format.modifier == DrmModifier::Linear {
-        Some(video_format.to_string())
+        Some(video_format.into())
     } else {
-        let modifier = match format.modifier {
+        match format.modifier {
             DrmModifier::Invalid => None,
-            modifier => Some(modifier),
-        };
-        let modifier: u64 = modifier?.into();
-        let vendor: u8 = match format.modifier.vendor() {
-            Ok(vendor) => match vendor {
-                Some(DrmVendor::Allwinner) => 9,
-                Some(DrmVendor::Amd) => 2,
-                Some(DrmVendor::Amlogic) => 10,
-                Some(DrmVendor::Arm) => 8,
-                Some(DrmVendor::Broadcom) => 7,
-                Some(DrmVendor::Intel) => 1,
-                Some(DrmVendor::Nvidia) => 3,
-                Some(DrmVendor::Qcom) => 5,
-                Some(DrmVendor::Samsung) => 4,
-                Some(DrmVendor::Vivante) => 6,
-                None => 0,
-            },
-            Err(_) => 0,
-        };
-        Some(format!(
-            "{}:0x{:02x}{:014x}",
-            video_format, vendor, modifier
-        ))
+            modifier => {
+                let modifier: u64 = modifier.into();
+                Some(format!("{}:0x{:016x}", video_format, modifier))
+            }
+        }
     }
 }
 
@@ -514,7 +474,7 @@ mod tests {
                 code: waylanddisplaycore::Fourcc::Abgr8888,
                 modifier: waylanddisplaycore::DrmModifier::Linear
             }),
-            Some("RGBA".to_string())
+            Some("AB24".to_string())
         );
 
         assert_eq!(
@@ -522,7 +482,7 @@ mod tests {
                 code: waylanddisplaycore::Fourcc::Rgba8888,
                 modifier: waylanddisplaycore::DrmModifier::Nvidia_16bx2_block_eight_gob
             }),
-            Some("ABGR:0x03300000000000013".to_string())
+            Some("RA24:0x0300000000000013".to_string())
         );
     }
 }

--- a/gst-plugin-wayland-display/src/waylandsrc/imp.rs
+++ b/gst-plugin-wayland-display/src/waylandsrc/imp.rs
@@ -165,7 +165,7 @@ impl ElementImpl for WaylandDisplaySrc {
             let mut dmabuf_caps = gst_video::VideoCapsBuilder::new()
                 .features([gstreamer_allocators::CAPS_FEATURE_MEMORY_DMABUF])
                 .format(VideoFormat::DmaDrm)
-                .field("drm-format", "ABGR") // Modifier is linear
+                .field("drm-format", "NV12:0x0100000000000001") // Modifier is linear
                 .height_range(..i32::MAX)
                 .width_range(..i32::MAX)
                 .framerate_range(Fraction::new(1, 1)..Fraction::new(i32::MAX, 1))
@@ -224,7 +224,7 @@ impl BaseSrcImpl for WaylandDisplaySrc {
         let mut dmabuf_caps = gst_video::VideoCapsBuilder::new()
             .features([gstreamer_allocators::CAPS_FEATURE_MEMORY_DMABUF])
             .format(VideoFormat::DmaDrm)
-            .field("drm-format", "ABGR") // Modifier is linear
+            .field("drm-format", "NV12:0x0100000000000001") // TODO: ask the GlesRenderer for render_formats
             .height_range(..i32::MAX)
             .width_range(..i32::MAX)
             .framerate_range(Fraction::new(1, 1)..Fraction::new(i32::MAX, 1))
@@ -336,6 +336,10 @@ impl BaseSrcImpl for WaylandDisplaySrc {
             .unwrap()
             .display
             .set_video_info(video_info);
+
+
+        // TODO: gst_video_is_dma_drm_caps(caps)
+        //  and bubble up the VideoInfoDmaDrm
 
         self.parent_set_caps(caps)
     }

--- a/gst-plugin-wayland-display/src/waylandsrc/imp.rs
+++ b/gst-plugin-wayland-display/src/waylandsrc/imp.rs
@@ -5,16 +5,12 @@ use gst_video::{VideoCapsBuilder, VideoFormat};
 
 use gst::subclass::prelude::*;
 use gst::{glib, Event, Fraction};
-use gst::{
-    glib::{once_cell::sync::Lazy, ValueArray},
-    LibraryError,
-};
+use gst::{glib::ValueArray, LibraryError};
 use gst::{prelude::*, Structure};
-
+use gst_base::prelude::BaseSrcExt;
 use gst_base::subclass::base_src::CreateSuccess;
 use gst_base::subclass::prelude::*;
-use gst_base::traits::BaseSrcExt;
-
+use once_cell::sync::Lazy;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::Registry;
 use waylanddisplaycore::WaylandDisplay;
@@ -166,11 +162,20 @@ impl ElementImpl for WaylandDisplaySrc {
                 .width_range(..i32::MAX)
                 .framerate_range(Fraction::new(1, 1)..Fraction::new(i32::MAX, 1))
                 .build();
+            let mut dmabuf_caps = gst_video::VideoCapsBuilder::new()
+                .features([gstreamer_allocators::CAPS_FEATURE_MEMORY_DMABUF])
+                .format(VideoFormat::DmaDrm)
+                .field("drm-format", "ABGR") // Modifier is linear
+                .height_range(..i32::MAX)
+                .width_range(..i32::MAX)
+                .framerate_range(Fraction::new(1, 1)..Fraction::new(i32::MAX, 1))
+                .build();
+            dmabuf_caps.merge(caps);
             let src_pad_template = gst::PadTemplate::new(
                 "src",
                 gst::PadDirection::Src,
                 gst::PadPresence::Always,
-                &caps,
+                &dmabuf_caps,
             )
             .unwrap();
 
@@ -209,18 +214,28 @@ impl BaseSrcImpl for WaylandDisplaySrc {
     }
 
     fn caps(&self, filter: Option<&gst::Caps>) -> Option<gst::Caps> {
-        let mut caps = VideoCapsBuilder::new()
+        let caps = VideoCapsBuilder::new()
             .format(VideoFormat::Rgbx)
             .height_range(..i32::MAX)
             .width_range(..i32::MAX)
             .framerate_range(Fraction::new(1, 1)..Fraction::new(i32::MAX, 1))
             .build();
 
+        let mut dmabuf_caps = gst_video::VideoCapsBuilder::new()
+            .features([gstreamer_allocators::CAPS_FEATURE_MEMORY_DMABUF])
+            .format(VideoFormat::DmaDrm)
+            .field("drm-format", "ABGR") // Modifier is linear
+            .height_range(..i32::MAX)
+            .width_range(..i32::MAX)
+            .framerate_range(Fraction::new(1, 1)..Fraction::new(i32::MAX, 1))
+            .build();
+        dmabuf_caps.merge(caps);
+
         if let Some(filter) = filter {
-            caps = caps.intersect(filter);
+            dmabuf_caps = dmabuf_caps.intersect(filter);
         }
 
-        Some(caps)
+        Some(dmabuf_caps)
     }
 
     fn negotiate(&self) -> Result<(), gst::LoggableError> {

--- a/gst-plugin-wayland-display/src/waylandsrc/imp.rs
+++ b/gst-plugin-wayland-display/src/waylandsrc/imp.rs
@@ -1,4 +1,5 @@
 use std::fmt::Debug;
+use std::ops::DerefMut;
 use std::sync::Mutex;
 
 use gst::message::Application;
@@ -14,20 +15,29 @@ use gst_base::subclass::prelude::*;
 use once_cell::sync::Lazy;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::Registry;
-use waylanddisplaycore::{DrmFormat, DrmModifier, GstVideoInfo, WaylandDisplay};
+use waylanddisplaycore::{
+    channel, ButtonState, Channel, Command, DrmFormat, DrmModifier, GstVideoInfo, KeyState, Sender,
+    WaylandDisplay,
+};
 
 use crate::utils::{GstLayer, CAT};
 
 pub struct WaylandDisplaySrc {
     state: Mutex<Option<State>>,
     settings: Mutex<Settings>,
+    command_tx: Sender<Command>,
+    command_rx: Mutex<Option<Channel<Command>>>,
 }
 
 impl Default for WaylandDisplaySrc {
     fn default() -> Self {
+        let (command_tx, command_rx) = channel();
+
         WaylandDisplaySrc {
             state: Mutex::new(None),
             settings: Mutex::new(Settings::default()),
+            command_tx,
+            command_rx: Mutex::new(Some(command_rx)),
         }
     }
 }
@@ -48,6 +58,96 @@ impl ObjectSubclass for WaylandDisplaySrc {
     type Type = super::WaylandDisplaySrc;
     type ParentType = gst_base::PushSrc;
     type Interfaces = ();
+}
+
+trait EventHandler {
+    fn handle_event(&self, event: &Event) -> bool;
+}
+
+impl EventHandler for WaylandDisplaySrc {
+    fn handle_event(&self, event: &Event) -> bool {
+        tracing::debug!("Received event: {:?}", event);
+        if event.type_() == gst::EventType::CustomUpstream {
+            let structure = event.structure().expect("Unable to get message structure");
+            if structure.has_name("VirtualDevicesReady") {
+                let paths = structure
+                    .get::<ValueArray>("paths")
+                    .expect("Should contain paths");
+                for value in paths.into_iter() {
+                    let path = value.get::<String>().expect("Paths are strings");
+                    let _ = self.command_tx.send(Command::InputDevice(path));
+                }
+
+                return true;
+            } else if structure.has_name("MouseMoveAbsolute") {
+                let x = structure
+                    .get::<f64>("pointer_x")
+                    .expect("Should contain pointer_x");
+                let y = structure
+                    .get::<f64>("pointer_y")
+                    .expect("Should contain pointer_y");
+
+                let _ = self
+                    .command_tx
+                    .send(Command::PointerMotionAbsolute((x, y).into()));
+
+                return true;
+            } else if structure.has_name("MouseMoveRelative") {
+                let x = structure
+                    .get::<f64>("pointer_x")
+                    .expect("Should contain pointer_x");
+                let y = structure
+                    .get::<f64>("pointer_y")
+                    .expect("Should contain pointer_y");
+
+                let _ = self.command_tx.send(Command::PointerMotion((x, y).into()));
+
+                return true;
+            } else if structure.has_name("MouseButton") {
+                let button = structure
+                    .get::<u32>("button")
+                    .expect("Should contain button");
+                let pressed = structure
+                    .get::<bool>("pressed")
+                    .expect("Should contain pressed");
+
+                let _ = self.command_tx.send(Command::PointerButton(
+                    button,
+                    if pressed {
+                        ButtonState::Pressed
+                    } else {
+                        ButtonState::Released
+                    },
+                ));
+
+                return true;
+            } else if structure.has_name("MouseAxis") {
+                let x = structure.get::<f64>("x").expect("Should contain x");
+                let y = structure.get::<f64>("y").expect("Should contain y");
+
+                let _ = self.command_tx.send(Command::PointerAxis(x, y));
+
+                return true;
+            } else if structure.has_name("KeyboardKey") {
+                let key = structure.get::<u32>("key").expect("Should contain key");
+                let pressed = structure
+                    .get::<bool>("pressed")
+                    .expect("Should contain pressed");
+
+                let _ = self.command_tx.send(Command::KeyboardInput(
+                    key,
+                    if pressed {
+                        KeyState::Pressed
+                    } else {
+                        KeyState::Released
+                    },
+                ));
+
+                return true;
+            }
+        }
+        false
+    }
 }
 
 impl ObjectImpl for WaylandDisplaySrc {
@@ -153,6 +253,13 @@ impl ElementImpl for WaylandDisplaySrc {
         });
 
         Some(&*ELEMENT_METADATA)
+    }
+
+    fn send_event(&self, event: Event) -> bool {
+        if self.handle_event(&event) {
+            return true;
+        }
+        self.parent_send_event(event)
     }
 
     fn pad_templates() -> &'static [gst::PadTemplate] {
@@ -269,86 +376,8 @@ impl BaseSrcImpl for WaylandDisplaySrc {
     }
 
     fn event(&self, event: &Event) -> bool {
-        if event.type_() == gst::EventType::CustomUpstream {
-            let structure = event.structure().expect("Unable to get message structure");
-            if structure.has_name("VirtualDevicesReady") {
-                let mut state = self.state.lock().unwrap();
-                let display = &mut state.as_mut().unwrap().display;
-
-                let paths = structure
-                    .get::<ValueArray>("paths")
-                    .expect("Should contain paths");
-                for value in paths.into_iter() {
-                    let path = value.get::<String>().expect("Paths are strings");
-                    display.add_input_device(path);
-                }
-
-                return true;
-            } else if structure.has_name("MouseMoveAbsolute") {
-                let mut state = self.state.lock().unwrap();
-                let display = &mut state.as_mut().unwrap().display;
-
-                let x = structure
-                    .get::<f64>("pointer_x")
-                    .expect("Should contain pointer_x");
-                let y = structure
-                    .get::<f64>("pointer_y")
-                    .expect("Should contain pointer_y");
-
-                display.pointer_motion_absolute(x, y);
-
-                return true;
-            } else if structure.has_name("MouseMoveRelative") {
-                let mut state = self.state.lock().unwrap();
-                let display = &mut state.as_mut().unwrap().display;
-
-                let x = structure
-                    .get::<f64>("pointer_x")
-                    .expect("Should contain pointer_x");
-                let y = structure
-                    .get::<f64>("pointer_y")
-                    .expect("Should contain pointer_y");
-
-                display.pointer_motion(x, y);
-
-                return true;
-            } else if structure.has_name("MouseButton") {
-                let mut state = self.state.lock().unwrap();
-                let display = &mut state.as_mut().unwrap().display;
-
-                let button = structure
-                    .get::<u32>("button")
-                    .expect("Should contain button");
-                let pressed = structure
-                    .get::<bool>("pressed")
-                    .expect("Should contain pressed");
-
-                display.pointer_button(button, pressed);
-
-                return true;
-            } else if structure.has_name("MouseAxis") {
-                let mut state = self.state.lock().unwrap();
-                let display = &mut state.as_mut().unwrap().display;
-
-                let x = structure.get::<f64>("x").expect("Should contain x");
-                let y = structure.get::<f64>("y").expect("Should contain y");
-
-                display.pointer_axis(x, y);
-
-                return true;
-            } else if structure.has_name("KeyboardKey") {
-                let mut state = self.state.lock().unwrap();
-                let display = &mut state.as_mut().unwrap().display;
-
-                let key = structure.get::<u32>("key").expect("Should contain key");
-                let pressed = structure
-                    .get::<bool>("pressed")
-                    .expect("Should contain pressed");
-
-                display.keyboard_input(key, pressed);
-
-                return true;
-            }
+        if self.handle_event(&event) {
+            return true;
         }
         self.parent_event(event)
     }
@@ -361,13 +390,7 @@ impl BaseSrcImpl for WaylandDisplaySrc {
             ),
         };
 
-        self.state
-            .lock()
-            .unwrap()
-            .as_mut()
-            .unwrap()
-            .display
-            .set_video_info(video_info);
+        let _ = self.command_tx.send(Command::VideoInfo(video_info));
 
         self.parent_set_caps(caps)
     }
@@ -383,7 +406,12 @@ impl BaseSrcImpl for WaylandDisplaySrc {
         let subscriber = Registry::default().with(GstLayer);
 
         let Ok(mut display) = tracing::subscriber::with_default(subscriber, || {
-            WaylandDisplay::new(settings.render_node.clone())
+            let mut command_rx = self.command_rx.lock().unwrap();
+            WaylandDisplay::new_with_channel(
+                settings.render_node.clone(),
+                self.command_tx.clone(),
+                command_rx.deref_mut().take().unwrap(),
+            )
         }) else {
             return Err(gst::error_msg!(LibraryError::Failed, ("Failed to open drm node {}, if you want to utilize software rendering set `render-node=software`.", settings.render_node.as_deref().unwrap_or("/dev/dri/renderD128"))));
         };

--- a/gst-plugin-wayland-display/src/waylandsrc/imp.rs
+++ b/gst-plugin-wayland-display/src/waylandsrc/imp.rs
@@ -248,7 +248,7 @@ impl ElementImpl for WaylandDisplaySrc {
                 "Wayland display source",
                 "Source/Video",
                 "GStreamer video src running a wayland compositor",
-                "Victoria Brekenfeld <wayland@drakulix.de>",
+                "Victoria Brekenfeld <wayland@drakulix.de>, ABeltramo <https://github.com/ABeltramo>",
             )
         });
 

--- a/gst-plugin-wayland-display/src/waylandsrc/imp.rs
+++ b/gst-plugin-wayland-display/src/waylandsrc/imp.rs
@@ -1,7 +1,7 @@
 use std::sync::Mutex;
 
 use gst::message::Application;
-use gst_video::{VideoCapsBuilder, VideoFormat};
+use gst_video::{VideoCapsBuilder, VideoFormat, VideoInfoDmaDrm};
 
 use gst::subclass::prelude::*;
 use gst::{glib, Event, Fraction};
@@ -13,7 +13,7 @@ use gst_base::subclass::prelude::*;
 use once_cell::sync::Lazy;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::Registry;
-use waylanddisplaycore::WaylandDisplay;
+use waylanddisplaycore::{GstVideoInfo, WaylandDisplay};
 
 use crate::utils::{GstLayer, CAT};
 
@@ -165,7 +165,8 @@ impl ElementImpl for WaylandDisplaySrc {
             let mut dmabuf_caps = gst_video::VideoCapsBuilder::new()
                 .features([gstreamer_allocators::CAPS_FEATURE_MEMORY_DMABUF])
                 .format(VideoFormat::DmaDrm)
-                .field("drm-format", "NV12:0x0100000000000001") // Modifier is linear
+                // we can let the drm-format field absent to mean the super set of all formats
+                // we'll negotiate the actual format with the pads
                 .height_range(..i32::MAX)
                 .width_range(..i32::MAX)
                 .framerate_range(Fraction::new(1, 1)..Fraction::new(i32::MAX, 1))
@@ -224,7 +225,7 @@ impl BaseSrcImpl for WaylandDisplaySrc {
         let mut dmabuf_caps = gst_video::VideoCapsBuilder::new()
             .features([gstreamer_allocators::CAPS_FEATURE_MEMORY_DMABUF])
             .format(VideoFormat::DmaDrm)
-            .field("drm-format", "NV12:0x0100000000000001") // TODO: ask the GlesRenderer for render_formats
+            .field("drm-format", "RGBA") // TODO: ask the GlesRenderer for render_formats
             .height_range(..i32::MAX)
             .width_range(..i32::MAX)
             .framerate_range(Fraction::new(1, 1)..Fraction::new(i32::MAX, 1))
@@ -328,7 +329,15 @@ impl BaseSrcImpl for WaylandDisplaySrc {
     }
 
     fn set_caps(&self, caps: &gst::Caps) -> Result<(), gst::LoggableError> {
-        let video_info = gst_video::VideoInfo::from_caps(caps).expect("failed to get video info");
+        let video_info = match VideoInfoDmaDrm::from_caps(caps) {
+            Ok(dma_video_info) => {
+                GstVideoInfo::DMA(dma_video_info)
+            }
+            Err(_) => {
+                GstVideoInfo::RAW(gst_video::VideoInfo::from_caps(caps).expect("failed to get video info"))
+            }
+        };
+
         self.state
             .lock()
             .unwrap()
@@ -336,10 +345,6 @@ impl BaseSrcImpl for WaylandDisplaySrc {
             .unwrap()
             .display
             .set_video_info(video_info);
-
-
-        // TODO: gst_video_is_dma_drm_caps(caps)
-        //  and bubble up the VideoInfoDmaDrm
 
         self.parent_set_caps(caps)
     }

--- a/gst-plugin-wayland-display/src/waylandsrc/imp.rs
+++ b/gst-plugin-wayland-display/src/waylandsrc/imp.rs
@@ -232,7 +232,7 @@ impl BaseSrcImpl for WaylandDisplaySrc {
             }
         };
 
-        gst::debug!(CAT, "Supported DMA formats: {:?}", gst_dma_formats);
+        tracing::info!("Supported DMA formats: {:?}", gst_dma_formats);
 
         if gst_dma_formats.is_empty() {
             let dmabuf_caps = gst_video::VideoCapsBuilder::new()

--- a/gst-plugin-wayland-display/src/waylandsrc/imp.rs
+++ b/gst-plugin-wayland-display/src/waylandsrc/imp.rs
@@ -473,6 +473,15 @@ fn drm_to_gst_format(format: &DrmFormat) -> Option<String> {
     } else {
         match format.modifier {
             DrmModifier::Invalid => None,
+            DrmModifier::Unrecognized(0x0100000000000009) => {
+                // NOTE: This is a workaround for the i915 4-tiled modifiers
+                //       not being advertised by gstreamer elements.
+                // - In this part we tell we map any 4-tiled modifiers 
+                //   to y-tiled ones for compatibility with gstreamer.
+                // Continued in wayland-display-core allocator/mod.rs.
+                let modifier: u64 = DrmModifier::I915_y_tiled.into();
+                Some(format!("{}:0x{:016x}", video_format, modifier))
+            },
             modifier => {
                 let modifier: u64 = modifier.into();
                 Some(format!("{}:0x{:016x}", video_format, modifier))

--- a/gst-plugin-wayland-display/src/waylandsrc/imp.rs
+++ b/gst-plugin-wayland-display/src/waylandsrc/imp.rs
@@ -1,3 +1,4 @@
+use std::fmt::Debug;
 use std::sync::Mutex;
 
 use gst::message::Application;
@@ -13,7 +14,7 @@ use gst_base::subclass::prelude::*;
 use once_cell::sync::Lazy;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::Registry;
-use waylanddisplaycore::{GstVideoInfo, WaylandDisplay};
+use waylanddisplaycore::{DrmFormat, DrmModifier, DrmVendor, Fourcc, GstVideoInfo, WaylandDisplay};
 
 use crate::utils::{GstLayer, CAT};
 
@@ -215,28 +216,56 @@ impl BaseSrcImpl for WaylandDisplaySrc {
     }
 
     fn caps(&self, filter: Option<&gst::Caps>) -> Option<gst::Caps> {
-        let caps = VideoCapsBuilder::new()
+        let mut caps = VideoCapsBuilder::new()
             .format(VideoFormat::Rgbx)
             .height_range(..i32::MAX)
             .width_range(..i32::MAX)
             .framerate_range(Fraction::new(1, 1)..Fraction::new(i32::MAX, 1))
             .build();
 
-        let mut dmabuf_caps = gst_video::VideoCapsBuilder::new()
-            .features([gstreamer_allocators::CAPS_FEATURE_MEMORY_DMABUF])
-            .format(VideoFormat::DmaDrm)
-            .field("drm-format", "RGBA") // TODO: ask the GlesRenderer for render_formats
-            .height_range(..i32::MAX)
-            .width_range(..i32::MAX)
-            .framerate_range(Fraction::new(1, 1)..Fraction::new(i32::MAX, 1))
-            .build();
-        dmabuf_caps.merge(caps);
+        let state = self.state.lock().unwrap();
+        let gst_dma_formats: Vec<String> = match state.as_ref() {
+            None => Default::default(),
+            Some(state) => {
+                let dma_formats = state
+                    .display
+                    .get_supported_dma_formats()
+                    .unwrap_or(Default::default());
 
-        if let Some(filter) = filter {
-            dmabuf_caps = dmabuf_caps.intersect(filter);
+                dma_formats.iter().filter_map(drm_to_gst_format).collect()
+            }
+        };
+
+        gst::info!(CAT, "Supported DMA formats: {:?}", gst_dma_formats);
+
+        if gst_dma_formats.is_empty() {
+            let dmabuf_caps = gst_video::VideoCapsBuilder::new()
+                .features([gstreamer_allocators::CAPS_FEATURE_MEMORY_DMABUF])
+                .format(VideoFormat::DmaDrm)
+                .height_range(..i32::MAX)
+                .width_range(..i32::MAX)
+                .framerate_range(Fraction::new(1, 1)..Fraction::new(i32::MAX, 1))
+                .build();
+            caps.merge(dmabuf_caps);
+        } else {
+            for format in gst_dma_formats {
+                let dmabuf_caps = gst_video::VideoCapsBuilder::new()
+                    .features([gstreamer_allocators::CAPS_FEATURE_MEMORY_DMABUF])
+                    .format(VideoFormat::DmaDrm)
+                    .field("drm-format", &format)
+                    .height_range(..i32::MAX)
+                    .width_range(..i32::MAX)
+                    .framerate_range(Fraction::new(1, 1)..Fraction::new(i32::MAX, 1))
+                    .build();
+                caps.merge(dmabuf_caps);
+            }
         }
 
-        Some(dmabuf_caps)
+        if let Some(filter) = filter {
+            caps = caps.intersect(filter);
+        }
+
+        Some(caps)
     }
 
     fn negotiate(&self) -> Result<(), gst::LoggableError> {
@@ -330,12 +359,10 @@ impl BaseSrcImpl for WaylandDisplaySrc {
 
     fn set_caps(&self, caps: &gst::Caps) -> Result<(), gst::LoggableError> {
         let video_info = match VideoInfoDmaDrm::from_caps(caps) {
-            Ok(dma_video_info) => {
-                GstVideoInfo::DMA(dma_video_info)
-            }
-            Err(_) => {
-                GstVideoInfo::RAW(gst_video::VideoInfo::from_caps(caps).expect("failed to get video info"))
-            }
+            Ok(dma_video_info) => GstVideoInfo::DMA(dma_video_info),
+            Err(_) => GstVideoInfo::RAW(
+                gst_video::VideoInfo::from_caps(caps).expect("failed to get video info"),
+            ),
         };
 
         self.state
@@ -411,5 +438,91 @@ impl PushSrcImpl for WaylandDisplaySrc {
         tracing::subscriber::with_default(subscriber, || {
             state.display.frame().map(CreateSuccess::NewBuffer)
         })
+    }
+}
+
+fn drm_to_video_format(format: &DrmFormat) -> Option<VideoFormat> {
+    let format = match format.code {
+        // see: https://gitlab.freedesktop.org/gstreamer/gstreamer/-/blob/main/subprojects/gst-plugins-base/gst-libs/gst/video/video-info-dma.c#L702-742
+        Fourcc::Abgr8888 => VideoFormat::Rgba,
+        Fourcc::Argb8888 => VideoFormat::Bgra,
+        Fourcc::Bgra8888 => VideoFormat::Argb,
+        Fourcc::Bgrx8888 => VideoFormat::Xrgb,
+        Fourcc::Rgba8888 => VideoFormat::Abgr,
+        Fourcc::Rgbx8888 => VideoFormat::Xbgr,
+        Fourcc::Xbgr8888 => VideoFormat::Rgbx,
+        Fourcc::Xrgb8888 => VideoFormat::Bgrx,
+        _ => {
+            gst::debug!(CAT, "Unsupported format {:?}", format.code);
+            return None;
+        }
+    };
+    Some(format)
+}
+
+fn drm_to_gst_format(format: &DrmFormat) -> Option<String> {
+    let video_format = drm_to_video_format(format)?;
+    if format.modifier == DrmModifier::Linear {
+        Some(video_format.to_string())
+    } else {
+        let modifier = match format.modifier {
+            DrmModifier::Invalid => None,
+            modifier => Some(modifier),
+        };
+        let modifier: u64 = modifier?.into();
+        let vendor: u8 = match format.modifier.vendor() {
+            Ok(vendor) => match vendor {
+                Some(DrmVendor::Allwinner) => 9,
+                Some(DrmVendor::Amd) => 2,
+                Some(DrmVendor::Amlogic) => 10,
+                Some(DrmVendor::Arm) => 8,
+                Some(DrmVendor::Broadcom) => 7,
+                Some(DrmVendor::Intel) => 1,
+                Some(DrmVendor::Nvidia) => 3,
+                Some(DrmVendor::Qcom) => 5,
+                Some(DrmVendor::Samsung) => 4,
+                Some(DrmVendor::Vivante) => 6,
+                None => 0,
+            },
+            Err(_) => 0,
+        };
+        Some(format!(
+            "{}:0x{:02x}{:014x}",
+            video_format, vendor, modifier
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use waylanddisplaycore::utils::tests::INIT;
+    use waylanddisplaycore::DrmFormat;
+
+    fn test_init() -> () {
+        INIT.call_once(|| {
+            tracing_subscriber::fmt::try_init().ok();
+            gst::init().expect("Failed to initialize GStreamer");
+        });
+    }
+
+    #[test]
+    fn test_drm_format_to_gstreamer() {
+        test_init();
+
+        assert_eq!(
+            super::drm_to_gst_format(&DrmFormat {
+                code: waylanddisplaycore::Fourcc::Abgr8888,
+                modifier: waylanddisplaycore::DrmModifier::Linear
+            }),
+            Some("RGBA".to_string())
+        );
+
+        assert_eq!(
+            super::drm_to_gst_format(&DrmFormat {
+                code: waylanddisplaycore::Fourcc::Rgba8888,
+                modifier: waylanddisplaycore::DrmModifier::Nvidia_16bx2_block_eight_gob
+            }),
+            Some("ABGR:0x03300000000000013".to_string())
+        );
     }
 }

--- a/gst-plugin-wayland-display/src/waylandsrc/mod.rs
+++ b/gst-plugin-wayland-display/src/waylandsrc/mod.rs
@@ -11,7 +11,7 @@ pub fn register(plugin: &gst::Plugin) -> Result<(), glib::BoolError> {
     gst::Element::register(
         Some(plugin),
         "waylanddisplaysrc",
-        gst::Rank::Marginal,
+        gst::Rank::MARGINAL,
         WaylandDisplaySrc::static_type(),
     )
 }

--- a/wayland-display-core/Cargo.toml
+++ b/wayland-display-core/Cargo.toml
@@ -19,7 +19,10 @@ tracing.workspace = true
 once_cell.workspace = true
 wayland-backend = "0.3.3"
 wayland-scanner = "0.31.1"
-gstreamer-allocators = {version = "0.23.2", package = "gstreamer-allocators", features = ["v1_24"]}
+gstreamer-allocators = {version = "0.23.2", package = "gstreamer-allocators", features = ["v1_24", "v1_16"] }
+
+[dev-dependencies]
+tracing-subscriber = "0.3.18"
 
 [dependencies.smithay]
 git = "https://github.com/games-on-whales/smithay"

--- a/wayland-display-core/Cargo.toml
+++ b/wayland-display-core/Cargo.toml
@@ -27,6 +27,7 @@ default-features = false
 features = [
     "backend_drm",
     "backend_egl",
+    "backend_gbm",
     "backend_libinput",
     "backend_udev",
     "renderer_gl",

--- a/wayland-display-core/Cargo.toml
+++ b/wayland-display-core/Cargo.toml
@@ -19,6 +19,7 @@ tracing.workspace = true
 once_cell.workspace = true
 wayland-backend = "0.3.3"
 wayland-scanner = "0.31.1"
+gstreamer-allocators = {version = "0.23.2", package = "gstreamer-allocators", features = ["v1_24"]}
 
 [dependencies.smithay]
 git = "https://github.com/games-on-whales/smithay"

--- a/wayland-display-core/src/comp/mod.rs
+++ b/wayland-display-core/src/comp/mod.rs
@@ -1,5 +1,5 @@
-use super::Command;
-use gst_video::{VideoFormat, VideoInfo, VideoInfoDmaDrm};
+use super::{Command, GstVideoInfo};
+use gst_video::{VideoInfo};
 use smithay::backend::input::AxisSource;
 use smithay::backend::renderer::gles::GlesRenderer;
 use smithay::{
@@ -96,7 +96,7 @@ pub(crate) struct State {
 
     // management
     pub output: Option<Output>,
-    pub video_info: Option<VideoInfo>,
+    pub video_info: Option<GstVideoInfo>,
     pub seat: Seat<Self>,
     pub space: Space<Window>,
     pub popups: PopupManager,
@@ -246,15 +246,16 @@ pub(crate) fn init(
         .handle()
         .insert_source(command_src, move |event, _, state| {
             match event {
-                Event::Msg(Command::VideoInfo(info)) => {
+                Event::Msg(Command::VideoInfo(video_info)) => {
+                    let base_info: VideoInfo = video_info.clone().into();
                     debug!(
                         "Requested video format: {} .to_fourcc() = {}",
-                        info.format(),
-                        info.format().to_fourcc()
+                        base_info.format(),
+                        base_info.format().to_fourcc()
                     );
                     let size: Size<i32, Physical> =
-                        (info.width() as i32, info.height() as i32).into();
-                    let framerate = info.fps();
+                        (base_info.width() as i32, base_info.height() as i32).into();
+                    let framerate = base_info.fps();
                     let duration = Duration::from_secs_f64(
                         framerate.numer() as f64 / framerate.denom() as f64,
                     );
@@ -285,29 +286,26 @@ pub(crate) fn init(
                     state.dtr = Some(dtr);
                     state.pointer_location = (size.w as f64 / 2.0, size.h as f64 / 2.0).into();
                     match render_target {
-                        RenderTarget::Hardware(_) => {
-                            if info.format() == VideoFormat::DmaDrm {
-                                // TODO: this doesn't work, get the right one from set_caps()
-                                let caps = info.clone().to_caps().unwrap();
-                                let dma_info = VideoInfoDmaDrm::from_caps(caps.as_ref())
-                                    .expect("Failed to create VideoInfoDmaDrm");
-                                let allocator = GsDmaBuf::new(render_node.unwrap(), dma_info)
-                                    .expect("Failed to create GsDmaBuf");
-                                state.output_buffer = Some(GsBufferType::DMA(allocator));
-                            } else {
-                                let allocator =
-                                    GsGlesbuffer::new(&mut state.renderer, info.clone())
-                                        .expect("Failed to create GsGlesbuffer");
+                        RenderTarget::Hardware(_) => match video_info.clone() {
+                            GstVideoInfo::RAW(base_info) => {
+                                let allocator = GsGlesbuffer::new(&mut state.renderer, base_info)
+                                    .expect("Failed to create GsGlesbuffer");
                                 state.output_buffer = Some(GsBufferType::RAW(allocator));
                             }
-                        }
+                            GstVideoInfo::DMA(base_info) => {
+                                let allocator = GsDmaBuf::new(render_node.unwrap(), base_info)
+                                    .expect("Failed to create GsDmaBuf");
+                                state.output_buffer = Some(GsBufferType::DMA(allocator));
+                            }
+                        },
                         RenderTarget::Software => {
-                            let allocator = GsGlesbuffer::new(&mut state.renderer, info.clone())
-                                .expect("Failed to create GsGlesbuffer");
+                            let allocator =
+                                GsGlesbuffer::new(&mut state.renderer, base_info.clone())
+                                    .expect("Failed to create GsGlesbuffer");
                             state.output_buffer = Some(GsBufferType::RAW(allocator));
                         }
                     }
-                    state.video_info = Some(info);
+                    state.video_info = Some(video_info);
 
                     let new_size = size
                         .to_f64()
@@ -345,7 +343,9 @@ pub(crate) fn init(
                 }
                 Event::Msg(Command::Buffer(buffer_sender, tracer)) => {
                     let wait = if let Some(last_render) = state.last_render {
-                        let framerate = state.video_info.as_ref().unwrap().fps();
+                        let base_info: VideoInfo =
+                            state.video_info.as_ref().unwrap().clone().into();
+                        let framerate = base_info.fps();
                         let duration = Duration::from_secs_f64(
                             framerate.denom() as f64 / framerate.numer() as f64,
                         );

--- a/wayland-display-core/src/comp/mod.rs
+++ b/wayland-display-core/src/comp/mod.rs
@@ -1,23 +1,16 @@
-use std::{
-    collections::{HashMap, HashSet},
-    ffi::CString,
-    sync::{mpsc::Sender, Arc, Mutex, Weak},
-    time::{Duration, Instant},
-};
 use super::Command;
 use gst_video::VideoInfo;
-use once_cell::sync::Lazy;
+use smithay::backend::input::AxisSource;
+use smithay::backend::renderer::gles::GlesRenderer;
 use smithay::{
     backend::{
-        allocator::{Fourcc, dmabuf::Dmabuf},
-        drm::{DrmNode, NodeType},
-        egl::{EGLContext, EGLDevice, EGLDisplay},
+        allocator::{dmabuf::Dmabuf, Fourcc},
+        drm::DrmNode,
         libinput::LibinputInputBackend,
         renderer::{
-            element::memory::{MemoryRenderBuffer, MemoryBuffer},
-            damage::{OutputDamageTracker, Error as DTRError},
-            gles::{GlesRenderbuffer, GlesRenderer},
-            Bind, Offscreen,
+            damage::{Error as DTRError, OutputDamageTracker},
+            element::memory::{MemoryBuffer, MemoryRenderBuffer},
+            Bind,
         },
     },
     desktop::{
@@ -40,26 +33,31 @@ use smithay::{
         input::Libinput,
         wayland_protocols::wp::presentation_time::server::wp_presentation_feedback,
         wayland_server::{
-            backend::{GlobalId, ClientData, ClientId, DisconnectReason},
+            backend::{ClientData, ClientId, DisconnectReason, GlobalId},
             Display, DisplayHandle,
         },
     },
     utils::{Clock, Logical, Monotonic, Physical, Point, Rectangle, Size, Transform},
     wayland::{
-        compositor::{with_states, CompositorState, CompositorClientState},
+        compositor::{with_states, CompositorClientState, CompositorState},
         dmabuf::{DmabufGlobal, DmabufState},
         output::OutputManagerState,
+        pointer_constraints::PointerConstraintsState,
         presentation::PresentationState,
-        shell::xdg::{XdgShellState, XdgToplevelSurfaceData, SurfaceCachedState},
+        relative_pointer::RelativePointerManagerState,
+        selection::data_device::DataDeviceState,
+        shell::xdg::{SurfaceCachedState, XdgShellState, XdgToplevelSurfaceData},
         shm::ShmState,
         socket::ListeningSocketSource,
         viewporter::ViewporterState,
-        relative_pointer::RelativePointerManagerState,
-        pointer_constraints::PointerConstraintsState,
-        selection::data_device::DataDeviceState,
     },
 };
-use smithay::backend::input::AxisSource;
+use std::{
+    collections::HashSet,
+    ffi::CString,
+    sync::{mpsc::Sender, Arc},
+    time::{Duration, Instant},
+};
 use tracing::debug;
 
 mod focus;
@@ -69,10 +67,9 @@ mod rendering;
 pub use self::focus::*;
 pub use self::input::*;
 pub use self::rendering::*;
+use crate::utils::allocator::{Allocator, AllocatorType, GLESAllocator};
+use crate::utils::renderer::setup_renderer;
 use crate::{utils::RenderTarget, wayland::protocols::wl_drm::create_drm_global};
-
-static EGL_DISPLAYS: Lazy<Mutex<HashMap<Option<DrmNode>, Weak<EGLDisplay>>>> =
-    Lazy::new(|| Mutex::new(HashMap::new()));
 
 #[derive(Debug, Default)]
 pub struct ClientState {
@@ -92,9 +89,8 @@ pub(crate) struct State {
 
     // render
     dtr: Option<OutputDamageTracker>,
-    renderbuffer: Option<GlesRenderbuffer>,
+    buffer_allocator: Option<AllocatorType>,
     pub renderer: GlesRenderer,
-    egl_display_ref: Arc<EGLDisplay>,
     dmabuf_global: Option<(DmabufGlobal, GlobalId)>,
     last_render: Option<Instant>,
 
@@ -128,17 +124,6 @@ pub(crate) struct State {
     cursor_event_count: i32,
 }
 
-pub fn get_egl_device_for_node(drm_node: &DrmNode) -> EGLDevice {
-    let drm_node = drm_node
-        .node_with_type(NodeType::Render)
-        .and_then(Result::ok)
-        .unwrap_or(drm_node.clone());
-    EGLDevice::enumerate()
-        .expect("Failed to enumerate EGLDevices")
-        .find(|d| d.try_get_render_node().unwrap_or_default() == Some(drm_node))
-        .expect("Unable to find EGLDevice for drm-node")
-}
-
 pub(crate) fn init(
     command_src: Channel<Command>,
     render: impl Into<RenderTarget>,
@@ -164,38 +149,7 @@ pub(crate) fn init(
     let render_target = render.into();
     let render_node: Option<DrmNode> = render_target.clone().into();
 
-    // init render backend
-    let (egl_display_ref, context) = {
-        let mut displays = EGL_DISPLAYS.lock().unwrap();
-        let maybe_display = displays
-            .get(&render_node)
-            .and_then(|weak_display| weak_display.upgrade());
-
-        let egl = match maybe_display {
-            Some(display) => display,
-            None => {
-                let device = match render_node.as_ref() {
-                    Some(render_node) => get_egl_device_for_node(render_node),
-                    None => EGLDevice::enumerate()
-                        .expect("Failed to enumerate EGLDevices")
-                        .find(|device| {
-                            device
-                                .extensions()
-                                .iter()
-                                .any(|e| e == "EGL_MESA_device_software")
-                        })
-                        .expect("Failed to find software device"),
-                };
-                let egl = unsafe { EGLDisplay::new(device).expect("Failed to create EGLDisplay") };
-                let display = Arc::new(egl);
-                displays.insert(render_node, Arc::downgrade(&display));
-                display
-            }
-        };
-        let context = EGLContext::new(&egl).expect("Failed to initialize EGL context");
-        (egl, context)
-    };
-    let renderer = unsafe { GlesRenderer::new(context) }.expect("Failed to initialize renderer");
+    let renderer = setup_renderer(render_node);
     let _ = devices_tx.send(render_target.as_devices());
 
     let shm_state = ShmState::new::<State>(&dh, vec![]);
@@ -220,11 +174,12 @@ pub(crate) fn init(
         None
     };
 
-    let cursor_element =
-        MemoryRenderBuffer::from_memory(MemoryBuffer::from_slice(
-            CURSOR_DATA_BYTES,
-            Fourcc::Abgr8888,
-            (64, 64)), 1, Transform::Normal, None);
+    let cursor_element = MemoryRenderBuffer::from_memory(
+        MemoryBuffer::from_slice(CURSOR_DATA_BYTES, Fourcc::Abgr8888, (64, 64)),
+        1,
+        Transform::Normal,
+        None,
+    );
 
     // init input backend
     let libinput_context = Libinput::new_from_path(NixInterface);
@@ -238,8 +193,7 @@ pub(crate) fn init(
         .expect("Failed to add keyboard to seat");
     seat.add_pointer();
 
-    let mut event_loop =
-        EventLoop::<State>::try_new().expect("Unable to create event_loop");
+    let mut event_loop = EventLoop::<State>::try_new().expect("Unable to create event_loop");
 
     let mut state = State {
         handle: event_loop.handle(),
@@ -247,9 +201,8 @@ pub(crate) fn init(
         clock,
 
         renderer,
-        egl_display_ref,
         dtr: None,
-        renderbuffer: None,
+        buffer_allocator: None,
         dmabuf_global,
         video_info: None,
         last_render: None,
@@ -294,7 +247,11 @@ pub(crate) fn init(
         .insert_source(command_src, move |event, _, state| {
             match event {
                 Event::Msg(Command::VideoInfo(info)) => {
-                    debug!("Requested video format: {} .to_fourcc() = {}", info.format(), info.format().to_fourcc());
+                    debug!(
+                        "Requested video format: {} .to_fourcc() = {}",
+                        info.format(),
+                        info.format().to_fourcc()
+                    );
                     let size: Size<i32, Physical> =
                         (info.width() as i32, info.height() as i32).into();
                     let framerate = info.fps();
@@ -327,13 +284,14 @@ pub(crate) fn init(
                     state.space.map_output(&output, (0, 0));
                     state.dtr = Some(dtr);
                     state.pointer_location = (size.w as f64 / 2.0, size.h as f64 / 2.0).into();
-                    state.renderbuffer = Some(
-                        state
-                            .renderer
-                            .create_buffer(Fourcc::try_from(info.format().to_fourcc()).unwrap_or(Fourcc::Abgr8888),
-                                           (info.width() as i32, info.height() as i32).into())
-                            .expect("Failed to create renderbuffer"),
+                    let mut allocator = AllocatorType::GLES(GLESAllocator::default());
+                    allocator.alloc_buffer(
+                        &mut state.renderer,
+                        Fourcc::try_from(info.format().to_fourcc()).unwrap_or(Fourcc::Abgr8888),
+                        info.width() as i32,
+                        info.height() as i32,
                     );
+                    state.buffer_allocator = Some(allocator);
                     state.video_info = Some(info);
 
                     let new_size = size
@@ -348,9 +306,15 @@ pub(crate) fn init(
                                 states
                                     .data_map
                                     .get::<XdgToplevelSurfaceData>()
-                                    .map(|_attrs| states.cached_state.get::<SurfaceCachedState>().current().max_size)
+                                    .map(|_attrs| {
+                                        states
+                                            .cached_state
+                                            .get::<SurfaceCachedState>()
+                                            .current()
+                                            .max_size
+                                    })
                             })
-                                .unwrap_or(new_size),
+                            .unwrap_or(new_size),
                         );
 
                         let new_size = max_size
@@ -383,11 +347,14 @@ pub(crate) fn init(
                     let render = move |state: &mut State, now: Instant| {
                         let _span = match tracer {
                             Some(ref tracer) => Some(tracer.trace("render")),
-                            None => None
+                            None => None,
                         };
                         if let Err(_) = match state.create_frame() {
                             Ok((buf, render_result)) => {
-                                render_result.sync.wait().expect("Error during render_result.sync"); // we need to wait before giving a hardware buffer to gstreamer or we might not be done writing to it
+                                render_result
+                                    .sync
+                                    .wait()
+                                    .expect("Error during render_result.sync"); // we need to wait before giving a hardware buffer to gstreamer or we might not be done writing to it
                                 let res = buffer_sender.send(Ok(buf));
                                 let rendered_states = &render_result.states;
                                 let rendered_damage = render_result.damage.is_some();
@@ -425,10 +392,13 @@ pub(crate) fn init(
                                     if rendered_damage {
                                         output_presentation_feedback.presented(
                                             state.clock.now(),
-                                            Duration::from_millis(output
-                                                .current_mode()
-                                                .map(|mode| mode.refresh)
-                                                .unwrap_or_default() as u64),
+                                            Duration::from_millis(
+                                                output
+                                                    .current_mode()
+                                                    .map(|mode| mode.refresh)
+                                                    .unwrap_or_default()
+                                                    as u64,
+                                            ),
                                             0,
                                             wp_presentation_feedback::Kind::Vsync,
                                         );
@@ -498,7 +468,14 @@ pub(crate) fn init(
                 }
                 Event::Msg(Command::PointerAxis(horizontal_amount, vertical_amount)) => {
                     let time: Duration = state.clock.now().into();
-                    state.pointer_axis(time.as_millis() as u32, AxisSource::Wheel, horizontal_amount * 3.0 / 120.0, vertical_amount * 3.0 / 120.0, Some(horizontal_amount), Some(vertical_amount));
+                    state.pointer_axis(
+                        time.as_millis() as u32,
+                        AxisSource::Wheel,
+                        horizontal_amount * 3.0 / 120.0,
+                        vertical_amount * 3.0 / 120.0,
+                        Some(horizontal_amount),
+                        Some(vertical_amount),
+                    );
                 }
             };
         })
@@ -519,8 +496,8 @@ pub(crate) fn init(
         })
         .expect("Failed to init wayland socket source");
 
-    event_loop.
-        handle()
+    event_loop
+        .handle()
         .insert_source(
             Generic::new(display, Interest::READ, Mode::Level),
             |_, display, state| {
@@ -540,9 +517,7 @@ pub(crate) fn init(
 
     let signal = event_loop.get_signal();
     if let Err(err) = event_loop.run(None, &mut state, |state| {
-        state.dh
-            .flush_clients()
-            .expect("Failed to flush clients");
+        state.dh.flush_clients().expect("Failed to flush clients");
         state.space.refresh();
         state.popups.cleanup();
 

--- a/wayland-display-core/src/comp/mod.rs
+++ b/wayland-display-core/src/comp/mod.rs
@@ -514,7 +514,7 @@ pub(crate) fn init(
                         }
                         None => FormatSet::default(),
                     };
-                    tracing::info!("Supported dma formats: {:?}", supported_formats);
+                    debug!("Supported dma formats: {:?}", supported_formats);
                     let _ = sender.send(supported_formats);
                 }
             };

--- a/wayland-display-core/src/comp/mod.rs
+++ b/wayland-display-core/src/comp/mod.rs
@@ -1,5 +1,5 @@
 use super::Command;
-use gst_video::{VideoFormat, VideoInfo};
+use gst_video::{VideoFormat, VideoInfo, VideoInfoDmaDrm};
 use smithay::backend::input::AxisSource;
 use smithay::backend::renderer::gles::GlesRenderer;
 use smithay::{
@@ -287,7 +287,11 @@ pub(crate) fn init(
                     match render_target {
                         RenderTarget::Hardware(_) => {
                             if info.format() == VideoFormat::DmaDrm {
-                                let allocator = GsDmaBuf::new(render_node.unwrap(), info.clone())
+                                // TODO: this doesn't work, get the right one from set_caps()
+                                let caps = info.clone().to_caps().unwrap();
+                                let dma_info = VideoInfoDmaDrm::from_caps(caps.as_ref())
+                                    .expect("Failed to create VideoInfoDmaDrm");
+                                let allocator = GsDmaBuf::new(render_node.unwrap(), dma_info)
                                     .expect("Failed to create GsDmaBuf");
                                 state.output_buffer = Some(GsBufferType::DMA(allocator));
                             } else {

--- a/wayland-display-core/src/comp/mod.rs
+++ b/wayland-display-core/src/comp/mod.rs
@@ -1,5 +1,5 @@
 use super::{Command, GstVideoInfo};
-use gst_video::{VideoInfo};
+use gst_video::VideoInfo;
 use smithay::backend::input::AxisSource;
 use smithay::backend::renderer::gles::GlesRenderer;
 use smithay::{
@@ -491,6 +491,11 @@ pub(crate) fn init(
                         Some(horizontal_amount),
                         Some(vertical_amount),
                     );
+                }
+                Event::Msg(Command::GetSupportedDmaFormats(sender)) => {
+                    let formats = Bind::<Dmabuf>::supported_formats(&state.renderer);
+                    debug!("Supported dma formats: {:?}", formats);
+                    let _ = sender.send(formats);
                 }
             };
         })

--- a/wayland-display-core/src/comp/mod.rs
+++ b/wayland-display-core/src/comp/mod.rs
@@ -1,5 +1,5 @@
 use super::Command;
-use gst_video::VideoInfo;
+use gst_video::{VideoFormat, VideoInfo};
 use smithay::backend::input::AxisSource;
 use smithay::backend::renderer::gles::GlesRenderer;
 use smithay::{
@@ -67,7 +67,7 @@ mod rendering;
 pub use self::focus::*;
 pub use self::input::*;
 pub use self::rendering::*;
-use crate::utils::allocator::{Allocator, AllocatorType, GLESAllocator};
+use crate::utils::allocator::{GsBufferType, GsDmaBuf, GsGlesbuffer};
 use crate::utils::renderer::setup_renderer;
 use crate::{utils::RenderTarget, wayland::protocols::wl_drm::create_drm_global};
 
@@ -89,7 +89,7 @@ pub(crate) struct State {
 
     // render
     dtr: Option<OutputDamageTracker>,
-    buffer_allocator: Option<AllocatorType>,
+    output_buffer: Option<GsBufferType>,
     pub renderer: GlesRenderer,
     dmabuf_global: Option<(DmabufGlobal, GlobalId)>,
     last_render: Option<Instant>,
@@ -202,7 +202,7 @@ pub(crate) fn init(
 
         renderer,
         dtr: None,
-        buffer_allocator: None,
+        output_buffer: None,
         dmabuf_global,
         video_info: None,
         last_render: None,
@@ -284,14 +284,25 @@ pub(crate) fn init(
                     state.space.map_output(&output, (0, 0));
                     state.dtr = Some(dtr);
                     state.pointer_location = (size.w as f64 / 2.0, size.h as f64 / 2.0).into();
-                    let mut allocator = AllocatorType::GLES(GLESAllocator::default());
-                    allocator.alloc_buffer(
-                        &mut state.renderer,
-                        Fourcc::try_from(info.format().to_fourcc()).unwrap_or(Fourcc::Abgr8888),
-                        info.width() as i32,
-                        info.height() as i32,
-                    );
-                    state.buffer_allocator = Some(allocator);
+                    match render_target {
+                        RenderTarget::Hardware(_) => {
+                            if info.format() == VideoFormat::DmaDrm {
+                                let allocator = GsDmaBuf::new(render_node.unwrap(), info.clone())
+                                    .expect("Failed to create GsDmaBuf");
+                                state.output_buffer = Some(GsBufferType::DMA(allocator));
+                            } else {
+                                let allocator =
+                                    GsGlesbuffer::new(&mut state.renderer, info.clone())
+                                        .expect("Failed to create GsGlesbuffer");
+                                state.output_buffer = Some(GsBufferType::RAW(allocator));
+                            }
+                        }
+                        RenderTarget::Software => {
+                            let allocator = GsGlesbuffer::new(&mut state.renderer, info.clone())
+                                .expect("Failed to create GsGlesbuffer");
+                            state.output_buffer = Some(GsBufferType::RAW(allocator));
+                        }
+                    }
                     state.video_info = Some(info);
 
                     let new_size = size

--- a/wayland-display-core/src/comp/mod.rs
+++ b/wayland-display-core/src/comp/mod.rs
@@ -1,7 +1,9 @@
 use super::{Command, GstVideoInfo};
 use gst_video::VideoInfo;
+use smithay::backend::allocator::format::FormatSet;
 use smithay::backend::input::AxisSource;
 use smithay::backend::renderer::gles::GlesRenderer;
+use smithay::reexports::gbm::BufferObjectFlags;
 use smithay::{
     backend::{
         allocator::{dmabuf::Dmabuf, Fourcc},
@@ -67,7 +69,7 @@ mod rendering;
 pub use self::focus::*;
 pub use self::input::*;
 pub use self::rendering::*;
-use crate::utils::allocator::{GsBufferType, GsDmaBuf, GsGlesbuffer};
+use crate::utils::allocator::{new_gbm_device, GsBufferType, GsDmaBuf, GsGlesbuffer};
 use crate::utils::renderer::setup_renderer;
 use crate::{utils::RenderTarget, wayland::protocols::wl_drm::create_drm_global};
 
@@ -90,6 +92,7 @@ pub(crate) struct State {
     // render
     dtr: Option<OutputDamageTracker>,
     output_buffer: Option<GsBufferType>,
+    render_node: Option<DrmNode>,
     pub renderer: GlesRenderer,
     dmabuf_global: Option<(DmabufGlobal, GlobalId)>,
     last_render: Option<Instant>,
@@ -203,6 +206,7 @@ pub(crate) fn init(
         renderer,
         dtr: None,
         output_buffer: None,
+        render_node,
         dmabuf_global,
         video_info: None,
         last_render: None,
@@ -494,8 +498,24 @@ pub(crate) fn init(
                 }
                 Event::Msg(Command::GetSupportedDmaFormats(sender)) => {
                     let formats = Bind::<Dmabuf>::supported_formats(&state.renderer);
-                    debug!("Supported dma formats: {:?}", formats);
-                    let _ = sender.send(formats);
+                    let supported_formats = match state.render_node {
+                        Some(node) => {
+                            let gbm_dev =
+                                new_gbm_device(node).expect("Failed to create gbm device");
+                            formats
+                                .unwrap_or_default()
+                                .iter()
+                                .filter(|f| {
+                                    gbm_dev
+                                        .is_format_supported(f.code, BufferObjectFlags::RENDERING)
+                                })
+                                .map(|f| *f)
+                                .collect()
+                        }
+                        None => FormatSet::default(),
+                    };
+                    tracing::info!("Supported dma formats: {:?}", supported_formats);
+                    let _ = sender.send(supported_formats);
                 }
             };
         })

--- a/wayland-display-core/src/comp/rendering.rs
+++ b/wayland-display-core/src/comp/rendering.rs
@@ -1,7 +1,8 @@
 use std::time::{Duration, Instant};
 
+use super::State;
+use crate::utils::allocator::Allocator;
 use smithay::{
-    desktop::space::render_output,
     backend::allocator::Fourcc,
     backend::renderer::{
         damage::Error as DTRError,
@@ -12,12 +13,11 @@ use smithay::{
         gles::GlesRenderer,
         Bind, ExportMem, ImportAll, ImportMem, Renderer, Unbind,
     },
+    desktop::space::render_output,
     input::pointer::CursorImageStatus,
     render_elements,
-    utils::{Rectangle},
+    utils::Rectangle,
 };
-
-use super::State;
 
 pub const CURSOR_DATA_BYTES: &[u8] = include_bytes!("../../resources/cursor.rgba");
 
@@ -30,52 +30,46 @@ render_elements! {
 impl State {
     pub fn create_frame(
         &mut self,
-    ) -> Result<
-        (
-            gst::Buffer,
-            RenderOutputResult,
-        ),
-        DTRError<GlesRenderer>,
-    > {
+    ) -> Result<(gst::Buffer, RenderOutputResult), DTRError<GlesRenderer>> {
         assert!(self.output.is_some());
         assert!(self.dtr.is_some());
         assert!(self.video_info.is_some());
-        assert!(self.renderbuffer.is_some());
+        assert!(self.buffer_allocator.is_some());
 
         let elements =
             if Instant::now().duration_since(self.last_pointer_movement) < Duration::from_secs(5) {
                 match &self.cursor_state {
-                    CursorImageStatus::Named(_cursor_icon) => vec![CursorElement::Memory(
-                        // TODO: icon?
-                        MemoryRenderBufferRenderElement::from_buffer(
-                            &mut self.renderer,
-                            self.pointer_location.to_physical_precise_round(1),
-                            &self.cursor_element,
-                            None,
-                            None,
-                            None,
-                            Kind::Cursor,
-                        )
-                            .map_err(DTRError::Rendering)?,
-                    )],
-                    CursorImageStatus::Surface(wl_surface) => {
-                        smithay::backend::renderer::element::surface::render_elements_from_surface_tree(
-                            &mut self.renderer,
-                            wl_surface,
-                            self.pointer_location.to_physical_precise_round(1),
-                            1.,
-                            1.,
-                            Kind::Cursor,
-                        )
-                    }
-                    CursorImageStatus::Hidden => vec![],
+                CursorImageStatus::Named(_cursor_icon) => vec![CursorElement::Memory(
+                    // TODO: icon?
+                    MemoryRenderBufferRenderElement::from_buffer(
+                        &mut self.renderer,
+                        self.pointer_location.to_physical_precise_round(1),
+                        &self.cursor_element,
+                        None,
+                        None,
+                        None,
+                        Kind::Cursor,
+                    )
+                    .map_err(DTRError::Rendering)?,
+                )],
+                CursorImageStatus::Surface(wl_surface) => {
+                    smithay::backend::renderer::element::surface::render_elements_from_surface_tree(
+                        &mut self.renderer,
+                        wl_surface,
+                        self.pointer_location.to_physical_precise_round(1),
+                        1.,
+                        1.,
+                        Kind::Cursor,
+                    )
                 }
+                CursorImageStatus::Hidden => vec![],
+            }
             } else {
                 vec![]
             };
 
         self.renderer
-            .bind(self.renderbuffer.clone().unwrap())
+            .bind(self.buffer_allocator.clone().unwrap().get_buffer().unwrap())
             .map_err(DTRError::Rendering)?;
         let render_output_result = render_output(
             self.output.as_ref().unwrap(),
@@ -90,13 +84,17 @@ impl State {
 
         let mapping = self
             .renderer
-            .copy_framebuffer(Rectangle::from_loc_and_size(
-                (0, 0),
-                (
-                    self.video_info.as_ref().unwrap().width() as i32,
-                    self.video_info.as_ref().unwrap().height() as i32,
+            .copy_framebuffer(
+                Rectangle::from_loc_and_size(
+                    (0, 0),
+                    (
+                        self.video_info.as_ref().unwrap().width() as i32,
+                        self.video_info.as_ref().unwrap().height() as i32,
+                    ),
                 ),
-            ), Fourcc::try_from(self.video_info.as_ref().unwrap().format().to_fourcc()).unwrap_or(Fourcc::Abgr8888))
+                Fourcc::try_from(self.video_info.as_ref().unwrap().format().to_fourcc())
+                    .unwrap_or(Fourcc::Abgr8888),
+            )
             .expect("Failed to export framebuffer");
         let map = self
             .renderer
@@ -112,7 +110,7 @@ impl State {
                     buffer,
                     self.video_info.as_ref().unwrap(),
                 )
-                    .unwrap();
+                .unwrap();
                 let plane_data = vframe.plane_data_mut(0).unwrap();
                 plane_data.clone_from_slice(map);
             }

--- a/wayland-display-core/src/comp/rendering.rs
+++ b/wayland-display-core/src/comp/rendering.rs
@@ -1,9 +1,8 @@
 use std::time::{Duration, Instant};
 
 use super::State;
-use crate::utils::allocator::Allocator;
+use crate::utils::allocator::GsBuffer;
 use smithay::{
-    backend::allocator::Fourcc,
     backend::renderer::{
         damage::Error as DTRError,
         damage::RenderOutputResult,
@@ -11,12 +10,11 @@ use smithay::{
             memory::MemoryRenderBufferRenderElement, surface::WaylandSurfaceRenderElement, Kind,
         },
         gles::GlesRenderer,
-        Bind, ExportMem, ImportAll, ImportMem, Renderer, Unbind,
+        ImportAll, ImportMem, Renderer, Unbind,
     },
     desktop::space::render_output,
     input::pointer::CursorImageStatus,
     render_elements,
-    utils::Rectangle,
 };
 
 pub const CURSOR_DATA_BYTES: &[u8] = include_bytes!("../../resources/cursor.rgba");
@@ -34,7 +32,7 @@ impl State {
         assert!(self.output.is_some());
         assert!(self.dtr.is_some());
         assert!(self.video_info.is_some());
-        assert!(self.buffer_allocator.is_some());
+        assert!(self.output_buffer.is_some());
 
         let elements =
             if Instant::now().duration_since(self.last_pointer_movement) < Duration::from_secs(5) {
@@ -68,9 +66,12 @@ impl State {
                 vec![]
             };
 
-        self.renderer
-            .bind(self.buffer_allocator.clone().unwrap().get_buffer().unwrap())
+        let mut output_buffer = self.output_buffer.clone().expect("Output buffer not set");
+
+        output_buffer
+            .bind(&mut self.renderer)
             .map_err(DTRError::Rendering)?;
+
         let render_output_result = render_output(
             self.output.as_ref().unwrap(),
             &mut self.renderer,
@@ -82,41 +83,8 @@ impl State {
             [0.0, 0.0, 0.0, 1.0],
         )?;
 
-        let mapping = self
-            .renderer
-            .copy_framebuffer(
-                Rectangle::from_loc_and_size(
-                    (0, 0),
-                    (
-                        self.video_info.as_ref().unwrap().width() as i32,
-                        self.video_info.as_ref().unwrap().height() as i32,
-                    ),
-                ),
-                Fourcc::try_from(self.video_info.as_ref().unwrap().format().to_fourcc())
-                    .unwrap_or(Fourcc::Abgr8888),
-            )
-            .expect("Failed to export framebuffer");
-        let map = self
-            .renderer
-            .map_texture(&mapping)
-            .expect("Failed to download framebuffer");
+        let buffer = output_buffer.to_gs_buffer(&mut self.renderer);
 
-        let buffer = {
-            let mut buffer = gst::Buffer::with_size(map.len()).expect("failed to create buffer");
-            {
-                let buffer = buffer.get_mut().unwrap();
-
-                let mut vframe = gst_video::VideoFrameRef::from_buffer_ref_writable(
-                    buffer,
-                    self.video_info.as_ref().unwrap(),
-                )
-                .unwrap();
-                let plane_data = vframe.plane_data_mut(0).unwrap();
-                plane_data.clone_from_slice(map);
-            }
-
-            buffer
-        };
         self.renderer.unbind().map_err(DTRError::Rendering)?;
         Ok((buffer, render_output_result))
     }

--- a/wayland-display-core/src/lib.rs
+++ b/wayland-display-core/src/lib.rs
@@ -12,8 +12,8 @@ use smithay::backend::input::{ButtonState, KeyState};
 use smithay::utils::{Logical, Point};
 use utils::RenderTarget;
 
-pub(crate) mod comp;
 pub(crate) mod utils;
+pub(crate) mod comp;
 pub(crate) mod wayland;
 
 pub(crate) enum Command {

--- a/wayland-display-core/src/lib.rs
+++ b/wayland-display-core/src/lib.rs
@@ -2,6 +2,9 @@ use smithay::backend::drm::CreateDrmNodeError;
 use smithay::backend::SwapBuffersError;
 use smithay::reexports::calloop::channel::Sender;
 
+pub use smithay::backend::allocator::{
+    format::FormatSet, Format as DrmFormat, Fourcc, Modifier as DrmModifier, Vendor as DrmVendor
+};
 use smithay::backend::input::{ButtonState, KeyState};
 use smithay::utils::{Logical, Point};
 use std::ffi::{c_char, c_void, CString};
@@ -11,11 +14,10 @@ use std::thread::JoinHandle;
 use utils::RenderTarget;
 
 pub(crate) mod comp;
-pub(crate) mod utils;
+pub mod utils;
 pub(crate) mod wayland;
 
 pub use crate::utils::video_info::GstVideoInfo;
-
 
 pub(crate) enum Command {
     InputDevice(String),
@@ -29,6 +31,7 @@ pub(crate) enum Command {
     PointerMotionAbsolute(Point<f64, Logical>),
     PointerButton(u32, ButtonState),
     PointerAxis(f64, f64),
+    GetSupportedDmaFormats(SyncSender<Option<FormatSet>>),
     Quit,
 }
 
@@ -203,6 +206,14 @@ impl WaylandDisplay {
                 Err(gst::FlowError::Error)
             }
         }
+    }
+
+    pub fn get_supported_dma_formats(&self) -> Option<FormatSet> {
+        let (buffer_tx, buffer_rx) = mpsc::sync_channel(0);
+        let _ = self
+            .command_tx
+            .send(Command::GetSupportedDmaFormats(buffer_tx));
+        buffer_rx.recv().unwrap()
     }
 }
 

--- a/wayland-display-core/src/lib.rs
+++ b/wayland-display-core/src/lib.rs
@@ -1,11 +1,11 @@
 use smithay::backend::drm::CreateDrmNodeError;
 use smithay::backend::SwapBuffersError;
-use smithay::reexports::calloop::channel::Sender;
+pub use smithay::reexports::calloop::channel::{channel, Channel, Sender};
 
 pub use smithay::backend::allocator::{
-    format::FormatSet, Format as DrmFormat, Fourcc, Modifier as DrmModifier, Vendor as DrmVendor
+    format::FormatSet, Format as DrmFormat, Fourcc, Modifier as DrmModifier, Vendor as DrmVendor,
 };
-use smithay::backend::input::{ButtonState, KeyState};
+pub use smithay::backend::input::{ButtonState, KeyState};
 use smithay::utils::{Logical, Point};
 use std::ffi::{c_char, c_void, CString};
 use std::str::FromStr;
@@ -19,7 +19,7 @@ pub(crate) mod wayland;
 
 pub use crate::utils::video_info::GstVideoInfo;
 
-pub(crate) enum Command {
+pub enum Command {
     InputDevice(String),
     VideoInfo(GstVideoInfo),
     Buffer(
@@ -120,6 +120,30 @@ impl WaylandDisplay {
             }
         });
         let command_tx = channel_rx.recv().unwrap();
+
+        Ok(WaylandDisplay {
+            thread_handle: Some(thread_handle),
+            command_tx,
+            tracer: None,
+            devices: MaybeRecv::Rx(devices_rx),
+            envs: MaybeRecv::Rx(envs_rx),
+        })
+    }
+
+    pub fn new_with_channel(
+        render_node: Option<String>,
+        command_tx: Sender<Command>,
+        commands_rx: Channel<Command>,
+    ) -> Result<WaylandDisplay, CreateDrmNodeError> {
+        let (devices_tx, devices_rx) = std::sync::mpsc::channel();
+        let (envs_tx, envs_rx) = std::sync::mpsc::channel();
+        let render_target = RenderTarget::from_str(
+            &render_node.unwrap_or_else(|| String::from("/dev/dri/renderD128")),
+        )?;
+
+        let thread_handle = std::thread::spawn(move || {
+            comp::init(commands_rx, render_target, devices_tx, envs_tx);
+        });
 
         Ok(WaylandDisplay {
             thread_handle: Some(thread_handle),

--- a/wayland-display-core/src/lib.rs
+++ b/wayland-display-core/src/lib.rs
@@ -1,25 +1,29 @@
-use gst_video::VideoInfo;
-
 use smithay::backend::drm::CreateDrmNodeError;
 use smithay::backend::SwapBuffersError;
 use smithay::reexports::calloop::channel::Sender;
 
+use smithay::backend::input::{ButtonState, KeyState};
+use smithay::utils::{Logical, Point};
 use std::ffi::{c_char, c_void, CString};
 use std::str::FromStr;
 use std::sync::mpsc::{self, Receiver, SyncSender};
 use std::thread::JoinHandle;
-use smithay::backend::input::{ButtonState, KeyState};
-use smithay::utils::{Logical, Point};
 use utils::RenderTarget;
 
-pub(crate) mod utils;
 pub(crate) mod comp;
+pub(crate) mod utils;
 pub(crate) mod wayland;
+
+pub use crate::utils::video_info::GstVideoInfo;
+
 
 pub(crate) enum Command {
     InputDevice(String),
-    VideoInfo(VideoInfo),
-    Buffer(SyncSender<Result<gst::Buffer, SwapBuffersError>>, Option<Tracer>),
+    VideoInfo(GstVideoInfo),
+    Buffer(
+        SyncSender<Result<gst::Buffer, SwapBuffersError>>,
+        Option<Tracer>,
+    ),
     KeyboardInput(u32, KeyState),
     PointerMotion(Point<f64, Logical>),
     PointerMotionAbsolute(Point<f64, Logical>),
@@ -40,11 +44,11 @@ pub struct Trace {
 }
 
 impl Tracer {
-    pub fn new(start_fn: extern "C" fn(*const c_char) -> *mut c_void, end_fn: extern "C" fn(*mut c_void)) -> Self {
-        Tracer {
-            start_fn,
-            end_fn,
-        }
+    pub fn new(
+        start_fn: extern "C" fn(*const c_char) -> *mut c_void,
+        end_fn: extern "C" fn(*mut c_void),
+    ) -> Self {
+        Tracer { start_fn, end_fn }
     }
 
     pub fn trace(&self, name: &str) -> Trace {
@@ -123,14 +127,14 @@ impl WaylandDisplay {
         })
     }
 
-    pub fn devices(&mut self) -> impl Iterator<Item=&str> {
+    pub fn devices(&mut self) -> impl Iterator<Item = &str> {
         self.devices
             .get()
             .iter()
             .map(|string| string.to_str().unwrap())
     }
 
-    pub fn env_vars(&mut self) -> impl Iterator<Item=&str> {
+    pub fn env_vars(&mut self) -> impl Iterator<Item = &str> {
         self.envs
             .get()
             .iter()
@@ -141,12 +145,16 @@ impl WaylandDisplay {
         let _ = self.command_tx.send(Command::InputDevice(path.into()));
     }
 
-    pub fn set_video_info(&self, info: VideoInfo) {
+    pub fn set_video_info(&self, info: GstVideoInfo) {
         let _ = self.command_tx.send(Command::VideoInfo(info));
     }
 
     pub fn keyboard_input(&self, key: u32, pressed: bool) {
-        let state = if pressed { KeyState::Pressed } else { KeyState::Released };
+        let state = if pressed {
+            KeyState::Pressed
+        } else {
+            KeyState::Released
+        };
         let _ = self.command_tx.send(Command::KeyboardInput(key, state));
     }
 
@@ -155,11 +163,17 @@ impl WaylandDisplay {
     }
 
     pub fn pointer_motion_absolute(&self, x: f64, y: f64) {
-        let _ = self.command_tx.send(Command::PointerMotionAbsolute((x, y).into()));
+        let _ = self
+            .command_tx
+            .send(Command::PointerMotionAbsolute((x, y).into()));
     }
 
     pub fn pointer_button(&self, button: u32, pressed: bool) {
-        let state = if pressed { ButtonState::Pressed } else { ButtonState::Released };
+        let state = if pressed {
+            ButtonState::Pressed
+        } else {
+            ButtonState::Released
+        };
         let _ = self.command_tx.send(Command::PointerButton(button, state));
     }
 
@@ -169,7 +183,10 @@ impl WaylandDisplay {
 
     pub fn frame(&self) -> Result<gst::Buffer, gst::FlowError> {
         let (buffer_tx, buffer_rx) = mpsc::sync_channel(0);
-        if let Err(err) = self.command_tx.send(Command::Buffer(buffer_tx, self.tracer.clone())) {
+        if let Err(err) = self
+            .command_tx
+            .send(Command::Buffer(buffer_tx, self.tracer.clone()))
+        {
             tracing::warn!(?err, "Failed to send buffer command.");
             return Err(gst::FlowError::Eos);
         }

--- a/wayland-display-core/src/lib.rs
+++ b/wayland-display-core/src/lib.rs
@@ -31,7 +31,7 @@ pub(crate) enum Command {
     PointerMotionAbsolute(Point<f64, Logical>),
     PointerButton(u32, ButtonState),
     PointerAxis(f64, f64),
-    GetSupportedDmaFormats(SyncSender<Option<FormatSet>>),
+    GetSupportedDmaFormats(SyncSender<FormatSet>),
     Quit,
 }
 
@@ -208,7 +208,7 @@ impl WaylandDisplay {
         }
     }
 
-    pub fn get_supported_dma_formats(&self) -> Option<FormatSet> {
+    pub fn get_supported_dma_formats(&self) -> FormatSet {
         let (buffer_tx, buffer_rx) = mpsc::sync_channel(0);
         let _ = self
             .command_tx

--- a/wayland-display-core/src/utils/allocator/mod.rs
+++ b/wayland-display-core/src/utils/allocator/mod.rs
@@ -47,6 +47,16 @@ pub struct GsDmaBuf {
     gst_allocator: DmaBufAllocator,
 }
 
+pub fn new_gbm_device(render_node: DrmNode) -> Option<GbmDevice<DeviceFd>> {
+    let file = File::options()
+        .read(true)
+        .write(true)
+        .open(render_node.dev_path()?.as_path())
+        .ok()?;
+    let fd = DeviceFd::from(Into::<OwnedFd>::into(file));
+    GbmDevice::new(fd).ok()
+}
+
 impl GsDmaBuf {
     pub fn new(render_node: DrmNode, video_info: VideoInfoDmaDrm) -> Option<Self> {
         tracing::debug!("Creating DMA buffer from {:?}", video_info);
@@ -58,13 +68,7 @@ impl GsDmaBuf {
             drm_modifier
         );
 
-        let file = File::options()
-            .read(true)
-            .write(true)
-            .open(render_node.dev_path().unwrap().as_path())
-            .expect("Failed to open device node");
-        let fd = DeviceFd::from(Into::<OwnedFd>::into(file));
-        let gbm = GbmDevice::new(fd).expect("Failed to create GBM device");
+        let gbm = new_gbm_device(render_node)?;
         let allocator = GbmAllocator::new(gbm, GbmBufferFlags::RENDERING);
         let mut dma_allocator = DmabufAllocator(allocator);
 
@@ -171,36 +175,45 @@ impl GsBuffer<GlesRenderer> for GsBufferType {
 
 pub fn gst_video_format_to_drm_fourcc(format: VideoInfoDmaDrm) -> Option<DrmFourcc> {
     // VideoFormat::from_fourcc() returns format unknown for some reason, so we manually parse the caps
-    let caps = format.to_caps().unwrap();
-    let drm_format_str = caps.structure(0)?.get::<&str>("drm-format");
-    if drm_format_str.is_err() {
-        tracing::warn!("Failed to get DRM format from caps {:?}", caps);
-        return None;
-    }
-    let gst_format = drm_format_str.unwrap().split(":").next().unwrap();
+    let fourcc = DrmFourcc::try_from(format.fourcc());
+    match fourcc {
+        Ok(fourcc) => Some(fourcc),
+        Err(error) => {
+            tracing::warn!(
+                "Failed to convert fourcc ({:?}): {:?}",
+                format.fourcc(),
+                error
+            );
+            let caps = format.to_caps().unwrap();
+            let drm_format_str = caps.structure(0)?.get::<&str>("drm-format");
+            if drm_format_str.is_err() {
+                tracing::warn!("Failed to get DRM format from caps {:?}", caps);
+                return None;
+            }
+            let gst_format = drm_format_str.unwrap().split(":").next().unwrap();
 
-    let format = match gst_format.to_lowercase().as_str() {
-        "abgr" => DrmFourcc::Rgba8888,
-        "argb" => DrmFourcc::Bgra8888,
-        "bgra" => DrmFourcc::Argb8888,
-        "bgrx" => DrmFourcc::Xrgb8888,
-        "rgba" => DrmFourcc::Abgr8888,
-        "rgbx" => DrmFourcc::Xbgr8888,
-        "xbgr" => DrmFourcc::Rgbx8888,
-        "xrgb" => DrmFourcc::Bgrx8888,
-        _ => {
-            tracing::warn!("Unsupported video format: {:?}", gst_format);
-            return None;
+            let format = match gst_format.to_lowercase().as_str() {
+                "abgr" => DrmFourcc::Rgba8888,
+                "argb" => DrmFourcc::Bgra8888,
+                "bgra" => DrmFourcc::Argb8888,
+                "bgrx" => DrmFourcc::Xrgb8888,
+                "rgba" => DrmFourcc::Abgr8888,
+                "rgbx" => DrmFourcc::Xbgr8888,
+                "xbgr" => DrmFourcc::Rgbx8888,
+                "xrgb" => DrmFourcc::Bgrx8888,
+                _ => {
+                    tracing::warn!("Unsupported video format: {:?}", gst_format);
+                    return None;
+                }
+            };
+            Some(format)
         }
-    };
-    Some(format)
+    }
 }
 
 pub fn gst_video_format_to_drm_modifier(format: VideoInfoDmaDrm) -> Option<DrmModifier> {
     let full_modifier = format.modifier();
-    // Here we want to drop the first 4 bits which are the vendor
-    let modifier = full_modifier & 0xCFFFFFFFFFFFFFFF;
-    match Modifier::try_from(modifier) {
+    match Modifier::try_from(full_modifier) {
         Ok(modifier) => Some(modifier),
         Err(error) => {
             tracing::warn!(
@@ -380,7 +393,7 @@ mod tests {
         let caps = gst_video::VideoCapsBuilder::new()
             .features([gstreamer_allocators::CAPS_FEATURE_MEMORY_DMABUF])
             .format(gst_video::VideoFormat::DmaDrm)
-            .field("drm-format", "BGRA:0x01100000000000001")
+            .field("drm-format", "AB24:0x0300000000606010")
             .height(10)
             .width(10)
             .pixel_aspect_ratio(1.into())
@@ -391,13 +404,13 @@ mod tests {
             VideoInfoDmaDrm::from_caps(&caps).expect("Failed to create video info");
 
         assert_eq!(
-            gst_video_format_to_drm_fourcc(drm_video_info.clone()),
-            Some(DrmFourcc::Argb8888)
+            gst_video_format_to_drm_fourcc(drm_video_info.clone()).unwrap(),
+            DrmFourcc::try_from(875708993).unwrap()
         );
 
         assert_eq!(
-            gst_video_format_to_drm_modifier(drm_video_info.clone()),
-            Some(Modifier::I915_x_tiled)
+            gst_video_format_to_drm_modifier(drm_video_info.clone()).unwrap(),
+            Modifier::Unrecognized(0x0300000000606010)
         )
     }
 }

--- a/wayland-display-core/src/utils/allocator/mod.rs
+++ b/wayland-display-core/src/utils/allocator/mod.rs
@@ -1,3 +1,4 @@
+use crate::DrmModifier;
 use gst::Buffer as GstBuffer;
 use gst_video::{VideoInfo, VideoInfoDmaDrm};
 use gstreamer_allocators::{DmaBufAllocator, FdMemoryFlags};
@@ -49,8 +50,13 @@ pub struct GsDmaBuf {
 impl GsDmaBuf {
     pub fn new(render_node: DrmNode, video_info: VideoInfoDmaDrm) -> Option<Self> {
         tracing::debug!("Creating DMA buffer from {:?}", video_info);
-        let drm_fourcc = Fourcc::try_from(video_info.fourcc()).ok()?;
-        let drm_modifier = Modifier::try_from(video_info.modifier()).unwrap_or(Modifier::Linear);
+        let drm_fourcc = gst_video_format_to_drm_fourcc(video_info.clone())?;
+        let drm_modifier = gst_video_format_to_drm_modifier(video_info.clone())?;
+        tracing::info!(
+            "Creating DMA buffer - DrmFourcc: {:?}, Modifier: {:?}",
+            drm_fourcc,
+            drm_modifier
+        );
 
         let file = File::options()
             .read(true)
@@ -163,20 +169,57 @@ impl GsBuffer<GlesRenderer> for GsBufferType {
     }
 }
 
+pub fn gst_video_format_to_drm_fourcc(format: VideoInfoDmaDrm) -> Option<DrmFourcc> {
+    // VideoFormat::from_fourcc() returns format unknown for some reason, so we manually parse the caps
+    let caps = format.to_caps().unwrap();
+    let drm_format_str = caps.structure(0)?.get::<&str>("drm-format");
+    if drm_format_str.is_err() {
+        tracing::warn!("Failed to get DRM format from caps {:?}", caps);
+        return None;
+    }
+    let gst_format = drm_format_str.unwrap().split(":").next().unwrap();
+
+    let format = match gst_format.to_lowercase().as_str() {
+        "abgr" => DrmFourcc::Rgba8888,
+        "argb" => DrmFourcc::Bgra8888,
+        "bgra" => DrmFourcc::Argb8888,
+        "bgrx" => DrmFourcc::Xrgb8888,
+        "rgba" => DrmFourcc::Abgr8888,
+        "rgbx" => DrmFourcc::Xbgr8888,
+        "xbgr" => DrmFourcc::Rgbx8888,
+        "xrgb" => DrmFourcc::Bgrx8888,
+        _ => {
+            tracing::warn!("Unsupported video format: {:?}", gst_format);
+            return None;
+        }
+    };
+    Some(format)
+}
+
+pub fn gst_video_format_to_drm_modifier(format: VideoInfoDmaDrm) -> Option<DrmModifier> {
+    let full_modifier = format.modifier();
+    // Here we want to drop the first 4 bits which are the vendor
+    let modifier = full_modifier & 0xCFFFFFFFFFFFFFFF;
+    match Modifier::try_from(modifier) {
+        Ok(modifier) => Some(modifier),
+        Err(error) => {
+            tracing::warn!(
+                "Failed to convert modifier ({:?}): {:?}",
+                full_modifier,
+                error
+            );
+            None
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::utils::renderer::setup_renderer;
+    use crate::utils::tests::test_init;
     use smithay::backend::renderer::Frame;
     use smithay::utils::Transform;
-    use std::sync::Once;
-    static INIT: Once = Once::new();
-    pub fn setup() -> () {
-        INIT.call_once(|| {
-            tracing_subscriber::fmt::try_init().ok();
-            gst::init().expect("Failed to initialize GStreamer");
-        });
-    }
 
     // Adapted from: https://github.com/games-on-whales/smithay/blob/ef9782b8548c6e876bc61052e4e09351e4071a35/examples/buffer_test.rs#L326-L351
     fn render_into<R>(renderer: &mut R, w: i32, h: i32)
@@ -219,7 +262,7 @@ mod tests {
 
     #[test]
     fn test_gsglesbuffer() {
-        setup();
+        test_init();
 
         let mut renderer = setup_renderer(None);
         let video_info = VideoInfo::builder(gst_video::VideoFormat::Rgba, 10, 10)
@@ -265,18 +308,31 @@ mod tests {
 
     #[test]
     fn test_dmabuf() {
-        setup();
+        test_init();
 
         let render_node =
             DrmNode::from_path("/dev/dri/renderD128").expect("Failed to create render node");
         let mut renderer = setup_renderer(Some(render_node));
-        let video_info = VideoInfo::builder(gst_video::VideoFormat::DmaDrm, 10, 10)
-            .build()
-            .unwrap();
-        let drm_video_info = VideoInfoDmaDrm::new(
-            video_info.clone(),
-            Fourcc::Abgr8888 as u32,
-            Modifier::Linear.into(),
+        let caps = gst_video::VideoCapsBuilder::new()
+            .features([gstreamer_allocators::CAPS_FEATURE_MEMORY_DMABUF])
+            .format(gst_video::VideoFormat::DmaDrm)
+            .field("drm-format", "RGBA")
+            .height(10)
+            .width(10)
+            .pixel_aspect_ratio(1.into())
+            .framerate(gst::Fraction::new(30, 1))
+            .build();
+        assert!(caps.is_fixed()); // Required to pass gst_video_is_dma_drm_caps()
+        let drm_video_info =
+            VideoInfoDmaDrm::from_caps(&caps).expect("Failed to create video info");
+
+        assert_eq!(
+            gst_video_format_to_drm_fourcc(drm_video_info.clone()),
+            Some(DrmFourcc::Abgr8888)
+        );
+        assert_eq!(
+            gst_video_format_to_drm_modifier(drm_video_info.clone()),
+            Some(Modifier::Linear)
         );
 
         let raw_buffer = GsDmaBuf::new(render_node, drm_video_info.clone());
@@ -314,6 +370,34 @@ mod tests {
                 .repeat(5)
             ]
             .concat()
+        )
+    }
+
+    #[test]
+    fn test_gst_video_format_conversions() {
+        test_init();
+
+        let caps = gst_video::VideoCapsBuilder::new()
+            .features([gstreamer_allocators::CAPS_FEATURE_MEMORY_DMABUF])
+            .format(gst_video::VideoFormat::DmaDrm)
+            .field("drm-format", "BGRA:0x01100000000000001")
+            .height(10)
+            .width(10)
+            .pixel_aspect_ratio(1.into())
+            .framerate(gst::Fraction::new(30, 1))
+            .build();
+        assert!(caps.is_fixed()); // Required to pass gst_video_is_dma_drm_caps()
+        let drm_video_info =
+            VideoInfoDmaDrm::from_caps(&caps).expect("Failed to create video info");
+
+        assert_eq!(
+            gst_video_format_to_drm_fourcc(drm_video_info.clone()),
+            Some(DrmFourcc::Argb8888)
+        );
+
+        assert_eq!(
+            gst_video_format_to_drm_modifier(drm_video_info.clone()),
+            Some(Modifier::I915_x_tiled)
         )
     }
 }

--- a/wayland-display-core/src/utils/allocator/mod.rs
+++ b/wayland-display-core/src/utils/allocator/mod.rs
@@ -5,11 +5,11 @@ use smithay::backend::allocator::dmabuf::{Dmabuf, DmabufAllocator};
 use smithay::backend::allocator::gbm::{GbmAllocator, GbmBufferFlags, GbmDevice};
 use smithay::backend::allocator::{Allocator, Fourcc};
 use smithay::backend::drm::DrmNode;
-use smithay::backend::renderer::gles::{GlesRenderbuffer, GlesRenderer, GlesTexture};
-use smithay::backend::renderer::{Bind, ExportMem, Frame, ImportDma, Offscreen, Renderer};
+use smithay::backend::renderer::gles::{GlesRenderbuffer, GlesRenderer};
+use smithay::backend::renderer::{Bind, ExportMem, Offscreen, Renderer};
 use smithay::reexports::drm::buffer::DrmFourcc;
 use smithay::reexports::gbm::Modifier;
-use smithay::utils::{DeviceFd, Rectangle, Transform};
+use smithay::utils::{DeviceFd, Rectangle};
 use std::fs::File;
 use std::os::fd::{AsRawFd, OwnedFd};
 
@@ -44,7 +44,6 @@ pub struct GsDmaBuf {
     buffer: Dmabuf,
     format: DrmFourcc,
     video_info: VideoInfo,
-    gles_texture: Option<GlesTexture>,
 }
 
 impl GsDmaBuf {
@@ -72,8 +71,7 @@ impl GsDmaBuf {
             Ok(buffer) => Some(GsDmaBuf {
                 buffer,
                 format,
-                video_info,
-                gles_texture: None,
+                video_info
             }),
             Err(_) => None,
         }
@@ -98,21 +96,8 @@ impl GsBuffer<GlesRenderer> for GsBufferType {
         renderer: &mut GlesRenderer,
     ) -> Result<(), <GlesRenderer as Renderer>::Error> {
         match self {
-            GsBufferType::RAW(buffer) => renderer.bind(buffer.buffer.clone()),
-            GsBufferType::DMA(buffer) => {
-                let texture = renderer.import_dmabuf(&buffer.buffer, None)?;
-                buffer.gles_texture = Some(texture);
-                let size = (
-                    buffer.video_info.width() as i32,
-                    buffer.video_info.height() as i32,
-                );
-                let offscreen = Offscreen::<GlesRenderbuffer>::create_buffer(
-                    renderer,
-                    buffer.format,
-                    size.into(),
-                )?;
-                renderer.bind(offscreen)
-            }
+            GsBufferType::RAW(buffer) => renderer.bind(buffer.clone().buffer),
+            GsBufferType::DMA(buffer) => renderer.bind(buffer.clone().buffer),
         }
     }
 
@@ -157,26 +142,6 @@ impl GsBuffer<GlesRenderer> for GsBufferType {
                     buffer.video_info.width() as i32,
                     buffer.video_info.height() as i32,
                 );
-                let mut frame = renderer
-                    .render(size.into(), Transform::Normal)
-                    .expect("Failed to create frame");
-                frame
-                    .render_texture_at(
-                        buffer.gles_texture.as_ref().unwrap(),
-                        (0, 0).into(),
-                        1,
-                        1.,
-                        Transform::Normal,
-                        &[Rectangle::from_loc_and_size((0, 0), size)],
-                        &[],
-                        1.0,
-                    )
-                    .expect("Failed to render texture");
-                frame
-                    .finish()
-                    .expect("Failed to finish frame")
-                    .wait()
-                    .expect("Synchronization error");
 
                 let mut gst_buffer = gst::Buffer::new();
                 {
@@ -206,6 +171,8 @@ mod tests {
     use super::*;
     use crate::utils::renderer::setup_renderer;
     use std::sync::Once;
+    use smithay::backend::renderer::Frame;
+    use smithay::utils::{Transform};
 
     fn render_into<R>(renderer: &mut R, w: i32, h: i32)
     where
@@ -312,21 +279,19 @@ mod tests {
         let raw_buffer = GsDmaBuf::new(render_node, video_info.clone());
         assert!(raw_buffer.is_some());
 
-        let mut buffer = GsBufferType::DMA(raw_buffer.unwrap());
+        let mut buffer = GsBufferType::DMA(raw_buffer.clone().unwrap());
         let bind_result = buffer.bind(&mut renderer);
         assert!(bind_result.is_ok());
 
         render_into(&mut renderer, 10, 10);
-        let mut gst_buffer = buffer.to_gs_buffer(&mut renderer);
-        assert!(gst_buffer.is_writable());
-        // TODO: fails with: fatal runtime error: IO Safety violation: owned file descriptor already closed
-        // Check buffer content
-        let vframe = gst_video::VideoFrameRef::from_buffer_ref_writable(
-            gst_buffer.get_mut().unwrap(),
-            &video_info,
-        )
-        .unwrap();
-        let plane_data = vframe.plane_data(0).unwrap();
+        // TODO: Output to Gstreamer
+        //       let mut gst_buffer = buffer.to_gs_buffer(&mut renderer);
+
+        let mapping = renderer
+            .copy_framebuffer(Rectangle::from_loc_and_size((0, 0), (10, 10)), Fourcc::Abgr8888)
+            .expect("Failed to map framebuffer");
+        let plane_data = renderer.map_texture(&mapping).expect("Failed to read mapping");
+
         assert_eq!(plane_data.len(), 10 * 10 * 4); // 10x10 pixels, 4 bytes per pixel (RGBA)
         assert_eq!(
             plane_data,

--- a/wayland-display-core/src/utils/allocator/mod.rs
+++ b/wayland-display-core/src/utils/allocator/mod.rs
@@ -48,6 +48,7 @@ pub struct GsDmaBuf {
 
 impl GsDmaBuf {
     pub fn new(render_node: DrmNode, video_info: VideoInfoDmaDrm) -> Option<Self> {
+        tracing::debug!("Creating DMA buffer from {:?}", video_info);
         let drm_fourcc = Fourcc::try_from(video_info.fourcc()).ok()?;
         let drm_modifier = Modifier::try_from(video_info.modifier()).unwrap_or(Modifier::Linear);
 
@@ -152,6 +153,9 @@ impl GsBuffer<GlesRenderer> for GsBufferType {
                         };
                         gst_buffer.append_memory(memory);
                     });
+                    // TODO: There may be some extra information about the pitch, stride and plane
+                    //       offset when we export the surface, we also need to translate them into
+                    //       GstVideoMeta and attached it to the GstBuffer
                 }
                 gst_buffer
             }

--- a/wayland-display-core/src/utils/allocator/mod.rs
+++ b/wayland-display-core/src/utils/allocator/mod.rs
@@ -3,15 +3,16 @@ use gst_video::{VideoInfo, VideoInfoDmaDrm};
 use gstreamer_allocators::{DmaBufAllocator, FdMemoryFlags};
 use smithay::backend::allocator::dmabuf::{Dmabuf, DmabufAllocator};
 use smithay::backend::allocator::gbm::{GbmAllocator, GbmBufferFlags, GbmDevice};
-use smithay::backend::allocator::{Allocator, Buffer, Fourcc};
+use smithay::backend::allocator::{Allocator, Fourcc};
 use smithay::backend::drm::DrmNode;
 use smithay::backend::renderer::gles::{GlesRenderbuffer, GlesRenderer};
 use smithay::backend::renderer::{Bind, ExportMem, Offscreen, Renderer};
 use smithay::reexports::drm::buffer::DrmFourcc;
 use smithay::reexports::gbm::Modifier;
+use smithay::reexports::rustix::fs::{seek, SeekFrom};
 use smithay::utils::{DeviceFd, Rectangle};
 use std::fs::File;
-use std::os::fd::{AsRawFd, OwnedFd};
+use std::os::fd::{AsFd, AsRawFd, OwnedFd};
 
 #[derive(Debug, Clone)]
 pub struct GsGlesbuffer {
@@ -42,7 +43,6 @@ impl GsGlesbuffer {
 #[derive(Debug, Clone)]
 pub struct GsDmaBuf {
     buffer: Dmabuf,
-    video_info: VideoInfoDmaDrm,
     gst_allocator: DmaBufAllocator,
 }
 
@@ -71,7 +71,6 @@ impl GsDmaBuf {
         match result {
             Ok(buffer) => Some(GsDmaBuf {
                 buffer,
-                video_info,
                 gst_allocator: DmaBufAllocator::new(),
             }),
             Err(_) => None,
@@ -138,13 +137,13 @@ impl GsBuffer<GlesRenderer> for GsBufferType {
                 gst_buffer
             }
             GsBufferType::DMA(buffer) => {
-                // Adapted from: https://github.com/games-on-whales/smithay/blob/ef9782b8548c6e876bc61052e4e09351e4071a35/examples/buffer_test.rs#L326-L351
                 let mut gst_buffer = GstBuffer::new();
                 {
                     let gst_buffer = gst_buffer.get_mut().unwrap();
                     buffer.buffer.handles().for_each(|handle| {
                         let fd = handle.as_raw_fd();
-                        let size = buffer.buffer.size().h * buffer.buffer.size().w * 4;
+                        let size = seek(&handle.as_fd(), SeekFrom::End(0)).unwrap();
+                        let _ = seek(&handle.as_fd(), SeekFrom::Start(0)); // Reset seek point
                         let memory = unsafe {
                             buffer
                                 .gst_allocator
@@ -167,7 +166,15 @@ mod tests {
     use smithay::backend::renderer::Frame;
     use smithay::utils::Transform;
     use std::sync::Once;
+    static INIT: Once = Once::new();
+    pub fn setup() -> () {
+        INIT.call_once(|| {
+            tracing_subscriber::fmt::try_init().ok();
+            gst::init().expect("Failed to initialize GStreamer");
+        });
+    }
 
+    // Adapted from: https://github.com/games-on-whales/smithay/blob/ef9782b8548c6e876bc61052e4e09351e4071a35/examples/buffer_test.rs#L326-L351
     fn render_into<R>(renderer: &mut R, w: i32, h: i32)
     where
         R: Renderer,
@@ -206,15 +213,6 @@ mod tests {
             .expect("Synchronization error");
     }
 
-    static INIT: Once = Once::new();
-
-    pub fn setup() -> () {
-        INIT.call_once(|| {
-            tracing_subscriber::fmt::try_init().ok();
-            gst::init().expect("Failed to initialize GStreamer");
-        });
-    }
-
     #[test]
     fn test_gsglesbuffer() {
         setup();
@@ -234,7 +232,7 @@ mod tests {
         render_into(&mut renderer, 10, 10);
         let gst_buffer = buffer.to_gs_buffer(&mut renderer);
         assert!(gst_buffer.is_writable());
-        assert!(gst_buffer.size() == video_info.size());
+        assert_eq!(gst_buffer.size(), video_info.size());
 
         let read_buf = gst_buffer
             .into_mapped_buffer_readable()
@@ -286,17 +284,17 @@ mod tests {
 
         render_into(&mut renderer, 10, 10);
         let gst_buffer = buffer.to_gs_buffer(&mut renderer);
-        assert!(gst_buffer.size() == 10 * 10 * 4);
-        // TODO: get buffer content
+        let gst_buffer_size = gst_buffer.size();
+        assert_eq!(gst_buffer_size, 65536); // There's going to be a lot of padding
 
         let read_buf = gst_buffer
             .into_mapped_buffer_readable()
             .expect("Failed to map buffer");
         let plane_data = read_buf.as_slice();
 
-        assert_eq!(plane_data.len(), 10 * 10 * 4); // 10x10 pixels, 4 bytes per pixel (RGBA)
+        assert_eq!(plane_data.len(), gst_buffer_size);
         assert_eq!(
-            plane_data,
+            plane_data[0..10 * 10 * 4],
             [
                 [
                     // R, G, B, A

--- a/wayland-display-core/src/utils/allocator/mod.rs
+++ b/wayland-display-core/src/utils/allocator/mod.rs
@@ -1,0 +1,45 @@
+use smithay::backend::allocator::Fourcc;
+use smithay::backend::renderer::gles::{GlesRenderbuffer, GlesRenderer};
+use smithay::backend::renderer::Offscreen;
+
+#[derive(Debug, Default, Clone)]
+pub struct GLESAllocator {
+    buffer: Option<GlesRenderbuffer>,
+}
+
+#[derive(Debug, Clone)]
+pub enum AllocatorType {
+    GLES(GLESAllocator),
+}
+
+pub trait Allocator<Renderer, Target> {
+    fn alloc_buffer(&mut self, renderer: &mut Renderer, format: Fourcc, width: i32, height: i32);
+
+    fn get_buffer(&self) -> Option<Target>;
+}
+
+impl Allocator<GlesRenderer, GlesRenderbuffer> for AllocatorType {
+    fn alloc_buffer(
+        &mut self,
+        renderer: &mut GlesRenderer,
+        format: Fourcc,
+        width: i32,
+        height: i32,
+    ) {
+        match self {
+            AllocatorType::GLES(allocator) => {
+                let result = renderer.create_buffer(format, (width, height).into());
+                match result {
+                    Ok(buffer) => allocator.buffer = Some(buffer),
+                    Err(_) => allocator.buffer = None,
+                }
+            }
+        }
+    }
+
+    fn get_buffer(&self) -> Option<GlesRenderbuffer> {
+        match self {
+            AllocatorType::GLES(allocator) => allocator.buffer.clone(),
+        }
+    }
+}

--- a/wayland-display-core/src/utils/allocator/mod.rs
+++ b/wayland-display-core/src/utils/allocator/mod.rs
@@ -1,10 +1,10 @@
 use crate::DrmModifier;
 use gst::Buffer as GstBuffer;
-use gst_video::{VideoInfo, VideoInfoDmaDrm};
+use gst_video::{VideoFormat, VideoInfo, VideoInfoDmaDrm, VideoMeta};
 use gstreamer_allocators::{DmaBufAllocator, FdMemoryFlags};
 use smithay::backend::allocator::dmabuf::{Dmabuf, DmabufAllocator};
 use smithay::backend::allocator::gbm::{GbmAllocator, GbmBufferFlags, GbmDevice};
-use smithay::backend::allocator::{Allocator, Fourcc};
+use smithay::backend::allocator::{Allocator, Buffer, Fourcc};
 use smithay::backend::drm::DrmNode;
 use smithay::backend::renderer::gles::{GlesRenderbuffer, GlesRenderer};
 use smithay::backend::renderer::{Bind, ExportMem, Offscreen, Renderer};
@@ -44,6 +44,7 @@ impl GsGlesbuffer {
 #[derive(Debug, Clone)]
 pub struct GsDmaBuf {
     buffer: Dmabuf,
+    video_info: VideoInfoDmaDrm,
     gst_allocator: DmaBufAllocator,
 }
 
@@ -82,6 +83,7 @@ impl GsDmaBuf {
         match result {
             Ok(buffer) => Some(GsDmaBuf {
                 buffer,
+                video_info,
                 gst_allocator: DmaBufAllocator::new(),
             }),
             Err(_) => None,
@@ -163,9 +165,43 @@ impl GsBuffer<GlesRenderer> for GsBufferType {
                         };
                         gst_buffer.append_memory(memory);
                     });
-                    // TODO: There may be some extra information about the pitch, stride and plane
-                    //       offset when we export the surface, we also need to translate them into
-                    //       GstVideoMeta and attached it to the GstBuffer
+
+                    let offsets = buffer
+                        .buffer
+                        .offsets()
+                        .map(|o| o as usize)
+                        .collect::<Vec<_>>();
+
+                    let strides = buffer
+                        .buffer
+                        .strides()
+                        .map(|s| s as i32)
+                        .collect::<Vec<_>>();
+
+                    let video_format =
+                        match VideoFormat::from_fourcc(buffer.buffer.format().code as u32) {
+                            // TODO: this seems to always fail
+                            VideoFormat::Unknown => {
+                                tracing::debug!(
+                                    "Failed to convert fourcc to video format: {:?}",
+                                    buffer.buffer.format().code
+                                );
+                                VideoFormat::Bgrx // TODO: Use a more appropriate fallback, can't pass DmaDRM format
+                            }
+                            format => format,
+                        };
+                    let meta_result = VideoMeta::add_full(
+                        gst_buffer,
+                        gst_video::VideoFrameFlags::empty(),
+                        video_format,
+                        buffer.video_info.width(),
+                        buffer.video_info.height(),
+                        &offsets,
+                        &strides,
+                    );
+                    if let Err(error) = meta_result {
+                        tracing::warn!("Failed to add video meta: {:?}", error);
+                    }
                 }
                 gst_buffer
             }
@@ -361,6 +397,7 @@ mod tests {
         assert_eq!(gst_buffer_size, 65536); // There's going to be a lot of padding
 
         let read_buf = gst_buffer
+            .clone()
             .into_mapped_buffer_readable()
             .expect("Failed to map buffer");
         let plane_data = read_buf.as_slice();
@@ -383,7 +420,16 @@ mod tests {
                 .repeat(5)
             ]
             .concat()
-        )
+        );
+
+        let buf_meta = gst_buffer
+            .meta::<VideoMeta>()
+            .expect("Failed to get buffer meta");
+        assert_eq!(buf_meta.width(), 10);
+        assert_eq!(buf_meta.height(), 10);
+        assert_eq!(buf_meta.n_planes(), 1);
+        assert_eq!(buf_meta.stride(), vec![40]);
+        assert_eq!(buf_meta.offset(), vec![0]);
     }
 
     #[test]

--- a/wayland-display-core/src/utils/allocator/mod.rs
+++ b/wayland-display-core/src/utils/allocator/mod.rs
@@ -62,12 +62,22 @@ impl GsDmaBuf {
     pub fn new(render_node: DrmNode, video_info: VideoInfoDmaDrm) -> Option<Self> {
         tracing::debug!("Creating DMA buffer from {:?}", video_info);
         let drm_fourcc = gst_video_format_to_drm_fourcc(video_info.clone())?;
-        let drm_modifier = gst_video_format_to_drm_modifier(video_info.clone())?;
+        let mut drm_modifier = gst_video_format_to_drm_modifier(video_info.clone())?;
         tracing::info!(
             "Creating DMA buffer - DrmFourcc: {:?}, Modifier: {:?}",
             drm_fourcc,
             drm_modifier
         );
+
+        // NOTE: This is a workaround for the i915 4-tiled modifiers
+        //       not being advertised by gstreamer elements.
+        // - In this part we check for y-tiled modifiers and
+        //   change them back to 4-tiled modifiers to make them actually work.
+        //   (These modifiers overlap well enough to work interchangeably)
+        // Earlier part in gst-plugin-wayland-display waylandsrc/imp.rs.
+        if drm_modifier == DrmModifier::I915_y_tiled {
+            drm_modifier = DrmModifier::Unrecognized(0x0100000000000009)
+        }
 
         let gbm = new_gbm_device(render_node)?;
         let allocator = GbmAllocator::new(gbm, GbmBufferFlags::RENDERING);

--- a/wayland-display-core/src/utils/allocator/mod.rs
+++ b/wayland-display-core/src/utils/allocator/mod.rs
@@ -200,3 +200,151 @@ impl GsBuffer<GlesRenderer> for GsBufferType {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::utils::renderer::setup_renderer;
+    use std::sync::Once;
+
+    fn render_into<R>(renderer: &mut R, w: i32, h: i32)
+    where
+        R: Renderer,
+    {
+        let mut frame = renderer
+            .render((w, h).into(), Transform::Normal)
+            .expect("Failed to create render frame");
+        frame
+            .clear(
+                [1.0, 0.0, 0.0, 1.0],
+                &[Rectangle::from_loc_and_size((0, 0), (w / 2, h / 2))],
+            )
+            .expect("Render error");
+        frame
+            .clear(
+                [0.0, 1.0, 0.0, 1.0],
+                &[Rectangle::from_loc_and_size((w / 2, 0), (w / 2, h / 2))],
+            )
+            .expect("Render error");
+        frame
+            .clear(
+                [0.0, 0.0, 1.0, 1.0],
+                &[Rectangle::from_loc_and_size((0, h / 2), (w / 2, h / 2))],
+            )
+            .expect("Render error");
+        frame
+            .clear(
+                [1.0, 1.0, 0.0, 1.0],
+                &[Rectangle::from_loc_and_size((w / 2, h / 2), (w / 2, h / 2))],
+            )
+            .expect("Render error");
+        frame
+            .finish()
+            .expect("Failed to finish render frame")
+            .wait()
+            .expect("Synchronization error");
+    }
+
+    static INIT: Once = Once::new();
+
+    pub fn setup() -> () {
+        INIT.call_once(|| {
+            gst::init().expect("Failed to initialize GStreamer");
+        });
+    }
+
+    #[test]
+    fn test_gsglesbuffer() {
+        setup();
+
+        let mut renderer = setup_renderer(None);
+        let video_info = VideoInfo::builder(gst_video::VideoFormat::Rgba, 10, 10)
+            .build()
+            .unwrap();
+
+        let raw_buffer = GsGlesbuffer::new(&mut renderer, video_info.clone());
+        assert!(raw_buffer.is_some());
+
+        let mut buffer = GsBufferType::RAW(raw_buffer.unwrap());
+        let bind_result = buffer.bind(&mut renderer);
+        assert!(bind_result.is_ok());
+
+        render_into(&mut renderer, 10, 10);
+        let mut gst_buffer = buffer.to_gs_buffer(&mut renderer);
+        assert!(gst_buffer.is_writable());
+        // Check buffer content
+        let vframe = gst_video::VideoFrameRef::from_buffer_ref_writable(
+            gst_buffer.get_mut().unwrap(),
+            &video_info,
+        )
+        .unwrap();
+        let plane_data = vframe.plane_data(0).unwrap();
+        assert_eq!(plane_data.len(), 10 * 10 * 4); // 10x10 pixels, 4 bytes per pixel (RGBA)
+        assert_eq!(
+            plane_data,
+            [
+                [
+                    // R, G, B, A
+                    255, 0, 0, 255, 255, 0, 0, 255, 255, 0, 0, 255, 255, 0, 0, 255, 255, 0, 0, 255,
+                    0, 255, 0, 255, 0, 255, 0, 255, 0, 255, 0, 255, 0, 255, 0, 255, 0, 255, 0, 255
+                ]
+                .repeat(5),
+                [
+                    0, 0, 255, 255, 0, 0, 255, 255, 0, 0, 255, 255, 0, 0, 255, 255, 0, 0, 255, 255,
+                    255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255,
+                    255, 0, 255
+                ]
+                .repeat(5)
+            ]
+            .concat()
+        )
+    }
+
+    #[test]
+    fn test_dmabuf() {
+        let render_node =
+            DrmNode::from_path("/dev/dri/card0").expect("Failed to create render node");
+        let mut renderer = setup_renderer(Some(render_node));
+        let video_info = VideoInfo::builder(gst_video::VideoFormat::DmaDrm, 10, 10)
+            .build()
+            .unwrap();
+
+        let raw_buffer = GsDmaBuf::new(render_node, video_info.clone());
+        assert!(raw_buffer.is_some());
+
+        let mut buffer = GsBufferType::DMA(raw_buffer.unwrap());
+        let bind_result = buffer.bind(&mut renderer);
+        assert!(bind_result.is_ok());
+
+        render_into(&mut renderer, 10, 10);
+        let mut gst_buffer = buffer.to_gs_buffer(&mut renderer);
+        assert!(gst_buffer.is_writable());
+        // TODO: fails with: fatal runtime error: IO Safety violation: owned file descriptor already closed
+        // Check buffer content
+        let vframe = gst_video::VideoFrameRef::from_buffer_ref_writable(
+            gst_buffer.get_mut().unwrap(),
+            &video_info,
+        )
+        .unwrap();
+        let plane_data = vframe.plane_data(0).unwrap();
+        assert_eq!(plane_data.len(), 10 * 10 * 4); // 10x10 pixels, 4 bytes per pixel (RGBA)
+        assert_eq!(
+            plane_data,
+            [
+                [
+                    // R, G, B, A
+                    255, 0, 0, 255, 255, 0, 0, 255, 255, 0, 0, 255, 255, 0, 0, 255, 255, 0, 0, 255,
+                    0, 255, 0, 255, 0, 255, 0, 255, 0, 255, 0, 255, 0, 255, 0, 255, 0, 255, 0, 255
+                ]
+                .repeat(5),
+                [
+                    0, 0, 255, 255, 0, 0, 255, 255, 0, 0, 255, 255, 0, 0, 255, 255, 0, 0, 255, 255,
+                    255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255,
+                    255, 0, 255
+                ]
+                .repeat(5)
+            ]
+            .concat()
+        )
+    }
+}

--- a/wayland-display-core/src/utils/allocator/mod.rs
+++ b/wayland-display-core/src/utils/allocator/mod.rs
@@ -1,9 +1,9 @@
-use gst::Buffer;
-use gst_video::VideoInfo;
-use gstreamer_allocators::DmaBufAllocator;
+use gst::Buffer as GstBuffer;
+use gst_video::{VideoInfo, VideoInfoDmaDrm};
+use gstreamer_allocators::{DmaBufAllocator, FdMemoryFlags};
 use smithay::backend::allocator::dmabuf::{Dmabuf, DmabufAllocator};
 use smithay::backend::allocator::gbm::{GbmAllocator, GbmBufferFlags, GbmDevice};
-use smithay::backend::allocator::{Allocator, Fourcc};
+use smithay::backend::allocator::{Allocator, Buffer, Fourcc};
 use smithay::backend::drm::DrmNode;
 use smithay::backend::renderer::gles::{GlesRenderbuffer, GlesRenderer};
 use smithay::backend::renderer::{Bind, ExportMem, Offscreen, Renderer};
@@ -42,13 +42,14 @@ impl GsGlesbuffer {
 #[derive(Debug, Clone)]
 pub struct GsDmaBuf {
     buffer: Dmabuf,
-    format: DrmFourcc,
-    video_info: VideoInfo,
+    video_info: VideoInfoDmaDrm,
+    gst_allocator: DmaBufAllocator,
 }
 
 impl GsDmaBuf {
-    pub fn new(render_node: DrmNode, video_info: VideoInfo) -> Option<Self> {
-        let format = Fourcc::Abgr8888; // TODO: format from drm-format
+    pub fn new(render_node: DrmNode, video_info: VideoInfoDmaDrm) -> Option<Self> {
+        let drm_fourcc = Fourcc::try_from(video_info.fourcc()).ok()?;
+        let drm_modifier = Modifier::try_from(video_info.modifier()).unwrap_or(Modifier::Linear);
 
         let file = File::options()
             .read(true)
@@ -60,18 +61,18 @@ impl GsDmaBuf {
         let allocator = GbmAllocator::new(gbm, GbmBufferFlags::RENDERING);
         let mut dma_allocator = DmabufAllocator(allocator);
 
-        let modifiers = [Modifier::Linear]; // TODO: Support modifiers from video_info
+        let modifiers = [drm_modifier];
         let result = dma_allocator.create_buffer(
             video_info.width(),
             video_info.height(),
-            format,
+            drm_fourcc,
             &modifiers,
         );
         match result {
             Ok(buffer) => Some(GsDmaBuf {
                 buffer,
-                format,
-                video_info
+                video_info,
+                gst_allocator: DmaBufAllocator::new(),
             }),
             Err(_) => None,
         }
@@ -101,7 +102,7 @@ impl GsBuffer<GlesRenderer> for GsBufferType {
         }
     }
 
-    fn to_gs_buffer(&self, renderer: &mut GlesRenderer) -> Buffer {
+    fn to_gs_buffer(&self, renderer: &mut GlesRenderer) -> GstBuffer {
         match self {
             GsBufferType::RAW(buffer) => {
                 let mapping = renderer
@@ -138,23 +139,16 @@ impl GsBuffer<GlesRenderer> for GsBufferType {
             }
             GsBufferType::DMA(buffer) => {
                 // Adapted from: https://github.com/games-on-whales/smithay/blob/ef9782b8548c6e876bc61052e4e09351e4071a35/examples/buffer_test.rs#L326-L351
-                let size = (
-                    buffer.video_info.width() as i32,
-                    buffer.video_info.height() as i32,
-                );
-
-                let mut gst_buffer = gst::Buffer::new();
+                let mut gst_buffer = GstBuffer::new();
                 {
-                    // TODO: is this right?
                     let gst_buffer = gst_buffer.get_mut().unwrap();
-
-                    let allocator = DmaBufAllocator::new();
                     buffer.buffer.handles().for_each(|handle| {
                         let fd = handle.as_raw_fd();
-                        // TODO: should we leak the handle here somehow?
+                        let size = buffer.buffer.size().h * buffer.buffer.size().w * 4;
                         let memory = unsafe {
-                            allocator
-                                .alloc(fd, (size.0 * size.1) as usize)
+                            buffer
+                                .gst_allocator
+                                .alloc_with_flags(fd, size as usize, FdMemoryFlags::DONT_CLOSE)
                                 .expect("Failed to allocate memory")
                         };
                         gst_buffer.append_memory(memory);
@@ -170,9 +164,9 @@ impl GsBuffer<GlesRenderer> for GsBufferType {
 mod tests {
     use super::*;
     use crate::utils::renderer::setup_renderer;
-    use std::sync::Once;
     use smithay::backend::renderer::Frame;
-    use smithay::utils::{Transform};
+    use smithay::utils::Transform;
+    use std::sync::Once;
 
     fn render_into<R>(renderer: &mut R, w: i32, h: i32)
     where
@@ -216,6 +210,7 @@ mod tests {
 
     pub fn setup() -> () {
         INIT.call_once(|| {
+            tracing_subscriber::fmt::try_init().ok();
             gst::init().expect("Failed to initialize GStreamer");
         });
     }
@@ -237,15 +232,14 @@ mod tests {
         assert!(bind_result.is_ok());
 
         render_into(&mut renderer, 10, 10);
-        let mut gst_buffer = buffer.to_gs_buffer(&mut renderer);
+        let gst_buffer = buffer.to_gs_buffer(&mut renderer);
         assert!(gst_buffer.is_writable());
-        // Check buffer content
-        let vframe = gst_video::VideoFrameRef::from_buffer_ref_writable(
-            gst_buffer.get_mut().unwrap(),
-            &video_info,
-        )
-        .unwrap();
-        let plane_data = vframe.plane_data(0).unwrap();
+        assert!(gst_buffer.size() == video_info.size());
+
+        let read_buf = gst_buffer
+            .into_mapped_buffer_readable()
+            .expect("Failed to map buffer");
+        let plane_data = read_buf.as_slice();
         assert_eq!(plane_data.len(), 10 * 10 * 4); // 10x10 pixels, 4 bytes per pixel (RGBA)
         assert_eq!(
             plane_data,
@@ -269,14 +263,21 @@ mod tests {
 
     #[test]
     fn test_dmabuf() {
+        setup();
+
         let render_node =
-            DrmNode::from_path("/dev/dri/card0").expect("Failed to create render node");
+            DrmNode::from_path("/dev/dri/renderD128").expect("Failed to create render node");
         let mut renderer = setup_renderer(Some(render_node));
         let video_info = VideoInfo::builder(gst_video::VideoFormat::DmaDrm, 10, 10)
             .build()
             .unwrap();
+        let drm_video_info = VideoInfoDmaDrm::new(
+            video_info.clone(),
+            Fourcc::Abgr8888 as u32,
+            Modifier::Linear.into(),
+        );
 
-        let raw_buffer = GsDmaBuf::new(render_node, video_info.clone());
+        let raw_buffer = GsDmaBuf::new(render_node, drm_video_info.clone());
         assert!(raw_buffer.is_some());
 
         let mut buffer = GsBufferType::DMA(raw_buffer.clone().unwrap());
@@ -284,13 +285,14 @@ mod tests {
         assert!(bind_result.is_ok());
 
         render_into(&mut renderer, 10, 10);
-        // TODO: Output to Gstreamer
-        //       let mut gst_buffer = buffer.to_gs_buffer(&mut renderer);
+        let gst_buffer = buffer.to_gs_buffer(&mut renderer);
+        assert!(gst_buffer.size() == 10 * 10 * 4);
+        // TODO: get buffer content
 
-        let mapping = renderer
-            .copy_framebuffer(Rectangle::from_loc_and_size((0, 0), (10, 10)), Fourcc::Abgr8888)
-            .expect("Failed to map framebuffer");
-        let plane_data = renderer.map_texture(&mapping).expect("Failed to read mapping");
+        let read_buf = gst_buffer
+            .into_mapped_buffer_readable()
+            .expect("Failed to map buffer");
+        let plane_data = read_buf.as_slice();
 
         assert_eq!(plane_data.len(), 10 * 10 * 4); // 10x10 pixels, 4 bytes per pixel (RGBA)
         assert_eq!(

--- a/wayland-display-core/src/utils/allocator/mod.rs
+++ b/wayland-display-core/src/utils/allocator/mod.rs
@@ -1,45 +1,202 @@
-use smithay::backend::allocator::Fourcc;
-use smithay::backend::renderer::gles::{GlesRenderbuffer, GlesRenderer};
-use smithay::backend::renderer::Offscreen;
+use gst::Buffer;
+use gst_video::VideoInfo;
+use gstreamer_allocators::DmaBufAllocator;
+use smithay::backend::allocator::dmabuf::{Dmabuf, DmabufAllocator};
+use smithay::backend::allocator::gbm::{GbmAllocator, GbmBufferFlags, GbmDevice};
+use smithay::backend::allocator::{Allocator, Fourcc};
+use smithay::backend::drm::DrmNode;
+use smithay::backend::renderer::gles::{GlesRenderbuffer, GlesRenderer, GlesTexture};
+use smithay::backend::renderer::{Bind, ExportMem, Frame, ImportDma, Offscreen, Renderer};
+use smithay::reexports::drm::buffer::DrmFourcc;
+use smithay::reexports::gbm::Modifier;
+use smithay::utils::{DeviceFd, Rectangle, Transform};
+use std::fs::File;
+use std::os::fd::{AsRawFd, OwnedFd};
 
-#[derive(Debug, Default, Clone)]
-pub struct GLESAllocator {
-    buffer: Option<GlesRenderbuffer>,
+#[derive(Debug, Clone)]
+pub struct GsGlesbuffer {
+    buffer: GlesRenderbuffer,
+    format: DrmFourcc,
+    video_info: VideoInfo,
+}
+
+impl GsGlesbuffer {
+    pub fn new(renderer: &mut GlesRenderer, video_info: VideoInfo) -> Option<Self> {
+        let format = Fourcc::try_from(video_info.format().to_fourcc()).unwrap_or(Fourcc::Abgr8888);
+
+        let result = renderer.create_buffer(
+            format,
+            (video_info.width() as i32, video_info.height() as i32).into(),
+        );
+        match result {
+            Ok(buffer) => Some(GsGlesbuffer {
+                buffer,
+                format,
+                video_info,
+            }),
+            Err(_) => None,
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
-pub enum AllocatorType {
-    GLES(GLESAllocator),
+pub struct GsDmaBuf {
+    buffer: Dmabuf,
+    format: DrmFourcc,
+    video_info: VideoInfo,
+    gles_texture: Option<GlesTexture>,
 }
 
-pub trait Allocator<Renderer, Target> {
-    fn alloc_buffer(&mut self, renderer: &mut Renderer, format: Fourcc, width: i32, height: i32);
+impl GsDmaBuf {
+    pub fn new(render_node: DrmNode, video_info: VideoInfo) -> Option<Self> {
+        let format = Fourcc::Abgr8888; // TODO: format from drm-format
 
-    fn get_buffer(&self) -> Option<Target>;
+        let file = File::options()
+            .read(true)
+            .write(true)
+            .open(render_node.dev_path().unwrap().as_path())
+            .expect("Failed to open device node");
+        let fd = DeviceFd::from(Into::<OwnedFd>::into(file));
+        let gbm = GbmDevice::new(fd).expect("Failed to create GBM device");
+        let allocator = GbmAllocator::new(gbm, GbmBufferFlags::RENDERING);
+        let mut dma_allocator = DmabufAllocator(allocator);
+
+        let modifiers = [Modifier::Linear]; // TODO: Support modifiers from video_info
+        let result = dma_allocator.create_buffer(
+            video_info.width(),
+            video_info.height(),
+            format,
+            &modifiers,
+        );
+        match result {
+            Ok(buffer) => Some(GsDmaBuf {
+                buffer,
+                format,
+                video_info,
+                gles_texture: None,
+            }),
+            Err(_) => None,
+        }
+    }
 }
 
-impl Allocator<GlesRenderer, GlesRenderbuffer> for AllocatorType {
-    fn alloc_buffer(
+#[derive(Debug, Clone)]
+pub enum GsBufferType {
+    RAW(GsGlesbuffer),
+    DMA(GsDmaBuf),
+}
+
+pub trait GsBuffer<R: Renderer> {
+    fn bind(&mut self, renderer: &mut R) -> Result<(), R::Error>;
+
+    fn to_gs_buffer(&self, renderer: &mut R) -> gst::Buffer;
+}
+
+impl GsBuffer<GlesRenderer> for GsBufferType {
+    fn bind(
         &mut self,
         renderer: &mut GlesRenderer,
-        format: Fourcc,
-        width: i32,
-        height: i32,
-    ) {
+    ) -> Result<(), <GlesRenderer as Renderer>::Error> {
         match self {
-            AllocatorType::GLES(allocator) => {
-                let result = renderer.create_buffer(format, (width, height).into());
-                match result {
-                    Ok(buffer) => allocator.buffer = Some(buffer),
-                    Err(_) => allocator.buffer = None,
-                }
+            GsBufferType::RAW(buffer) => renderer.bind(buffer.buffer.clone()),
+            GsBufferType::DMA(buffer) => {
+                let texture = renderer.import_dmabuf(&buffer.buffer, None)?;
+                buffer.gles_texture = Some(texture);
+                let size = (
+                    buffer.video_info.width() as i32,
+                    buffer.video_info.height() as i32,
+                );
+                let offscreen = Offscreen::<GlesRenderbuffer>::create_buffer(
+                    renderer,
+                    buffer.format,
+                    size.into(),
+                )?;
+                renderer.bind(offscreen)
             }
         }
     }
 
-    fn get_buffer(&self) -> Option<GlesRenderbuffer> {
+    fn to_gs_buffer(&self, renderer: &mut GlesRenderer) -> Buffer {
         match self {
-            AllocatorType::GLES(allocator) => allocator.buffer.clone(),
+            GsBufferType::RAW(buffer) => {
+                let mapping = renderer
+                    .copy_framebuffer(
+                        Rectangle::from_loc_and_size(
+                            (0, 0),
+                            (
+                                buffer.video_info.width() as i32,
+                                buffer.video_info.height() as i32,
+                            ),
+                        ),
+                        buffer.format,
+                    )
+                    .expect("Failed to export framebuffer");
+                let map = renderer
+                    .map_texture(&mapping)
+                    .expect("Failed to download framebuffer");
+
+                let mut gst_buffer =
+                    gst::Buffer::with_size(map.len()).expect("failed to create buffer");
+                {
+                    let gst_buffer = gst_buffer.get_mut().unwrap();
+
+                    let mut vframe = gst_video::VideoFrameRef::from_buffer_ref_writable(
+                        gst_buffer,
+                        &buffer.video_info,
+                    )
+                    .unwrap();
+                    let plane_data = vframe.plane_data_mut(0).unwrap();
+                    plane_data.clone_from_slice(map);
+                }
+
+                gst_buffer
+            }
+            GsBufferType::DMA(buffer) => {
+                // Adapted from: https://github.com/games-on-whales/smithay/blob/ef9782b8548c6e876bc61052e4e09351e4071a35/examples/buffer_test.rs#L326-L351
+                let size = (
+                    buffer.video_info.width() as i32,
+                    buffer.video_info.height() as i32,
+                );
+                let mut frame = renderer
+                    .render(size.into(), Transform::Normal)
+                    .expect("Failed to create frame");
+                frame
+                    .render_texture_at(
+                        buffer.gles_texture.as_ref().unwrap(),
+                        (0, 0).into(),
+                        1,
+                        1.,
+                        Transform::Normal,
+                        &[Rectangle::from_loc_and_size((0, 0), size)],
+                        &[],
+                        1.0,
+                    )
+                    .expect("Failed to render texture");
+                frame
+                    .finish()
+                    .expect("Failed to finish frame")
+                    .wait()
+                    .expect("Synchronization error");
+
+                let mut gst_buffer = gst::Buffer::new();
+                {
+                    // TODO: is this right?
+                    let gst_buffer = gst_buffer.get_mut().unwrap();
+
+                    let allocator = DmaBufAllocator::new();
+                    buffer.buffer.handles().for_each(|handle| {
+                        let fd = handle.as_raw_fd();
+                        // TODO: should we leak the handle here somehow?
+                        let memory = unsafe {
+                            allocator
+                                .alloc(fd, (size.0 * size.1) as usize)
+                                .expect("Failed to allocate memory")
+                        };
+                        gst_buffer.append_memory(memory);
+                    });
+                }
+                gst_buffer
+            }
         }
     }
 }

--- a/wayland-display-core/src/utils/mod.rs
+++ b/wayland-display-core/src/utils/mod.rs
@@ -5,3 +5,16 @@ pub mod video_info;
 mod target;
 
 pub use self::target::*;
+
+pub mod tests{
+    use std::sync::Once;
+    pub static INIT: Once = Once::new();
+
+    #[cfg(test)]
+    pub fn test_init() -> () {
+        INIT.call_once(|| {
+            tracing_subscriber::fmt::try_init().ok();
+            gst::init().expect("Failed to initialize GStreamer");
+        });
+    }
+}

--- a/wayland-display-core/src/utils/mod.rs
+++ b/wayland-display-core/src/utils/mod.rs
@@ -1,5 +1,6 @@
 pub mod allocator;
 pub mod renderer;
+pub mod video_info;
 
 mod target;
 

--- a/wayland-display-core/src/utils/mod.rs
+++ b/wayland-display-core/src/utils/mod.rs
@@ -1,3 +1,6 @@
+pub mod allocator;
+pub mod renderer;
+
 mod target;
 
 pub use self::target::*;

--- a/wayland-display-core/src/utils/renderer/mod.rs
+++ b/wayland-display-core/src/utils/renderer/mod.rs
@@ -1,0 +1,52 @@
+use once_cell::sync::Lazy;
+use smithay::backend::drm::{DrmNode, NodeType};
+use smithay::backend::egl::{EGLContext, EGLDevice, EGLDisplay};
+use smithay::backend::renderer::gles::GlesRenderer;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, Weak};
+
+static EGL_DISPLAYS: Lazy<Mutex<HashMap<Option<DrmNode>, Weak<EGLDisplay>>>> =
+    Lazy::new(|| Mutex::new(HashMap::new()));
+
+pub fn get_egl_device_for_node(drm_node: &DrmNode) -> EGLDevice {
+    let drm_node = drm_node
+        .node_with_type(NodeType::Render)
+        .and_then(Result::ok)
+        .unwrap_or(drm_node.clone());
+    EGLDevice::enumerate()
+        .expect("Failed to enumerate EGLDevices")
+        .find(|d| d.try_get_render_node().unwrap_or_default() == Some(drm_node))
+        .expect("Unable to find EGLDevice for drm-node")
+}
+
+pub fn setup_renderer(render_node: Option<DrmNode>) -> GlesRenderer {
+    let mut displays = EGL_DISPLAYS.lock().unwrap();
+    let maybe_display = displays
+        .get(&render_node)
+        .and_then(|weak_display| weak_display.upgrade());
+
+    let egl = match maybe_display {
+        Some(display) => display,
+        None => {
+            let device = match render_node.as_ref() {
+                Some(render_node) => get_egl_device_for_node(render_node),
+                None => EGLDevice::enumerate()
+                    .expect("Failed to enumerate EGLDevices")
+                    .find(|device| {
+                        device
+                            .extensions()
+                            .iter()
+                            .any(|e| e == "EGL_MESA_device_software")
+                    })
+                    .expect("Failed to find software device"),
+            };
+            let egl = unsafe { EGLDisplay::new(device).expect("Failed to create EGLDisplay") };
+            let display = Arc::new(egl);
+            displays.insert(render_node, Arc::downgrade(&display));
+            display
+        }
+    };
+    let context = EGLContext::new(&egl).expect("Failed to initialize EGL context");
+    let renderer = unsafe { GlesRenderer::new(context) }.expect("Failed to initialize renderer");
+    renderer
+}

--- a/wayland-display-core/src/utils/video_info.rs
+++ b/wayland-display-core/src/utils/video_info.rs
@@ -1,0 +1,34 @@
+use gst_video::{VideoInfo, VideoInfoDmaDrm};
+
+#[derive(Debug, Clone)]
+pub enum GstVideoInfo {
+    RAW(VideoInfo),
+    DMA(VideoInfoDmaDrm),
+}
+
+impl From<VideoInfo> for GstVideoInfo {
+    fn from(info: VideoInfo) -> Self {
+        GstVideoInfo::RAW(info)
+    }
+}
+
+impl From<VideoInfoDmaDrm> for GstVideoInfo {
+    fn from(info: VideoInfoDmaDrm) -> Self {
+        GstVideoInfo::DMA(info)
+    }
+}
+
+impl From<GstVideoInfo> for VideoInfo {
+    fn from(info: GstVideoInfo) -> Self {
+        match info {
+            GstVideoInfo::RAW(info) => info,
+            GstVideoInfo::DMA(info) => match info.to_video_info() {
+                Ok(info) => info,
+                Err(_) => VideoInfo::builder(info.format(), info.width(), info.height())
+                    .fps(info.fps())
+                    .build()
+                    .expect("Failed to build VideoInfo from VideoInfoDmaDrm"),
+            },
+        }
+    }
+}

--- a/wayland-display-core/src/wayland/handlers/compositor.rs
+++ b/wayland-display-core/src/wayland/handlers/compositor.rs
@@ -97,27 +97,7 @@ impl CompositorHandler for State {
                 toplevel.send_configure();
                 self.pending_windows.push(window);
             } else {
-                let window_size = toplevel.current_state().size.unwrap_or((0, 0).into());
-                let output_size: Size<i32, _> = self
-                    .output
-                    .as_ref()
-                    .unwrap()
-                    .current_mode()
-                    .unwrap()
-                    .size
-                    .to_f64()
-                    .to_logical(
-                        self.output
-                            .as_ref()
-                            .unwrap()
-                            .current_scale()
-                            .fractional_scale(),
-                    )
-                    .to_i32_round();
-                let loc = (
-                    (output_size.w / 2) - (window_size.w / 2),
-                    (output_size.h / 2) - (window_size.h / 2),
-                );
+                let loc = (0,0);
                 self.space.map_element(window.clone(), loc, true);
                 self.seat.get_keyboard().unwrap().set_focus(
                     self,

--- a/wayland-display-core/src/wayland/protocols/wl_drm.rs
+++ b/wayland-display-core/src/wayland/protocols/wl_drm.rs
@@ -56,6 +56,7 @@ pub enum ImportError {
     Failed,
 }
 
+#[allow(dead_code)]
 pub trait DrmHandler<R: 'static> {
     fn dmabuf_imported(&mut self, global: &DmabufGlobal, dmabuf: Dmabuf) -> Result<R, ImportError>;
     fn buffer_created(&mut self, buffer: WlBuffer, result: R) {


### PR DESCRIPTION
There's an i915 modifier issue with gstreamer elements DMA-BUF support being kinda incomplete, which happens to show up in this project.

Basically they advertise taking in DRM modifiers which aren't supported by the device for sampling use, while `waylanddisplaysrc` can only push out such modifiers as the wayland compositor is rendered to a buffer with sampling flags.

`I915_y_tiled` and `I915_4_tiled` seem to have almost same internal format, atleast close enough to make the trick of falsely-advertising y-tiled modifier pads while actually using 4-tiled modifiers to work.

Tested down to Coffee Lake-S generation's UHD Graphics P630 iGPU, and up to Intel Arc Alchemist (DG2) dGPU.

Test pipeline: `gst-launch-1.0 waylanddisplaysrc ! "video/x-raw(memory:DMABuf),width=1920,height=1080,framerate=60/1" ! vapostproc ! vah264enc ! fakesink` (or `vah264lpenc` as newer platforms may only support low-power encoding)

`qsv` encoders also seem to work just fine in-place of `va` ones in above pipeline :+1: