### PR TITLE
fix: Only use Intel workaround for DG2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,6 +92,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ash"
+version = "0.38.0+1.3.281"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bb44936d800fea8f016d7f2311c6a4f97aebd5dc86f09906139ec848cf3a46f"
+dependencies = [
+ "libloading",
+]
+
+[[package]]
 name = "async-task"
 version = "4.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1245,6 +1254,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "serde"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1317,6 +1332,7 @@ version = "0.7.0"
 source = "git+https://github.com/games-on-whales/smithay?rev=a166cf4c94b5aedc332a65aa1dd753e8148829c3#a166cf4c94b5aedc332a65aa1dd753e8148829c3"
 dependencies = [
  "appendlist",
+ "ash",
  "atomic_float",
  "bitflags",
  "calloop",
@@ -1338,6 +1354,7 @@ dependencies = [
  "profiling",
  "rand",
  "rustix 1.0.8",
+ "scopeguard",
  "sha2",
  "smallvec",
  "tempfile",

--- a/gst-plugin-wayland-display/src/waylandsrc/imp.rs
+++ b/gst-plugin-wayland-display/src/waylandsrc/imp.rs
@@ -18,6 +18,7 @@ use tracing_subscriber::layer::SubscriberExt;
 use waylanddisplaycore::{
     ButtonState, Channel, Command, DrmFormat, DrmModifier, GstVideoInfo, KeyState, Sender,
     WaylandDisplay, channel,
+    utils::device::PCIVendor,
 };
 
 use crate::utils::{CAT, GstLayer};
@@ -46,6 +47,7 @@ impl Default for WaylandDisplaySrc {
 pub struct Settings {
     render_node: Option<String>,
     input_devices: Vec<String>,
+    disable_intel_workaround: bool,
 }
 
 pub struct State {
@@ -189,6 +191,11 @@ impl ObjectImpl for WaylandDisplaySrc {
                     .blurb("Input device to use (e.g. /dev/input/event0")
                     .construct()
                     .build(),
+                glib::ParamSpecBoolean::builder("disable-intel-workaround")
+                    .nick("Disable Intel workaround")
+                    .blurb("Disable workaround for Intel GPUs that tries to fix DRM modifier issues")
+                    .default_value(false)
+                    .build(),
             ]
         });
 
@@ -221,6 +228,12 @@ impl ObjectImpl for WaylandDisplaySrc {
                     settings.input_devices.push(actual_val.unwrap());
                 }
             }
+            "disable-intel-workaround" => {
+                let mut settings = self.settings.lock().unwrap();
+                settings.disable_intel_workaround = value
+                    .get::<bool>()
+                    .expect("Type checked upstream");
+            }
             _ => unreachable!(),
         }
     }
@@ -242,6 +255,10 @@ impl ObjectImpl for WaylandDisplaySrc {
             "keyboard" => {
                 let settings = self.settings.lock().unwrap();
                 settings.input_devices.join(",").to_value()
+            }
+            "disable-intel-workaround" => {
+                let settings = self.settings.lock().unwrap();
+                settings.disable_intel_workaround.to_value()
             }
             _ => unreachable!(),
         }
@@ -355,7 +372,21 @@ impl BaseSrcImpl for WaylandDisplaySrc {
             None => Default::default(),
             Some(state) => {
                 let dma_formats = state.display.get_supported_dma_formats();
-                dma_formats.iter().filter_map(drm_to_gst_format).collect()
+
+                let settings = self.settings.lock().unwrap();
+                let mut disable_workaround = settings.disable_intel_workaround;
+                if let Some(render_device) = state.display.get_render_device() {
+                    // Disable workaround for non-DG2 (Alchemist) Intel GPUs, Battlemage and later
+                    // have reportedly no issues with the DRM modifier and don't require workaround.
+                    if *render_device.pci_vendor() == PCIVendor::Intel && !render_device.device_name().contains("DG2") {
+                        disable_workaround = true;
+                    }
+                }
+
+                dma_formats
+                    .iter()
+                    .filter_map(|format| drm_to_gst_format(format, disable_workaround))
+                    .collect()
             }
         };
 
