### PR TITLE
Workaround against NVIDIA bug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,15 +92,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ash"
-version = "0.38.0+1.3.281"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bb44936d800fea8f016d7f2311c6a4f97aebd5dc86f09906139ec848cf3a46f"
-dependencies = [
- "libloading",
-]
-
-[[package]]
 name = "async-task"
 version = "4.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1254,12 +1245,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
 name = "serde"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1332,7 +1317,6 @@ version = "0.7.0"
 source = "git+https://github.com/games-on-whales/smithay?rev=a166cf4c94b5aedc332a65aa1dd753e8148829c3#a166cf4c94b5aedc332a65aa1dd753e8148829c3"
 dependencies = [
  "appendlist",
- "ash",
  "atomic_float",
  "bitflags",
  "calloop",
@@ -1354,7 +1338,6 @@ dependencies = [
  "profiling",
  "rand",
  "rustix 1.0.8",
- "scopeguard",
  "sha2",
  "smallvec",
  "tempfile",

--- a/wayland-display-core/Cargo.toml
+++ b/wayland-display-core/Cargo.toml
@@ -39,7 +39,6 @@ features = [
     "backend_gbm",
     "backend_libinput",
     "backend_udev",
-    "backend_vulkan",
     "renderer_gl",
     "use_system_lib",
     "desktop",

--- a/wayland-display-core/src/comp/mod.rs
+++ b/wayland-display-core/src/comp/mod.rs
@@ -586,11 +586,18 @@ pub(crate) fn init(
                 Event::Msg(Command::GetRenderDevice(sender)) => {
                     let render_device: Option<GPUDevice> = match &state.render_node {
                         Some(node) => {
-                            if let Ok(gpu_dev) = GPUDevice::try_from(*node) {
-                                Some(gpu_dev)
-                            } else {
-                                tracing::warn!("Failed to create GPUDevice from render node.");
+                            // Check for existence of nvidia-smi, if it runs, return None instead
+                            // Done because apparently creating Vulkan instance causes -
+                            // EGL to die under NVIDIA GPUs, nice bug.
+                            if std::process::Command::new("nvidia-smi").arg("--help").output().is_ok() {
                                 None
+                            } else {
+                                if let Ok(gpu_dev) = GPUDevice::try_from(*node) {
+                                    Some(gpu_dev)
+                                } else {
+                                    tracing::warn!("Failed to create GPUDevice from render node.");
+                                    None
+                                }
                             }
                         }
                         None => None,

--- a/wayland-display-core/src/comp/mod.rs
+++ b/wayland-display-core/src/comp/mod.rs
@@ -586,11 +586,13 @@ pub(crate) fn init(
                 Event::Msg(Command::GetRenderDevice(sender)) => {
                     let render_device: Option<GPUDevice> = match &state.render_node {
                         Some(node) => {
-                            if let Ok(gpu_dev) = GPUDevice::try_from(*node) {
-                                Some(gpu_dev)
-                            } else {
-                                tracing::warn!("Failed to create GPUDevice from render node.");
-                                None
+                            let result = GPUDevice::try_from(*node);
+                            match result {
+                                Ok(device) => Some(device),
+                                Err(err) => {
+                                    tracing::warn!("Error during GetRenderDevice: {}", err);
+                                    None
+                                }
                             }
                         }
                         None => None,

--- a/wayland-display-core/src/comp/mod.rs
+++ b/wayland-display-core/src/comp/mod.rs
@@ -586,18 +586,11 @@ pub(crate) fn init(
                 Event::Msg(Command::GetRenderDevice(sender)) => {
                     let render_device: Option<GPUDevice> = match &state.render_node {
                         Some(node) => {
-                            // Check for existence of nvidia-smi, if it runs, return None instead
-                            // Done because apparently creating Vulkan instance causes -
-                            // EGL to die under NVIDIA GPUs, nice bug.
-                            if std::process::Command::new("nvidia-smi").arg("--help").output().is_ok() {
-                                None
+                            if let Ok(gpu_dev) = GPUDevice::try_from(*node) {
+                                Some(gpu_dev)
                             } else {
-                                if let Ok(gpu_dev) = GPUDevice::try_from(*node) {
-                                    Some(gpu_dev)
-                                } else {
-                                    tracing::warn!("Failed to create GPUDevice from render node.");
-                                    None
-                                }
+                                tracing::warn!("Failed to create GPUDevice from render node.");
+                                None
                             }
                         }
                         None => None,

--- a/wayland-display-core/src/tests/device.rs
+++ b/wayland-display-core/src/tests/device.rs
@@ -1,3 +1,5 @@
+use test_log::test;
+
 #[test]
 fn test_enumerate_gpu_devices() {
     use crate::utils::device::gpu::enumerate_gpu_devices;
@@ -8,6 +10,8 @@ fn test_enumerate_gpu_devices() {
     assert!(!devices.is_empty(), "No GPU devices found");
 
     for device in devices {
+        tracing::info!("Found GPU: {}", device);
+
         // Ensure each device has a valid DRM node
         assert!(
             !device.drm_node().to_string().is_empty(),
@@ -16,7 +20,5 @@ fn test_enumerate_gpu_devices() {
 
         // Ensure the device name is not empty
         assert!(!device.device_name().is_empty(), "Device name is empty");
-
-        tracing::info!("Found GPU: {}", device);
     }
 }

--- a/wayland-display-core/src/utils/allocator/mod.rs
+++ b/wayland-display-core/src/utils/allocator/mod.rs
@@ -112,7 +112,10 @@ impl GsDmaBuf {
                 video_info,
                 gst_allocator: DmaBufAllocator::new(),
             }),
-            Err(_) => None,
+            Err(_) => {
+                tracing::warn!("Failed to create DMA buffer: {}", result.unwrap_err());
+                None
+            }
         }
     }
 }

--- a/wayland-display-core/src/utils/device/gpu.rs
+++ b/wayland-display-core/src/utils/device/gpu.rs
@@ -44,8 +44,7 @@ impl std::fmt::Display for GPUDevice {
 }
 
 pub fn enumerate_gpu_devices() -> Result<Vec<GPUDevice>, Box<dyn Error>> {
-    EGLDevice::enumerate()
-        .expect("Failed to enumerate EGLDevices")
+    EGLDevice::enumerate()?
         .filter(|dev| !dev.is_software())
         .map(|dev| -> Result<GPUDevice, Box<dyn Error>> {
             let drm_path = dev.drm_device_path()?;
@@ -53,7 +52,6 @@ pub fn enumerate_gpu_devices() -> Result<Vec<GPUDevice>, Box<dyn Error>> {
             let minor = drm_node.minor();
             let vendor_str =
                 std::fs::read_to_string(format!("/sys/class/drm/card{}/device/vendor", minor))?;
-            // trim 0x prefix and final \n
             let vendor_str = vendor_str.trim_start_matches("0x").trim_end_matches('\n');
             let vendor = u32::from_str_radix(&vendor_str, 16)?;
 
@@ -61,10 +59,14 @@ pub fn enumerate_gpu_devices() -> Result<Vec<GPUDevice>, Box<dyn Error>> {
                 std::fs::read_to_string(format!("/sys/class/drm/card{}/device/device", minor))?;
             let device_id = device_id.trim_start_matches("0x").trim_end_matches('\n');
 
-            // Look up in PCI database
-            let pci_ids = std::fs::read_to_string("/usr/share/hwdata/pci.ids")?;
-            let device_name =
-                parse_pci_ids(&pci_ids, vendor_str, device_id).unwrap_or("".to_owned());
+            // Look up in hwdata PCI database
+            let device_name = match std::fs::read_to_string("/usr/share/hwdata/pci.ids") {
+                Ok(pci_ids) => parse_pci_ids(&pci_ids, device_id).unwrap_or("".to_owned()),
+                Err(e) => {
+                    tracing::warn!("Failed to read /usr/share/hwdata/pci.ids: {}", e);
+                    "".to_owned()
+                }
+            };
 
             Ok(GPUDevice {
                 drm_node,
@@ -75,22 +77,12 @@ pub fn enumerate_gpu_devices() -> Result<Vec<GPUDevice>, Box<dyn Error>> {
         .collect()
 }
 
-fn parse_pci_ids(pci_data: &str, vendor_id: &str, device_id: &str) -> Option<String> {
-    let mut current_vendor = None;
-    let mut vendor_name = None;
-
+fn parse_pci_ids(pci_data: &str, device_id: &str) -> Option<String> {
     for line in pci_data.lines() {
-        if let Some(stripped) = line.strip_prefix(vendor_id) {
+        if let Some(stripped) = line.strip_prefix(&format!("\t{}", device_id)) {
             if stripped.starts_with("  ") {
-                vendor_name = Some(stripped.trim());
-                current_vendor = Some(vendor_id);
-            }
-        } else if current_vendor == Some(vendor_id) {
-            if let Some(stripped) = line.strip_prefix(&format!("\t{}", device_id)) {
-                if stripped.starts_with("  ") {
-                    let device_name = stripped.trim();
-                    return Some(format!("{} {}", vendor_name?, device_name));
-                }
+                let device_name = stripped.trim();
+                return Some(device_name.to_owned());
             }
         }
     }

--- a/wayland-display-core/src/utils/device/gpu.rs
+++ b/wayland-display-core/src/utils/device/gpu.rs
@@ -1,7 +1,7 @@
 use crate::utils::device::PCIVendor;
 use smithay::backend::drm::DrmNode;
-use smithay::backend::vulkan::version::Version;
-use smithay::backend::vulkan::{Instance, PhysicalDevice};
+use smithay::backend::egl::EGLDevice;
+use std::error::Error;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct GPUDevice {
@@ -43,43 +43,56 @@ impl std::fmt::Display for GPUDevice {
     }
 }
 
-pub fn enumerate_gpu_devices() -> Result<Vec<GPUDevice>, Box<dyn std::error::Error>> {
-    let mut devices = Vec::new();
+pub fn enumerate_gpu_devices() -> Result<Vec<GPUDevice>, Box<dyn Error>> {
+    EGLDevice::enumerate()
+        .expect("Failed to enumerate EGLDevices")
+        .filter(|dev| !dev.is_software())
+        .map(|dev| -> Result<GPUDevice, Box<dyn Error>> {
+            let drm_path = dev.drm_device_path()?;
+            let drm_node = DrmNode::from_path(drm_path)?;
+            let minor = drm_node.minor();
+            let vendor_str =
+                std::fs::read_to_string(format!("/sys/class/drm/card{}/device/vendor", minor))?;
+            // trim 0x prefix and final \n
+            let vendor_str = vendor_str.trim_start_matches("0x").trim_end_matches('\n');
+            let vendor = u32::from_str_radix(&vendor_str, 16)?;
 
-    let instance = Instance::new(Version::VERSION_1_1, None)?;
+            let device_id =
+                std::fs::read_to_string(format!("/sys/class/drm/card{}/device/device", minor))?;
+            let device_id = device_id.trim_start_matches("0x").trim_end_matches('\n');
 
-    for p_dev in PhysicalDevice::enumerate(&instance)? {
-        // Add only devices that support DrmNode (filters out software devices)
-        let drm_node: DrmNode = if let Ok(render_node) = p_dev.render_node()
-            && let Some(render_node) = render_node
-        {
-            render_node
-        } else if let Ok(primary_node) = p_dev.primary_node()
-            && let Some(primary_node) = primary_node
-        {
-            primary_node
-        } else {
-            continue;
-        };
+            // Look up in PCI database
+            let pci_ids = std::fs::read_to_string("/usr/share/hwdata/pci.ids")?;
+            let device_name =
+                parse_pci_ids(&pci_ids, vendor_str, device_id).unwrap_or("".to_owned());
 
-        let properties = p_dev.properties();
-        let pci_vendor = PCIVendor::try_from(properties.vendor_id);
+            Ok(GPUDevice {
+                drm_node,
+                pci_vendor: PCIVendor::try_from(vendor)?,
+                device_name,
+            })
+        })
+        .collect()
+}
 
-        // array of c_char's (i8) needs conversion to String
-        let device_name = properties
-            .device_name
-            .as_slice()
-            .iter()
-            .take_while(|&&c| c != 0)
-            .map(|&c| c as u8 as char)
-            .collect::<String>();
+fn parse_pci_ids(pci_data: &str, vendor_id: &str, device_id: &str) -> Option<String> {
+    let mut current_vendor = None;
+    let mut vendor_name = None;
 
-        devices.push(GPUDevice {
-            drm_node,
-            pci_vendor: pci_vendor.unwrap_or(PCIVendor::Unknown),
-            device_name,
-        });
+    for line in pci_data.lines() {
+        if let Some(stripped) = line.strip_prefix(vendor_id) {
+            if stripped.starts_with("  ") {
+                vendor_name = Some(stripped.trim());
+                current_vendor = Some(vendor_id);
+            }
+        } else if current_vendor == Some(vendor_id) {
+            if let Some(stripped) = line.strip_prefix(&format!("\t{}", device_id)) {
+                if stripped.starts_with("  ") {
+                    let device_name = stripped.trim();
+                    return Some(format!("{} {}", vendor_name?, device_name));
+                }
+            }
+        }
     }
-
-    Ok(devices)
+    None
 }


### PR DESCRIPTION
Reported to Smithay side as well: https://github.com/Smithay/smithay/issues/1804

NVIDIA bugs, what a fun time..

If Vulkan instance is created, EGL is killed, doesn't happen under Intel or AMD GPUs.
~~Marked as draft initially since it's a very "dirty" workaround, basically relying on checking for existence of `nvidia-smi`.~~

Undrafted, using `/sys/class/` for checks rather than Vulkan API + removed nvidia-smi workaround.