### PR TITLE
feat: CPU optimizations for CUDA-path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1696,13 +1696,13 @@ dependencies = [
 
 [[package]]
 name = "wayland-backend"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe770181423e5fc79d3e2a7f4410b7799d5aab1de4372853de3c6aa13ca24121"
+checksum = "673a33c33048a5ade91a6b139580fa174e19fb0d23f396dca9fa15f2e1e49b35"
 dependencies = [
  "cc",
  "downcast-rs",
- "rustix 0.38.44",
+ "rustix 1.0.8",
  "scoped-tls",
  "smallvec",
  "wayland-sys",
@@ -1710,12 +1710,12 @@ dependencies = [
 
 [[package]]
 name = "wayland-client"
-version = "0.31.10"
+version = "0.31.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978fa7c67b0847dbd6a9f350ca2569174974cd4082737054dbb7fbb79d7d9a61"
+checksum = "c66a47e840dc20793f2264eb4b3e4ecb4b75d91c0dd4af04b456128e0bdd449d"
 dependencies = [
  "bitflags",
- "rustix 0.38.44",
+ "rustix 1.0.8",
  "wayland-backend",
  "wayland-scanner",
 ]
@@ -1747,9 +1747,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols"
-version = "0.32.8"
+version = "0.32.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "779075454e1e9a521794fed15886323ea0feda3f8b0fc1390f5398141310422a"
+checksum = "efa790ed75fbfd71283bd2521a1cfdc022aabcc28bdcff00851f9e4ae88d9901"
 dependencies = [
  "bitflags",
  "wayland-backend",
@@ -1786,9 +1786,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-scanner"
-version = "0.31.6"
+version = "0.31.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "896fdafd5d28145fce7958917d69f2fd44469b1d4e861cb5961bcbeebc6d1484"
+checksum = "54cb1e9dc49da91950bdfd8b848c49330536d9d1fb03d4bfec8cae50caa50ae3"
 dependencies = [
  "proc-macro2",
  "quick-xml",
@@ -1797,22 +1797,22 @@ dependencies = [
 
 [[package]]
 name = "wayland-server"
-version = "0.31.9"
+version = "0.31.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "485dfb8ccf0daa0d34625d34e6ac15f99e550a7999b6fd88a0835ccd37655785"
+checksum = "fcbd4f3aba6c9fba70445ad2a484c0ef0356c1a9459b1e8e435bedc1971a6222"
 dependencies = [
  "bitflags",
  "downcast-rs",
- "rustix 0.38.44",
+ "rustix 1.0.8",
  "wayland-backend",
  "wayland-scanner",
 ]
 
 [[package]]
 name = "wayland-sys"
-version = "0.31.6"
+version = "0.31.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbcebb399c77d5aa9fa5db874806ee7b4eba4e73650948e8f93963f128896615"
+checksum = "34949b42822155826b41db8e5d0c1be3a2bd296c747577a43a3e6daefc296142"
 dependencies = [
  "dlib",
  "libc",

--- a/gst-plugin-wayland-display/src/waylandsrc/imp.rs
+++ b/gst-plugin-wayland-display/src/waylandsrc/imp.rs
@@ -537,13 +537,7 @@ impl BaseSrcImpl for WaylandDisplaySrc {
             let (_pool, size, min, max) = pools.get(0).unwrap();
             // TODO: check if GST_IS_CUDA_BUFFER_POOL(pool)
             // TODO: wrap the pool in our buffer
-            (
-                CUDABufferPool::new(&cuda_ctx),
-                true,
-                *size,
-                *min,
-                *max,
-            )
+            (CUDABufferPool::new(&cuda_ctx), true, *size, *min, *max)
         };
 
         match pool {
@@ -561,6 +555,11 @@ impl BaseSrcImpl for WaylandDisplaySrc {
                 } else {
                     pool.add_allocation_pool(query, updated_size, min, max);
                 }
+
+                // Send the pool to the compositor
+                let _ = self
+                    .command_tx
+                    .send(Command::UpdateCUDABufferPool(pool.clone()));
 
                 settings.cudabuffer_pool = Some(pool);
             }

--- a/wayland-display-core/src/comp/mod.rs
+++ b/wayland-display-core/src/comp/mod.rs
@@ -353,11 +353,18 @@ pub(crate) fn init(
                                 state.output_buffer = Some(GsBufferType::DMA(allocator));
                             }
                             GstVideoInfo::CUDA(base_info) => {
+                                let egl_display = state
+                                    .renderer
+                                    .egl_context()
+                                    .display()
+                                    .get_display_handle()
+                                    .handle;
                                 let allocator = GsCUDABuf::new(
                                     render_node.unwrap(),
                                     base_info.cuda_context,
                                     base_info.video_info,
                                     base_info.buffer_pool,
+                                    &egl_display,
                                 )
                                 .expect("Failed to create GsCUDABuf");
                                 state.output_buffer = Some(GsBufferType::CUDA(allocator));
@@ -525,6 +532,12 @@ pub(crate) fn init(
                         }
                         None => render(state, Instant::now()),
                     };
+                }
+                Event::Msg(Command::UpdateCUDABufferPool(pool)) => {
+                    tracing::info!("Updating CUDA buffer pool");
+                    if let Some(GsBufferType::CUDA(ref mut cuda_buf)) = state.output_buffer {
+                        cuda_buf.buffer_pool = Some(pool);
+                    }
                 }
                 Event::Msg(Command::Quit) | Event::Closed => {
                     state.should_quit = true;

--- a/wayland-display-core/src/lib.rs
+++ b/wayland-display-core/src/lib.rs
@@ -2,6 +2,8 @@ use smithay::backend::SwapBuffersError;
 use smithay::backend::drm::CreateDrmNodeError;
 pub use smithay::reexports::calloop::channel::{Channel, Sender, channel};
 
+use crate::utils::allocator::cuda::CUDABufferPool;
+use crate::utils::device::gpu::GPUDevice;
 pub use smithay::backend::allocator::{
     Format as DrmFormat, Fourcc, Modifier as DrmModifier, Vendor as DrmVendor, format::FormatSet,
 };
@@ -12,8 +14,6 @@ use std::str::FromStr;
 use std::sync::mpsc::{self, Receiver, SyncSender};
 use std::thread::JoinHandle;
 use utils::RenderTarget;
-
-use crate::utils::device::gpu::GPUDevice;
 
 pub(crate) mod comp;
 #[cfg(test)]
@@ -30,6 +30,7 @@ pub enum Command {
         SyncSender<Result<gst::Buffer, SwapBuffersError>>,
         Option<Tracer>,
     ),
+    UpdateCUDABufferPool(CUDABufferPool),
     KeyboardInput(u32, KeyState),
     PointerMotion(Point<f64, Logical>),
     PointerMotionAbsolute(Point<f64, Logical>),

--- a/wayland-display-core/src/utils/allocator/cuda/ffi.rs
+++ b/wayland-display-core/src/utils/allocator/cuda/ffi.rs
@@ -139,7 +139,6 @@ fn gst_dma_video_info_to_video_info(
 
 #[link(name = "EGL")]
 unsafe extern "C" {
-    pub(crate) fn eglGetCurrentDisplay() -> EGLDisplay;
     pub(crate) fn eglGetProcAddress(procname: *const c_char) -> *mut c_void;
 }
 

--- a/wayland-display-core/src/utils/allocator/cuda/ffi.rs
+++ b/wayland-display-core/src/utils/allocator/cuda/ffi.rs
@@ -261,16 +261,13 @@ impl Drop for CudaContextGuard {
 pub(crate) const GST_BUFFER_POOL_OPTION_VIDEO_META: &[u8] = b"GstBufferPoolOptionVideoMeta\0";
 const GST_MAP_CUDA: u32 = gst_ffi::GST_MAP_FLAG_LAST << 1;
 
-pub(crate) fn alloc_copy_gst_memory(
-    egl_frame: CUeglFrame,
-    cuda_context: &CUDAContext,
-    dma_video_info: VideoInfoDmaDrm,
+pub(crate) fn acquire_or_alloc_buffer(
     buffer_pool: Option<GstBufferPool>,
-) -> Result<gst::memory::Memory, Box<dyn std::error::Error>> {
-    let mut video_info = gst_dma_video_info_to_video_info(&dma_video_info)?;
-
-    let (gst_memory, stream) = if let Some(pool) = buffer_pool {
-        // Acquire buffer from pool
+    cuda_context: &CUDAContext,
+    video_info: &VideoInfoDmaDrm,
+) -> Result<gst::Buffer, Box<dyn std::error::Error>> {
+    if let Some(pool) = buffer_pool {
+        // Use the pool if available
         let mut gst_buffer: *mut gst_ffi::GstBuffer = ptr::null_mut();
         let result = unsafe {
             gst::ffi::gst_buffer_pool_acquire_buffer(
@@ -288,40 +285,54 @@ pub(crate) fn alloc_copy_gst_memory(
             return Err("Acquired buffer is null".into());
         }
 
-        // Get the memory from the buffer
-        let gst_memory = unsafe { gst_ffi::gst_buffer_peek_memory(gst_buffer, 0) };
-        if gst_memory.is_null() {
-            unsafe { gst_ffi::gst_buffer_unref(gst_buffer) };
-            return Err("Failed to get memory from pooled buffer".into());
-        }
-
-        // We need to ref the memory since we're returning it separately
-        unsafe { gst_ffi::gst_memory_ref(gst_memory) };
-
-        // Unref the buffer (the memory is still valid since we ref'd it)
-        unsafe { gst_ffi::gst_buffer_unref(gst_buffer) };
-
-        let cuda_stream = cuda_context
-            .stream
-            .clone()
-            .expect("Cuda context without a stream");
-
-        (gst_memory, cuda_stream.stream)
+        Ok(unsafe { gst::Buffer::from_glib_full(gst_buffer) })
     } else {
         // Fallback to direct allocation
+        tracing::debug!("No buffer pool available, allocating directly");
+        let mut gst_video_info = gst_dma_video_info_to_video_info(video_info)?;
         let stream = unsafe { std::mem::zeroed() };
         let gst_memory = unsafe {
-            gst_cuda_allocator_alloc(ptr::null_mut(), cuda_context.ptr, stream, &mut video_info)
+            gst_cuda_allocator_alloc(
+                ptr::null_mut(),
+                cuda_context.ptr,
+                stream,
+                &mut gst_video_info,
+            )
         };
         if gst_memory.is_null() {
             return Err("Failed to allocate GST CUDA memory".into());
         }
-        (gst_memory, stream)
-    };
 
-    let stream_handle = unsafe { gst_cuda_stream_get_handle(stream) };
+        let mut buffer = gst::Buffer::new();
+        let buffer_ref = buffer.get_mut().unwrap();
+        buffer_ref.append_memory(unsafe { gst::Memory::from_glib_full(gst_memory) });
 
-    // Map the GStreamer memory to get destination device pointer
+        Ok(buffer)
+    }
+}
+
+pub(crate) fn copy_to_gst_buffer(
+    egl_frame: CUeglFrame,
+    gst_buffer: &mut gst::Buffer,
+    cuda_context: &CUDAContext,
+    dma_video_info: &VideoInfoDmaDrm,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let video_info = gst_dma_video_info_to_video_info(dma_video_info)?;
+
+    let stream_handle = cuda_context
+        .stream
+        .as_ref()
+        .map(|s| unsafe { gst_cuda_stream_get_handle(s.stream) })
+        .unwrap_or(unsafe { std::mem::zeroed() });
+
+    // Get memory from the buffer
+    let gst_memory = unsafe { gst_ffi::gst_buffer_peek_memory(gst_buffer.as_mut_ptr(), 0) };
+
+    if gst_memory.is_null() {
+        return Err("Failed to get memory from buffer".into());
+    }
+
+    // Map the GStreamer memory
     let mut map_info: gst_ffi::GstMapInfo = unsafe { std::mem::zeroed() };
     let map_success = unsafe {
         gst_ffi::gst_memory_map(
@@ -332,27 +343,27 @@ pub(crate) fn alloc_copy_gst_memory(
     };
 
     if map_success == glib_ffi::GFALSE {
-        unsafe { gst_ffi::gst_memory_unref(gst_memory) };
         return Err("Failed to map GStreamer CUDA memory".into());
     }
 
     let dst_device_ptr = map_info.data as CUdeviceptr;
 
-    // Copy from EGL frame to GStreamer memory for each plane
     let _cuda_context_guard = CudaContextGuard::new(cuda_context)?;
+
+    // Copy from EGL frame to GStreamer memory for each plane
     for plane in 0..egl_frame.plane_count as usize {
         let mut copy_params: CUDA_MEMCPY2D = unsafe { std::mem::zeroed() };
 
         // Set up source (from EGL frame)
         unsafe {
             match egl_frame.frame_type {
+                // Array type
                 0 => {
-                    // Array type
                     copy_params.srcMemoryType = CU_MEMORYTYPE_ARRAY;
                     copy_params.srcArray = egl_frame.frame.p_array[plane];
                 }
+                // Pitched pointer type
                 1 => {
-                    // Pitched pointer type
                     copy_params.srcMemoryType = CU_MEMORYTYPE_DEVICE;
                     copy_params.srcDevice = egl_frame.frame.p_pitch[plane] as CUdeviceptr;
                     copy_params.srcPitch = egl_frame.pitch as usize;
@@ -366,9 +377,8 @@ pub(crate) fn alloc_copy_gst_memory(
         copy_params.dstMemoryType = CU_MEMORYTYPE_DEVICE;
         copy_params.dstDevice = dst_device_ptr + video_info.offset[plane] as u64;
         copy_params.dstPitch = video_info.stride[plane] as usize;
-
-        // Set copy dimensions
         copy_params.WidthInBytes = video_info.stride[plane] as usize;
+        // Set copy dimensions
         copy_params.Height = match plane {
             0 => dma_video_info.height() as usize, // Y plane (or single plane)
             _ => {
@@ -384,17 +394,9 @@ pub(crate) fn alloc_copy_gst_memory(
         cuda_call!(CuMemcpy2DAsync(&copy_params, stream_handle))?;
     }
 
-    match cuda_call!(cuStreamSynchronize(stream_handle)) {
-        Ok(_) => {
-            unsafe { gst_ffi::gst_memory_unmap(gst_memory, &mut map_info) };
-            Ok(unsafe { gst::Memory::from_glib_full(gst_memory) })
-        }
-        Err(error) => {
-            unsafe { gst_ffi::gst_memory_unmap(gst_memory, &mut map_info) };
-            unsafe { gst_ffi::gst_memory_unref(gst_memory) };
-            Err(format!("Failed to synchronize CUDA stream: {}", error).into())
-        }
-    }
+    // Safe to unmap without synchronization as the copy is async
+    unsafe { gst_ffi::gst_memory_unmap(gst_memory, &mut map_info) };
+    Ok(())
 }
 
 pub(crate) fn cuda_result_to_string(result: CUresult) -> &'static str {

--- a/wayland-display-core/src/utils/allocator/cuda/mod.rs
+++ b/wayland-display-core/src/utils/allocator/cuda/mod.rs
@@ -12,6 +12,7 @@ use smithay::backend::egl::ffi::egl::types::{EGLDisplay, EGLImageKHR, EGLint};
 use std::os::fd::AsRawFd;
 use std::os::raw::{c_char, c_uint};
 use std::ptr;
+use std::sync::Arc;
 
 mod ffi;
 
@@ -51,6 +52,7 @@ impl EglExtensions {
 pub struct EGLImage {
     image: EGLImageKHR,
     destroy_fn: PFN_eglDestroyImageKHR,
+    egl_display: Arc<EGLDisplay>,
 }
 
 impl EGLImage {
@@ -130,6 +132,7 @@ impl EGLImage {
         if egl_image != ffi::EGL_NO_IMAGE_KHR {
             Ok(EGLImage {
                 image: egl_image,
+                egl_display: Arc::new(egl_display.clone()),
                 destroy_fn: egl_ext.destroy_image,
             })
         } else {
@@ -141,7 +144,7 @@ impl EGLImage {
 impl Drop for EGLImage {
     fn drop(&mut self) {
         unsafe {
-            (self.destroy_fn)(ffi::eglGetCurrentDisplay(), self.image);
+            (self.destroy_fn)(*self.egl_display, self.image);
         }
     }
 }

--- a/wayland-display-core/src/utils/allocator/cuda/mod.rs
+++ b/wayland-display-core/src/utils/allocator/cuda/mod.rs
@@ -4,7 +4,7 @@ use ffi::{GstCudaContext, PFN_eglDestroyImageKHR, eglGetProcAddress};
 use gst::glib::ffi as glib_ffi;
 use gst::glib::translate::ToGlibPtr;
 use gst::query::Allocation;
-use gst::{Buffer as GstBuffer, BufferPool, Element, QueryRef};
+use gst::{Buffer as GstBuffer, Element, QueryRef};
 use gst_video::{VideoFormat, VideoInfoDmaDrm, VideoMeta};
 use smithay::backend::allocator::Buffer;
 use smithay::backend::allocator::dmabuf::Dmabuf;
@@ -47,6 +47,7 @@ impl EglExtensions {
     }
 }
 
+#[derive(Debug)]
 pub struct EGLImage {
     image: EGLImageKHR,
     destroy_fn: PFN_eglDestroyImageKHR,
@@ -406,6 +407,7 @@ impl CUDAContext {
     }
 }
 
+#[derive(Debug)]
 pub struct CUDAImage {
     cuda_graphic_resource: CUgraphicsResource,
 }
@@ -442,40 +444,37 @@ impl CUDAImage {
             0
         ))?;
 
-        // Create Gstreamer memory
-        let gst_memory = ffi::alloc_copy_gst_memory(
-            egl_frame,
-            cuda_context,
-            dma_video_info.clone(),
+        // Acquire buffer from pool or allocate directly
+        let mut buffer = ffi::acquire_or_alloc_buffer(
             buffer_pool.as_ref().map(|p| p.pool),
+            cuda_context,
+            &dma_video_info,
         )?;
 
-        // Create the buffer using GStreamer Rust bindings
-        let mut buffer = gst::Buffer::new();
-        {
-            let buffer_ref = buffer.get_mut().unwrap();
-            buffer_ref.append_memory(gst_memory);
+        // Copy data to the buffer
+        ffi::copy_to_gst_buffer(egl_frame, &mut buffer, cuda_context, &dma_video_info)?;
 
-            let video_format = match VideoFormat::from_fourcc(dma_video_info.fourcc()) {
-                VideoFormat::Unknown => {
-                    tracing::debug!(
-                        "Failed to convert fourcc to video format: {:?}",
-                        dma_video_info.fourcc()
-                    );
-                    VideoFormat::Bgrx // Fallback
-                }
-                format => format,
-            };
+        // Add video meta
+        let video_format = match VideoFormat::from_fourcc(dma_video_info.fourcc()) {
+            VideoFormat::Unknown => {
+                tracing::debug!(
+                    "Failed to convert fourcc to video format: {:?}",
+                    dma_video_info.fourcc()
+                );
+                VideoFormat::Bgrx // Fallback
+            }
+            format => format,
+        };
 
-            VideoMeta::add(
-                buffer_ref,
-                gst_video::VideoFrameFlags::empty(),
-                video_format,
-                dma_video_info.width(),
-                dma_video_info.height(),
-                // TODO: Add stride and offset metadata here
-            )?;
-        }
+        let buffer_ref = buffer.get_mut().unwrap();
+        VideoMeta::add(
+            buffer_ref,
+            gst_video::VideoFrameFlags::empty(),
+            video_format,
+            dma_video_info.width(),
+            dma_video_info.height(),
+            // TODO: Add stride and offset metadata here
+        )?;
 
         Ok(buffer)
     }

--- a/wayland-display-core/src/utils/allocator/mod.rs
+++ b/wayland-display-core/src/utils/allocator/mod.rs
@@ -11,6 +11,7 @@ use smithay::backend::allocator::dmabuf::{Dmabuf, DmabufAllocator};
 use smithay::backend::allocator::gbm::{GbmAllocator, GbmBufferFlags, GbmDevice};
 use smithay::backend::allocator::{Allocator, Buffer, Fourcc};
 use smithay::backend::drm::DrmNode;
+use smithay::backend::egl::ffi::egl::types::EGLDisplay;
 use smithay::backend::renderer::gles::{GlesError, GlesRenderbuffer, GlesRenderer, GlesTarget};
 use smithay::backend::renderer::{Bind, ExportMem, Offscreen, Renderer};
 use smithay::reexports::drm::buffer::DrmFourcc;
@@ -19,6 +20,7 @@ use smithay::reexports::rustix::fs::{SeekFrom, seek};
 use smithay::utils::{DeviceFd, Rectangle};
 use std::fs::File;
 use std::os::fd::{AsFd, AsRawFd, OwnedFd};
+use std::sync::Arc;
 
 #[derive(Debug, Clone)]
 pub struct GsGlesbuffer {
@@ -130,8 +132,11 @@ pub struct GsCUDABuf {
     buffer: Dmabuf,
     video_info: VideoInfoDmaDrm,
     cuda_context: CUDAContext,
-    buffer_pool: Option<CUDABufferPool>,
+    // TODO: Set in compositor by UpdateCUDABufferPool, is this fine/ideal?
+    pub(crate) buffer_pool: Option<CUDABufferPool>,
     egl_extensions: EglExtensions,
+    // Cached for CUDA needs
+    cuda_image: Arc<CUDAImage>,
 }
 
 impl GsCUDABuf {
@@ -140,6 +145,7 @@ impl GsCUDABuf {
         cuda_context: CUDAContext,
         video_info: VideoInfoDmaDrm,
         buffer_pool: Option<CUDABufferPool>,
+        egl_display: &EGLDisplay,
     ) -> Option<Self> {
         tracing::debug!("Creating CUDA buffer from {:?}", &video_info);
         let drm_fourcc = gst_video_format_to_drm_fourcc(&video_info)?;
@@ -162,13 +168,26 @@ impl GsCUDABuf {
         );
 
         match result {
-            Ok(buffer) => Some(GsCUDABuf {
-                buffer,
-                video_info,
-                cuda_context,
-                buffer_pool,
-                egl_extensions: EglExtensions::new().expect("Failed to get EGL extensions"),
-            }),
+            Ok(buffer) => {
+                let egl_extensions = EglExtensions::new().expect("Failed to get EGL extensions");
+
+                // Create EGLImage once during initialization
+                let egl_image = EGLImage::from(&buffer, egl_display, &egl_extensions)
+                    .expect("Failed to create EGLImage from DMA-BUF");
+
+                // Create CUDAImage once during initialization
+                let cuda_image = CUDAImage::from(&egl_image, &cuda_context)
+                    .expect("Failed to create CUDA image from EGLImage");
+
+                Some(GsCUDABuf {
+                    buffer,
+                    video_info,
+                    cuda_context,
+                    buffer_pool,
+                    egl_extensions,
+                    cuda_image: Arc::new(cuda_image),
+                })
+            }
             Err(_) => {
                 tracing::warn!("Failed to create DMA buffer: {}", result.unwrap_err());
                 None
@@ -314,23 +333,14 @@ impl GsBuffer<GlesRenderer> for GsBufferType {
                 }
                 gst_buffer
             }
-            GsBufferType::CUDA(buffer) => {
-                let egl_display = renderer.egl_context().display().get_display_handle().handle;
-                let egl_image =
-                    EGLImage::from(&buffer.buffer, &egl_display, &buffer.egl_extensions)
-                        .expect("Failed to create EGLImage from DMA-BUF");
-
-                let cuda_image = CUDAImage::from(&egl_image, &buffer.cuda_context)
-                    .expect("Failed to create CUDA image from EGLImage");
-
-                cuda_image
-                    .to_gst_buffer(
-                        buffer.video_info.clone(),
-                        &buffer.cuda_context,
-                        &buffer.buffer_pool,
-                    )
-                    .expect("Failed to create Gstreamer buffer from CUDA image")
-            }
+            GsBufferType::CUDA(buffer) => buffer
+                .cuda_image
+                .to_gst_buffer(
+                    buffer.video_info.clone(),
+                    &buffer.cuda_context,
+                    &buffer.buffer_pool,
+                )
+                .expect("Failed to create Gstreamer buffer from CUDA image"),
         }
     }
 
@@ -620,11 +630,13 @@ mod tests {
             .activate()
             .expect("Failed to activate buffer pool");
 
+        let egl_display = renderer.egl_context().display().get_display_handle().handle;
         let raw_buffer = GsCUDABuf::new(
             render_node,
             gst_cuda_ctx.clone(),
             drm_video_info.clone(),
             Some(buffer_pool),
+            &egl_display,
         );
         assert!(raw_buffer.is_some());
 

--- a/wayland-display-core/src/utils/allocator/mod.rs
+++ b/wayland-display-core/src/utils/allocator/mod.rs
@@ -134,7 +134,10 @@ pub struct GsCUDABuf {
     cuda_context: CUDAContext,
     // TODO: Set in compositor by UpdateCUDABufferPool, is this fine/ideal?
     pub(crate) buffer_pool: Option<CUDABufferPool>,
+    #[allow(dead_code)]
     egl_extensions: EglExtensions,
+    #[allow(dead_code)]
+    egl_image: Arc<EGLImage>,
     // Cached for CUDA needs
     cuda_image: Arc<CUDAImage>,
 }
@@ -185,6 +188,7 @@ impl GsCUDABuf {
                     cuda_context,
                     buffer_pool,
                     egl_extensions,
+                    egl_image: Arc::new(egl_image),
                     cuda_image: Arc::new(cuda_image),
                 })
             }


### PR DESCRIPTION
Profiling with flamegraph showed that some resource allocations were eating plenty of CPU cycles each frame, those are now cached, as the pointer location stays same things work out, but without recreating the resource each time :slightly_smiling_face:

Secondly, `settings.cudabuffer_pool = Some(pool);` was set in `decide_allocation`, which happened later when settings were already communicated to wayland-display-core, so I added extra command to send the buffer pool later on separately, this works out from my testing just before gstreamer pipeline starts rolling.

Thirdly, now that buffer pool is set and available during runtime, I changed `alloc_copy_gst_memory` to return straight buffers instead and separated copy-op to it's own method. Syncing the CUDA stream after unmap was also eating some CPU cycles from simply waiting, as the `CuMemcpy2DAsync` is async, it seems to be fine to let the CUDA runtime handle the unmap later after the async-op is done.

I might've misplaced some comments from original locations, and I'm not sure if `UpdateCUDABufferPool` command is what you'd want so I marked that as TODO :sweat_smile:

Let me know of any issues :pray: 