@@ -494,7 +525,7 @@ impl PushSrcImpl for WaylandDisplaySrc {
     }
 }
 
-fn drm_to_gst_format(format: &DrmFormat) -> Option<String> {
+fn drm_to_gst_format(format: &DrmFormat, disable_workaround: bool) -> Option<String> {
     let video_format = format.code.to_string();
     let video_format = video_format.trim();
     if format.modifier == DrmModifier::Linear {
@@ -502,7 +533,7 @@ fn drm_to_gst_format(format: &DrmFormat) -> Option<String> {
     } else {
         match format.modifier {
             DrmModifier::Invalid => None,
-            DrmModifier::Unrecognized(0x0100000000000009) => {
+            DrmModifier::Unrecognized(0x0100000000000009) if !disable_workaround => {
                 // NOTE: This is a workaround for the i915 4-tiled modifiers
                 //       not being advertised by gstreamer elements.
                 // - In this part we tell we map any 4-tiled modifiers
@@ -539,7 +570,7 @@ mod tests {
             super::drm_to_gst_format(&DrmFormat {
                 code: waylanddisplaycore::Fourcc::Abgr8888,
                 modifier: waylanddisplaycore::DrmModifier::Linear
-            }),
+            }, false),
             Some("AB24".to_string())
         );
 
@@ -547,7 +578,7 @@ mod tests {
             super::drm_to_gst_format(&DrmFormat {
                 code: waylanddisplaycore::Fourcc::R8,
                 modifier: waylanddisplaycore::DrmModifier::Linear
-            }),
+            }, false),
             Some("R8  ".to_string())
         );
 
@@ -555,7 +586,7 @@ mod tests {
             super::drm_to_gst_format(&DrmFormat {
                 code: waylanddisplaycore::Fourcc::Rgba8888,
                 modifier: waylanddisplaycore::DrmModifier::Nvidia_16bx2_block_eight_gob
-            }),
+            }, false),
             Some("RA24:0x0300000000000013".to_string())
         );
     }

--- a/gst-plugin-wayland-display/src/waylandsrc/imp.rs
+++ b/gst-plugin-wayland-display/src/waylandsrc/imp.rs
@@ -17,8 +17,7 @@ use tracing_subscriber::Registry;
 use tracing_subscriber::layer::SubscriberExt;
 use waylanddisplaycore::{
     ButtonState, Channel, Command, DrmFormat, DrmModifier, GstVideoInfo, KeyState, Sender,
-    WaylandDisplay, channel,
-    utils::device::PCIVendor,
+    WaylandDisplay, channel, utils::device::PCIVendor,
 };
 
 use crate::utils::{CAT, GstLayer};
@@ -193,7 +192,9 @@ impl ObjectImpl for WaylandDisplaySrc {
                     .build(),
                 glib::ParamSpecBoolean::builder("disable-intel-workaround")
                     .nick("Disable Intel workaround")
-                    .blurb("Disable workaround for Intel GPUs that tries to fix DRM modifier issues")
+                    .blurb(
+                        "Disable workaround for Intel GPUs that tries to fix DRM modifier issues",
+                    )
                     .default_value(false)
                     .build(),
             ]
@@ -230,9 +231,8 @@ impl ObjectImpl for WaylandDisplaySrc {
             }
             "disable-intel-workaround" => {
                 let mut settings = self.settings.lock().unwrap();
-                settings.disable_intel_workaround = value
-                    .get::<bool>()
-                    .expect("Type checked upstream");
+                settings.disable_intel_workaround =
+                    value.get::<bool>().expect("Type checked upstream");
             }
             _ => unreachable!(),
         }
