### PR TITLE
feat: get cuda_device_id from render node

### DIFF
--- a/wayland-display-core/src/utils/allocator/mod.rs
+++ b/wayland-display-core/src/utils/allocator/mod.rs
@@ -425,6 +425,7 @@ pub fn gst_video_format_to_drm_modifier(format: &VideoInfoDmaDrm) -> Option<DrmM
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::utils::device::gpu::get_cuda_device_id_from_drm_node;
     use crate::utils::renderer::setup_renderer;
     use crate::utils::tests::test_init;
     use smithay::backend::renderer::Frame;
@@ -598,6 +599,13 @@ mod tests {
 
         let render_node =
             DrmNode::from_path("/dev/dri/renderD129").expect("Failed to create render node");
+
+        // Get CUDA device ID from render_node before it's moved to setup_renderer
+        let cuda_device_id = get_cuda_device_id_from_drm_node(render_node)
+            .expect("Failed to get CUDA device ID from render_node");
+
+        println!("CUDA device ID: {}", cuda_device_id);
+
         let mut renderer = setup_renderer(Some(render_node));
         let caps = gst_video::VideoCapsBuilder::new()
             .features([gstreamer_allocators::CAPS_FEATURE_MEMORY_DMABUF])
@@ -621,7 +629,7 @@ mod tests {
             Some(Modifier::Unrecognized(0x0300000000606010))
         );
 
-        let gst_cuda_ctx = CUDAContext::new(0).expect("Failed to create CUDA context");
+        let gst_cuda_ctx = CUDAContext::new(cuda_device_id).expect("Failed to create CUDA context");
 
         let cuda_caps = gst_video::VideoCapsBuilder::new()
             .features([cuda::CAPS_FEATURE_MEMORY_CUDA_MEMORY])

--- a/wayland-display-core/src/utils/device/gpu.rs
+++ b/wayland-display-core/src/utils/device/gpu.rs
@@ -135,3 +135,105 @@ fn gnu_dev_minor(dev: u64) -> u32 {
     minor |= ((dev >> 12) & 0xffffff00) as u32;
     minor
 }
+
+/// Get PCI bus ID from NVIDIA render-node
+/// 
+/// # Arguments
+/// * `render_path` - DRM render node path, e.g., "/dev/dri/renderD128"
+/// 
+/// # Returns
+/// Returns PCI bus ID in format "00000000:01:00.0"
+pub fn get_pci_bus_id_from_render_node(render_path: &str) -> Result<String, Box<dyn Error>> {
+    let card = get_card_from_render_node(render_path)?;
+    
+    // Read PCI information from /sys/class/drm/cardX/device/uevent
+    let uevent_path = format!("/sys/class/drm/{}/device/uevent", card);
+    let uevent_content = fs::read_to_string(uevent_path)?;
+    
+    // Find PCI_SLOT_NAME in format "0000:01:00.0"
+    for line in uevent_content.lines() {
+        if line.starts_with("PCI_SLOT_NAME=") {
+            let pci_slot = line.strip_prefix("PCI_SLOT_NAME=").unwrap();
+            // Convert to nvidia-smi format: "00000000:01:00.0"
+            let parts: Vec<&str> = pci_slot.split(':').collect();
+            if parts.len() == 3 {
+                return Ok(format!("00000000:{}:{}", parts[1], parts[2]));
+            }
+        }
+    }
+    
+    Err("Failed to find PCI bus ID from render node".into())
+}
+
+/// Get CUDA device ID from NVIDIA render-node (without using nvidia-smi)
+/// 
+/// # Arguments
+/// * `render_path` - DRM render node path, e.g., "/dev/dri/renderD128"
+/// 
+/// # Returns
+/// Returns CUDA device ID (typically 0, 1, 2, ...)
+/// 
+/// # Method
+/// 1. Get PCI bus ID from render-node (format: 0000:01:00.0)
+/// 2. Iterate through /proc/driver/nvidia/gpus/ directory to find matching PCI bus ID
+/// 3. CUDA device ID is assigned in alphabetical order of PCI bus IDs (this is CUDA's default behavior)
+/// 
+/// # Note
+/// This method does not depend on nvidia-smi, but requires NVIDIA driver to be loaded
+/// and /proc/driver/nvidia/gpus/ directory to be accessible
+pub fn get_cuda_device_id_from_render_node(render_path: &str) -> Result<i32, Box<dyn Error>> {
+    // Get PCI bus ID from render-node (format: 0000:01:00.0)
+    let card = get_card_from_render_node(render_path)?;
+    let uevent_path = format!("/sys/class/drm/{}/device/uevent", card);
+    let uevent_content = fs::read_to_string(uevent_path)?;
+    
+    let mut pci_slot_name: Option<&str> = None;
+    for line in uevent_content.lines() {
+        if line.starts_with("PCI_SLOT_NAME=") {
+            pci_slot_name = Some(line.strip_prefix("PCI_SLOT_NAME=").unwrap());
+            break;
+        }
+    }
+    
+    let pci_slot = pci_slot_name.ok_or("Failed to find PCI_SLOT_NAME from render node")?;
+    
+    // Read /proc/driver/nvidia/gpus/ directory
+    // Each subdirectory name in this directory is the PCI bus ID of the corresponding GPU
+    let nvidia_gpus_dir = "/proc/driver/nvidia/gpus";
+    let entries: Vec<_> = fs::read_dir(nvidia_gpus_dir)
+        .map_err(|e| format!("Failed to read {}: {}. Make sure NVIDIA driver is loaded and accessible.", nvidia_gpus_dir, e))?
+        .collect::<Result<Vec<_>, _>>()?;
+    
+    if entries.is_empty() {
+        return Err("No NVIDIA GPUs found in /proc/driver/nvidia/gpus/".into());
+    }
+    
+    // Collect PCI bus IDs of all GPUs
+    let mut gpus: Vec<String> = Vec::new();
+    for entry in &entries {
+        let dir_name = entry.file_name().to_string_lossy().to_string();
+        // Directory name is the PCI bus ID (format: 0000:01:00.0)
+        gpus.push(dir_name);
+    }
+    
+    // Sort by PCI bus ID
+    // CUDA device ID is assigned in alphabetical order of PCI bus IDs (this is CUDA's default behavior)
+    gpus.sort();
+    
+    // Find matching PCI bus ID, the index is the CUDA device ID
+    for (cuda_id, pci_id) in gpus.iter().enumerate() {
+        if pci_id == pci_slot {
+            return Ok(cuda_id as i32);
+        }
+    }
+    
+    Err(format!("No CUDA device found for PCI bus ID: {}. Available GPUs: {:?}", 
+        pci_slot, gpus).into())
+}
+
+/// Get CUDA device ID from DrmNode
+pub fn get_cuda_device_id_from_drm_node(drm_node: DrmNode) -> Result<i32, Box<dyn Error>> {
+    let render_path = drm_node.dev_path()
+        .ok_or("Failed to get device path from DrmNode")?;
+    get_cuda_device_id_from_render_node(render_path.to_str().unwrap())
+}


### PR DESCRIPTION
This PR adds support for selecting the correct `cuda_device_id` based on the `render_node` in environments with multiple NVIDIA GPUs. 

This resolves the https://github.com/games-on-whales/wolf/issues/233 issue where wolf cannot use the zero_copy feature on systems with multiple NVIDIA graphics cards.

The following is the pci path info about the GPUs:

```bash
$ ls -alh /dev/dri/by-path/
lrwxrwxrwx 1 root root   8 Aug  1 07:23 pci-0000:01:00.0-card -> ../card4
lrwxrwxrwx 1 root root  13 Aug  1 07:23 pci-0000:01:00.0-render -> ../renderD131
lrwxrwxrwx 1 root root   8 Aug  1 07:23 pci-0000:23:00.0-card -> ../card3
lrwxrwxrwx 1 root root  13 Aug  1 07:23 pci-0000:23:00.0-render -> ../renderD130
lrwxrwxrwx 1 root root   8 Aug  1 07:23 pci-0000:41:00.0-card -> ../card2
lrwxrwxrwx 1 root root  13 Aug  1 07:23 pci-0000:41:00.0-render -> ../renderD129
lrwxrwxrwx 1 root root   8 Aug  1 07:23 pci-0000:61:00.0-card -> ../card1
lrwxrwxrwx 1 root root  13 Aug  1 07:23 pci-0000:61:00.0-render -> ../renderD128
lrwxrwxrwx 1 root root   8 Aug  1 07:23 pci-0000:63:00.0-card -> ../card0
lrwxrwxrwx 1 root root   8 Aug  1 07:23 pci-0000:81:00.0-card -> ../card8
lrwxrwxrwx 1 root root  13 Aug  1 07:23 pci-0000:81:00.0-render -> ../renderD135
lrwxrwxrwx 1 root root   8 Aug  1 07:23 pci-0000:a1:00.0-card -> ../card7
lrwxrwxrwx 1 root root  13 Aug  1 07:23 pci-0000:a1:00.0-render -> ../renderD134
lrwxrwxrwx 1 root root   8 Aug  1 07:23 pci-0000:c1:00.0-card -> ../card6
lrwxrwxrwx 1 root root  13 Aug  1 07:23 pci-0000:c1:00.0-render -> ../renderD133
lrwxrwxrwx 1 root root   8 Aug  1 07:23 pci-0000:e1:00.0-card -> ../card5
lrwxrwxrwx 1 root root  13 Aug  1 07:23 pci-0000:e1:00.0-render -> ../renderD132

$ nvidia-smi --query-gpu=index,pci.bus_id --format=csv,noheader
0, 00000000:01:00.0
1, 00000000:23:00.0
2, 00000000:41:00.0
3, 00000000:61:00.0
4, 00000000:81:00.0
5, 00000000:A1:00.0
6, 00000000:C1:00.0
7, 00000000:E1:00.0

$ ls -alh /proc/driver/nvidia/gpus/ 
dr-xr-xr-x  5 root root   0 Aug  1 07:25 0000:01:00.0
dr-xr-xr-x  5 root root   0 Aug  1 07:25 0000:23:00.0
dr-xr-xr-x  5 root root   0 Aug  1 07:25 0000:41:00.0
dr-xr-xr-x  5 root root   0 Aug  1 07:25 0000:61:00.0
dr-xr-xr-x  5 root root   0 Aug  1 07:25 0000:81:00.0
dr-xr-xr-x  5 root root   0 Aug  1 07:25 0000:a1:00.0
dr-xr-xr-x  5 root root   0 Aug  1 07:25 0000:c1:00.0
dr-xr-xr-x  5 root root   0 Aug  1 07:25 0000:e1:00.0
```