### PR TITLE
feat: Simple clipboard

### DIFF
--- a/gst-plugin-wayland-display/src/waylandsrc/imp.rs
+++ b/gst-plugin-wayland-display/src/waylandsrc/imp.rs
@@ -176,6 +176,12 @@ impl EventHandler for WaylandDisplaySrc {
             } else if structure.has_name("TouchCancel") {
                 let _ = self.command_tx.send(Command::TouchCancel);
                 return true;
+            } else if structure.has_name("SetClipboard") {
+                let content = structure
+                    .get::<String>("content")
+                    .expect("Should contain text content");
+                let _ = self.command_tx.send(Command::SetClipboard(content));
+                return true;
             }
         }
         false

--- a/wayland-display-core/src/comp/mod.rs
+++ b/wayland-display-core/src/comp/mod.rs
@@ -8,6 +8,7 @@ use smithay::backend::renderer::gles::GlesRenderer;
 use smithay::reexports::gbm::BufferObjectFlags;
 use smithay::wayland::dmabuf::DmabufFeedbackBuilder;
 use smithay::wayland::presentation::Refresh;
+use smithay::wayland::selection::data_device::set_data_device_selection;
 use smithay::{
     backend::{
         allocator::{Fourcc, dmabuf::Dmabuf},
@@ -675,6 +676,14 @@ pub(crate) fn init(
                 }
                 Event::Msg(Command::TouchFrame) => {
                     state.touch_frame();
+                }
+                Event::Msg(Command::SetClipboard(contents)) => {
+                    set_data_device_selection(
+                        &state.dh,
+                        &state.seat,
+                        vec!["text/plain".to_string()],
+                        contents,
+                    );
                 }
             };
         })

--- a/wayland-display-core/src/lib.rs
+++ b/wayland-display-core/src/lib.rs
@@ -45,6 +45,7 @@ pub enum Command {
     TouchMotion(u32, Point<f64, Logical>),
     TouchCancel,
     TouchFrame,
+    SetClipboard(String),
     Quit,
 }
 

--- a/wayland-display-core/src/wayland/handlers/data_device.rs
+++ b/wayland-display-core/src/wayland/handlers/data_device.rs
@@ -1,19 +1,33 @@
-use smithay::wayland::selection::SelectionHandler;
+use crate::comp::State;
+use smithay::input::Seat;
+use smithay::wayland::selection::{SelectionHandler, SelectionTarget};
 use smithay::{
     delegate_data_device,
     wayland::selection::data_device::{
         ClientDndGrabHandler, DataDeviceHandler, DataDeviceState, ServerDndGrabHandler,
     },
 };
-
-use crate::comp::State;
+use std::io::Write;
+use std::os::fd::{FromRawFd, IntoRawFd, OwnedFd};
 
 impl ServerDndGrabHandler for State {}
 
 impl ClientDndGrabHandler for State {}
 
 impl SelectionHandler for State {
-    type SelectionUserData = ();
+    type SelectionUserData = String;
+
+    fn send_selection(
+        &mut self,
+        _ty: SelectionTarget,
+        _mime_type: String,
+        fd: OwnedFd,
+        _seat: Seat<Self>,
+        user_data: &Self::SelectionUserData,
+    ) {
+        let mut f = unsafe { std::fs::File::from_raw_fd(fd.into_raw_fd()) };
+        write!(&mut f, "{}", user_data).unwrap();
+    }
 }
 
 impl DataDeviceHandler for State {


### PR DESCRIPTION
Draft as unsure if can be done "safely" and if `set_data_device_selection` is even needed, should State keep track of the clipboard by itself?

I spent hours just looking for any kind of Smithay example code or documentation, it's **so** lacking, even in Cosmic DE's code I couldn't find anything useful.. So I just write to the FD; what could go wrong? :)

Image below shows clipboard text copied from host to container running gst-wayland-display. Currently limited to text-only, so no images etc.
<img width="1131" height="409" alt="image" src="https://github.com/user-attachments/assets/172787dd-47eb-42a0-9047-fffdfaf5a9ea" />