@@ -378,7 +378,10 @@ impl BaseSrcImpl for WaylandDisplaySrc {
                 if let Some(render_device) = state.display.get_render_device() {
                     // Disable workaround for non-DG2 (Alchemist) Intel GPUs, Battlemage and later
                     // have reportedly no issues with the DRM modifier and don't require workaround.
-                    if *render_device.pci_vendor() == PCIVendor::Intel && !render_device.device_name().contains("DG2") {
+                    if *render_device.pci_vendor() == PCIVendor::Intel
+                        && !render_device.device_name().contains("DG2")
+                    {
+                        tracing::info!("Disabling workaround for Intel GPU");
                         disable_workaround = true;
                     }
                 }
@@ -567,26 +570,35 @@ mod tests {
         test_init();
 
         assert_eq!(
-            super::drm_to_gst_format(&DrmFormat {
-                code: waylanddisplaycore::Fourcc::Abgr8888,
-                modifier: waylanddisplaycore::DrmModifier::Linear
-            }, false),
+            super::drm_to_gst_format(
+                &DrmFormat {
+                    code: waylanddisplaycore::Fourcc::Abgr8888,
+                    modifier: waylanddisplaycore::DrmModifier::Linear
+                },
+                false
+            ),
             Some("AB24".to_string())
         );
 
         assert_eq!(
-            super::drm_to_gst_format(&DrmFormat {
-                code: waylanddisplaycore::Fourcc::R8,
-                modifier: waylanddisplaycore::DrmModifier::Linear
-            }, false),
+            super::drm_to_gst_format(
+                &DrmFormat {
+                    code: waylanddisplaycore::Fourcc::R8,
+                    modifier: waylanddisplaycore::DrmModifier::Linear
+                },
+                false
+            ),
             Some("R8  ".to_string())
         );
 
         assert_eq!(
-            super::drm_to_gst_format(&DrmFormat {
-                code: waylanddisplaycore::Fourcc::Rgba8888,
-                modifier: waylanddisplaycore::DrmModifier::Nvidia_16bx2_block_eight_gob
-            }, false),
+            super::drm_to_gst_format(
+                &DrmFormat {
+                    code: waylanddisplaycore::Fourcc::Rgba8888,
+                    modifier: waylanddisplaycore::DrmModifier::Nvidia_16bx2_block_eight_gob
+                },
+                false
+            ),
             Some("RA24:0x0300000000000013".to_string())
         );
     }

--- a/gst-plugin-wayland-display/src/waylandsrc/imp.rs
+++ b/gst-plugin-wayland-display/src/waylandsrc/imp.rs
@@ -376,13 +376,17 @@ impl BaseSrcImpl for WaylandDisplaySrc {
                 let settings = self.settings.lock().unwrap();
                 let mut disable_workaround = settings.disable_intel_workaround;
                 if let Some(render_device) = state.display.get_render_device() {
-                    // Disable workaround for non-DG2 (Alchemist) Intel GPUs, Battlemage and later
+                    // Only enable workaround for DG2 (Alchemist) Intel GPUs, Battlemage and later
                     // have reportedly no issues with the DRM modifier and don't require workaround.
-                    if *render_device.pci_vendor() == PCIVendor::Intel
-                        && !render_device.device_name().contains("DG2")
-                    {
-                        tracing::info!("Disabling workaround for Intel GPU");
-                        disable_workaround = true;
+                    if !disable_workaround && *render_device.pci_vendor() == PCIVendor::Intel {
+                        if !render_device.device_name().contains("DG2") {
+                            tracing::info!(
+                                "Disabling workaround for non-Alchemist (DG2) Intel GPU"
+                            );
+                            disable_workaround = true;
+                        } else if !disable_workaround {
+                            tracing::info!("Enabling workaround for Alchemist (DG2) Intel GPU");
+                        }
                     }
                 }
 

--- a/wayland-display-core/Cargo.toml
+++ b/wayland-display-core/Cargo.toml
@@ -39,6 +39,7 @@ features = [
     "backend_gbm",
     "backend_libinput",
     "backend_udev",
+    "backend_vulkan",
     "renderer_gl",
     "use_system_lib",
     "desktop",

--- a/wayland-display-core/src/comp/mod.rs
+++ b/wayland-display-core/src/comp/mod.rs
@@ -77,6 +77,7 @@ use crate::utils::allocator::{
 };
 use crate::utils::renderer::setup_renderer;
 use crate::{utils::RenderTarget, wayland::protocols::wl_drm::create_drm_global};
+use crate::utils::device::gpu::GPUDevice;
 
 #[derive(Debug, Default)]
 pub struct ClientState {
@@ -581,6 +582,23 @@ pub(crate) fn init(
                     };
                     debug!("Supported dma formats: {:?}", supported_formats);
                     let _ = sender.send(supported_formats);
+                }
+                Event::Msg(Command::GetRenderDevice(sender)) => {
+                    let render_device: Option<GPUDevice> = match &state.render_node {
+                        Some(node) => {
+                            if let Ok(gpu_dev) = GPUDevice::try_from(*node) {
+                                Some(gpu_dev)
+                            } else {
+                                tracing::warn!("Failed to create GPUDevice from render node.");
+                                None
+                            }
+                        },
+                        None => None,
+                    };
+                    debug!("Render device requested: {:?}", render_device);
+                    if let Err(err) = sender.send(render_device) {
+                        tracing::warn!(?err, "Failed to send render device.");
+                    }
                 }
                 Event::Msg(Command::TouchDown(id, rel_position)) => {
                     let time: Duration = state.clock.now().into();

--- a/wayland-display-core/src/comp/mod.rs
+++ b/wayland-display-core/src/comp/mod.rs
@@ -75,9 +75,9 @@ use crate::utils::allocator::{
     GsBuffer, GsBufferType, GsDmaBuf, GsGlesbuffer, VideoInfoTypes, gst_video_format_to_drm_fourcc,
     gst_video_format_to_drm_modifier, new_gbm_device,
 };
+use crate::utils::device::gpu::GPUDevice;
 use crate::utils::renderer::setup_renderer;
 use crate::{utils::RenderTarget, wayland::protocols::wl_drm::create_drm_global};
-use crate::utils::device::gpu::GPUDevice;
 
 #[derive(Debug, Default)]
 pub struct ClientState {
@@ -592,7 +592,7 @@ pub(crate) fn init(
                                 tracing::warn!("Failed to create GPUDevice from render node.");
                                 None
                             }
-                        },
+                        }
                         None => None,
                     };
                     debug!("Render device requested: {:?}", render_device);

--- a/wayland-display-core/src/lib.rs
+++ b/wayland-display-core/src/lib.rs
@@ -13,6 +13,8 @@ use std::sync::mpsc::{self, Receiver, SyncSender};
 use std::thread::JoinHandle;
 use utils::RenderTarget;
 
+use crate::utils::device::gpu::GPUDevice;
+
 pub(crate) mod comp;
 #[cfg(test)]
 mod tests;
@@ -34,6 +36,7 @@ pub enum Command {
     PointerButton(u32, ButtonState),
     PointerAxis(f64, f64),
     GetSupportedDmaFormats(SyncSender<FormatSet>),
+    GetRenderDevice(SyncSender<Option<GPUDevice>>),
     TouchDown(u32, Point<f64, Logical>),
     TouchUp(u32),
     TouchMotion(u32, Point<f64, Logical>),
@@ -268,6 +271,12 @@ impl WaylandDisplay {
         let _ = self
             .command_tx
             .send(Command::GetSupportedDmaFormats(buffer_tx));
+        buffer_rx.recv().unwrap()
+    }
+
+    pub fn get_render_device(&self) -> Option<GPUDevice> {
+        let (buffer_tx, buffer_rx) = mpsc::sync_channel(0);
+        let _ = self.command_tx.send(Command::GetRenderDevice(buffer_tx));
         buffer_rx.recv().unwrap()
     }
 }

--- a/wayland-display-core/src/tests/device.rs
+++ b/wayland-display-core/src/tests/device.rs
@@ -1,0 +1,30 @@
+#[test]
+fn test_enumerate_gpu_devices() {
+    use crate::utils::device::PCIVendor;
+    use crate::utils::device::gpu::enumerate_gpu_devices;
+
+    let devices = enumerate_gpu_devices().expect("Failed to enumerate GPU devices");
+
+    // Check that we have at least one device
+    assert!(!devices.is_empty(), "No GPU devices found");
+
+    for device in devices {
+        // Ensure each device has a valid DRM node
+        assert!(
+            !device.drm_node().to_string().is_empty(),
+            "DRM node path is empty"
+        );
+
+        // Ensure the PCI vendor is known
+        assert_ne!(
+            *device.pci_vendor(),
+            PCIVendor::Unknown,
+            "Unknown PCI vendor"
+        );
+
+        // Ensure the device name is not empty
+        assert!(!device.device_name().is_empty(), "Device name is empty");
+
+        tracing::info!("Found GPU: {}", device);
+    }
+}

--- a/wayland-display-core/src/tests/device.rs
+++ b/wayland-display-core/src/tests/device.rs
@@ -1,6 +1,5 @@
 #[test]
 fn test_enumerate_gpu_devices() {
-    use crate::utils::device::PCIVendor;
     use crate::utils::device::gpu::enumerate_gpu_devices;
 
     let devices = enumerate_gpu_devices().expect("Failed to enumerate GPU devices");
@@ -13,13 +12,6 @@ fn test_enumerate_gpu_devices() {
         assert!(
             !device.drm_node().to_string().is_empty(),
             "DRM node path is empty"
-        );
-
-        // Ensure the PCI vendor is known
-        assert_ne!(
-            *device.pci_vendor(),
-            PCIVendor::Unknown,
-            "Unknown PCI vendor"
         );
 
         // Ensure the device name is not empty

--- a/wayland-display-core/src/tests/mod.rs
+++ b/wayland-display-core/src/tests/mod.rs
@@ -1,3 +1,4 @@
 pub(crate) mod client;
 mod fixture;
 mod test_pointer;
+mod device;

--- a/wayland-display-core/src/tests/mod.rs
+++ b/wayland-display-core/src/tests/mod.rs
@@ -1,4 +1,4 @@
 pub(crate) mod client;
+mod device;
 mod fixture;
 mod test_pointer;
-mod device;

--- a/wayland-display-core/src/utils/device/gpu.rs
+++ b/wayland-display-core/src/utils/device/gpu.rs
@@ -64,9 +64,6 @@ pub fn enumerate_gpu_devices() -> Result<Vec<GPUDevice>, Box<dyn std::error::Err
 
         let properties = p_dev.properties();
         let pci_vendor = PCIVendor::try_from(properties.vendor_id);
-        if pci_vendor.is_err() {
-            continue; // Skip unknown vendor
-        }
 
         // array of c_char's (i8) needs conversion to String
         let device_name = properties
@@ -79,7 +76,7 @@ pub fn enumerate_gpu_devices() -> Result<Vec<GPUDevice>, Box<dyn std::error::Err
 
         devices.push(GPUDevice {
             drm_node,
-            pci_vendor: pci_vendor.unwrap(),
+            pci_vendor: pci_vendor.unwrap_or(PCIVendor::Unknown),
             device_name,
         });
     }

--- a/wayland-display-core/src/utils/device/gpu.rs
+++ b/wayland-display-core/src/utils/device/gpu.rs
@@ -1,0 +1,90 @@
+use crate::utils::device::PCIVendor;
+use smithay::backend::drm::DrmNode;
+use smithay::backend::vulkan::version::Version;
+use smithay::backend::vulkan::{Instance, PhysicalDevice};
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct GPUDevice {
+    drm_node: DrmNode,
+    pci_vendor: PCIVendor,
+    device_name: String,
+}
+impl GPUDevice {
+    pub fn drm_node(&self) -> &DrmNode {
+        &self.drm_node
+    }
+
+    pub fn pci_vendor(&self) -> &PCIVendor {
+        &self.pci_vendor
+    }
+
+    pub fn device_name(&self) -> &str {
+        &self.device_name
+    }
+}
+impl TryFrom<DrmNode> for GPUDevice {
+    type Error = Box<dyn std::error::Error>;
+    fn try_from(drm_node: DrmNode) -> Result<Self, Self::Error> {
+        let devices = enumerate_gpu_devices()?;
+        if let Some(device) = devices.iter().find(|d| d.drm_node == drm_node) {
+            Ok(device.clone())
+        } else {
+            Err("No GPU device for given DRM node".into())
+        }
+    }
+}
+impl std::fmt::Display for GPUDevice {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "GPUDevice {{ drm_node: {}, pci_vendor: {}, device_name: {} }}",
+            self.drm_node,
+            self.pci_vendor,
+            self.device_name
+        )
+    }
+}
+
+pub fn enumerate_gpu_devices() -> Result<Vec<GPUDevice>, Box<dyn std::error::Error>> {
+    let mut devices = Vec::new();
+
+    let instance = Instance::new(Version::VERSION_1_1, None)?;
+
+    for p_dev in PhysicalDevice::enumerate(&instance)? {
+        // Add only devices that support DrmNode (filters out software devices)
+        let drm_node: DrmNode = if let Ok(render_node) = p_dev.render_node()
+            && let Some(render_node) = render_node
+        {
+            render_node
+        } else if let Ok(primary_node) = p_dev.primary_node()
+            && let Some(primary_node) = primary_node
+        {
+            primary_node
+        } else {
+            continue;
+        };
+
+        let properties = p_dev.properties();
+        let pci_vendor = PCIVendor::try_from(properties.vendor_id);
+        if pci_vendor.is_err() {
+            continue; // Skip unknown vendor
+        }
+
+        // array of c_char's (i8) needs conversion to String
+        let device_name = properties
+            .device_name
+            .as_slice()
+            .iter()
+            .take_while(|&&c| c != 0)
+            .map(|&c| c as u8 as char)
+            .collect::<String>();
+
+        devices.push(GPUDevice {
+            drm_node,
+            pci_vendor: pci_vendor.unwrap(),
+            device_name,
+        });
+    }
+
+    Ok(devices)
+}

--- a/wayland-display-core/src/utils/device/gpu.rs
+++ b/wayland-display-core/src/utils/device/gpu.rs
@@ -38,9 +38,7 @@ impl std::fmt::Display for GPUDevice {
         write!(
             f,
             "GPUDevice {{ drm_node: {}, pci_vendor: {}, device_name: {} }}",
-            self.drm_node,
-            self.pci_vendor,
-            self.device_name
+            self.drm_node, self.pci_vendor, self.device_name
         )
     }
 }

--- a/wayland-display-core/src/utils/device/mod.rs
+++ b/wayland-display-core/src/utils/device/mod.rs
@@ -1,0 +1,34 @@
+pub mod gpu;
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub enum PCIVendor {
+    Unknown = 0x0000,
+    Intel = 0x8086,
+    NVIDIA = 0x10de,
+    AMD = 0x1002,
+}
+impl PCIVendor {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            PCIVendor::Intel => "Intel",
+            PCIVendor::NVIDIA => "NVIDIA",
+            PCIVendor::AMD => "AMD",
+            PCIVendor::Unknown => "Unknown",
+        }
+    }
+}
+impl From<u32> for PCIVendor {
+    fn from(vendor_id: u32) -> Self {
+        match vendor_id {
+            0x8086 => PCIVendor::Intel,
+            0x10de => PCIVendor::NVIDIA,
+            0x1002 => PCIVendor::AMD,
+            _ => PCIVendor::Unknown,
+        }
+    }
+}
+impl std::fmt::Display for PCIVendor {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}

--- a/wayland-display-core/src/utils/mod.rs
+++ b/wayland-display-core/src/utils/mod.rs
@@ -1,6 +1,7 @@
 pub mod allocator;
 pub mod renderer;
 pub mod video_info;
+pub mod device;
 
 mod target;
 

--- a/wayland-display-core/src/utils/mod.rs
+++ b/wayland-display-core/src/utils/mod.rs
@@ -1,7 +1,7 @@
 pub mod allocator;
+pub mod device;
 pub mod renderer;
 pub mod video_info;
-pub mod device;
 
 mod target;
 


### PR DESCRIPTION
Took a bit, needed bit more than I thought.

Added mainly utilities for devices, with PCI vendor enums and Vulkan-based enumeration for GPUs.
New command to get the render device based on `state.render_node`, I thought about changing `RenderTarget` to use the new GPUDevice to make the enumeration-on-command unneeded, however I feel that's overreaching for a "fix" PR :sweat_smile: 

Draft initially as I reckon you might want some changes @ABeltramo ?

Should fix: #14