### PR TITLE
Initial Nix flake

### DIFF
--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -1,0 +1,26 @@
+name: "Nix flake build"
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    name: Build nix flake
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v13
+
+      - name: Setup Nix cache
+        uses: DeterminateSystems/magic-nix-cache-action@v7
+
+      - name: Check flake
+        run: nix flake check
+
+      - name: Build package
+        run: nix build .#gst-wayland-display --print-build-logs
+
+      - name: Build default package
+        run: nix build --print-build-logs

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ gen
 *.app
 .snapshots/*
 
+# Nix
+/result
+/result-*

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,77 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nix-filter": {
+      "locked": {
+        "lastModified": 1757882181,
+        "narHash": "sha256-+cCxYIh2UNalTz364p+QYmWHs0P+6wDhiWR4jDIKQIU=",
+        "owner": "numtide",
+        "repo": "nix-filter",
+        "rev": "59c44d1909c72441144b93cf0f054be7fe764de5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "nix-filter",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1759322190,
+        "narHash": "sha256-s+0wBPx9FAphKv8BYRN7OLCiZkiK1Dc8ebbCzczI9S8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ee4cd98afba682ca27242f2d7fdbd8583f6ef51a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nix-filter": "nix-filter",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -61,6 +61,12 @@
           inputsFrom = [
             gst-wayland-display
           ];
+
+          packages = with pkgs; [
+            gst_all_1.gst-plugins-good
+          ];
+
+          LD_LIBRARY_PATH = "${pkgs.libglvnd}/lib";
         };
 
         packages = {

--- a/flake.nix
+++ b/flake.nix
@@ -37,6 +37,7 @@
           cargoHash = "sha256-VjtrS0wmG9heZqb68GLM4PE6IezalQ3Z9CEYeJ/ndZw=";
 
           nativeBuildInputs = with pkgs; [
+            cargo-c
             pkg-config
           ];
 
@@ -49,6 +50,20 @@
             udev
             wayland
           ];
+
+          buildPhase = ''
+            runHook preBuild
+            ${pkgs.rust.envVars.setEnv} cargo cbuild -j $NIX_BUILD_CORES --release --frozen \
+              --prefix=${placeholder "out"} --target ${pkgs.stdenv.hostPlatform.rust.rustcTarget}
+            runHook postBuild
+          '';
+
+          installPhase = ''
+            runHook preInstall
+            ${pkgs.rust.envVars.setEnv} cargo cinstall -j $NIX_BUILD_CORES --release --frozen \
+              --prefix=${placeholder "out"} --target ${pkgs.stdenv.hostPlatform.rust.rustcTarget}
+            runHook postInstall
+          '';
 
           # Checks don't work properly in the Nix sandbox.
           doCheck = false;

--- a/flake.nix
+++ b/flake.nix
@@ -66,6 +66,7 @@
             gst_all_1.gst-plugins-good
           ];
 
+          GST_PLUGIN_PATH = "${gst-wayland-display}/lib";
           LD_LIBRARY_PATH = "${pkgs.libglvnd}/lib";
         };
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,72 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    nix-filter.url = "github:numtide/nix-filter";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+      nix-filter,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+
+        gst-wayland-display = pkgs.rustPlatform.buildRustPackage {
+          pname = "gst-wayland-display";
+          version = "0.4.0";
+
+          src = nix-filter {
+            root = self;
+
+            include = [
+              (nix-filter.lib.inDirectory "c-bindings")
+              (nix-filter.lib.inDirectory "gst-plugin-wayland-display")
+              (nix-filter.lib.inDirectory "wayland-display-core")
+
+              "Cargo.lock"
+              "Cargo.toml"
+            ];
+          };
+
+          cargoHash = "sha256-VjtrS0wmG9heZqb68GLM4PE6IezalQ3Z9CEYeJ/ndZw=";
+
+          nativeBuildInputs = with pkgs; [
+            pkg-config
+          ];
+
+          buildInputs = with pkgs; [
+            gst_all_1.gstreamer
+            gst_all_1.gst-plugins-base
+            libgbm
+            libinput
+            libxkbcommon
+            udev
+            wayland
+          ];
+
+          # Checks don't work properly in the Nix sandbox.
+          doCheck = false;
+        };
+      in
+      {
+        formatter = pkgs.nixfmt-tree;
+
+        devShells.default = pkgs.mkShell {
+          inputsFrom = [
+            gst-wayland-display
+          ];
+        };
+
+        packages = {
+          inherit gst-wayland-display;
+          default = gst-wayland-display;
+        };
+      }
+    );
+}


### PR DESCRIPTION
This introduces a very basic flake, suitable for building `gst-wayland-display`. It should be relatively low maintenance, as the only moving part is the `cargoHash` that will need to be erased and updated whenever the `Cargo.lock` file is updated.

I'm not very familiar with GitHub Actions, although I expect configuring some kind of runner to ensure this continues to build wouldn't be too difficult: @DatCaptainHorse, would you care to take a look? :P
