### PR TITLE
fix: add single pixel buffer protocol and use proper refresh value for damage tracking

### DIFF
--- a/wayland-display-core/src/comp/mod.rs
+++ b/wayland-display-core/src/comp/mod.rs
@@ -8,6 +8,7 @@ use smithay::backend::renderer::gles::GlesRenderer;
 use smithay::reexports::gbm::BufferObjectFlags;
 use smithay::wayland::dmabuf::DmabufFeedbackBuilder;
 use smithay::wayland::presentation::Refresh;
+use smithay::wayland::single_pixel_buffer::SinglePixelBufferState;
 use smithay::{
     backend::{
         allocator::{Fourcc, dmabuf::Dmabuf},
@@ -136,6 +137,7 @@ pub struct State {
     pub shm_state: ShmState,
     viewporter_state: ViewporterState,
     cursor_event_count: i32,
+    pub single_pixel_buffer_state: SinglePixelBufferState,
 }
 
 impl State {
@@ -158,6 +160,7 @@ impl State {
         let mut seat_state = SeatState::new();
         let shell_state = XdgShellState::new::<State>(&dh);
         let viewporter_state = ViewporterState::new::<State>(&dh);
+        let single_pixel_buffer_state = SinglePixelBufferState::new::<Self>(&dh);
 
         let render_node: Option<DrmNode> = render_target.clone().into();
 
@@ -252,6 +255,7 @@ impl State {
             shell_state,
             shm_state,
             viewporter_state,
+            single_pixel_buffer_state,
         }
     }
 }

--- a/wayland-display-core/src/comp/mod.rs
+++ b/wayland-display-core/src/comp/mod.rs
@@ -485,13 +485,14 @@ pub(crate) fn init(
                                     if rendered_damage {
                                         output_presentation_feedback.presented(
                                             state.clock.now(),
-                                            Refresh::Fixed(Duration::from_millis(
-                                                output
-                                                    .current_mode()
-                                                    .map(|mode| mode.refresh)
-                                                    .unwrap_or_default()
-                                                    as u64,
-                                            )),
+                                            output
+                                                .current_mode()
+                                                .map(|mode| {
+                                                    Refresh::fixed(Duration::from_secs_f64(
+                                                        1_000f64 / mode.refresh as f64,
+                                                    ))
+                                                })
+                                                .unwrap_or(Refresh::Unknown),
                                             0,
                                             wp_presentation_feedback::Kind::Vsync,
                                         );

--- a/wayland-display-core/src/wayland/handlers/compositor.rs
+++ b/wayland-display-core/src/wayland/handlers/compositor.rs
@@ -1,6 +1,6 @@
 use smithay::{
     backend::renderer::utils::on_commit_buffer_handler,
-    delegate_compositor,
+    delegate_compositor, delegate_single_pixel_buffer,
     desktop::PopupKind,
     reexports::{
         wayland_protocols::xdg::shell::server::xdg_toplevel::State as XdgState,
@@ -139,3 +139,4 @@ impl CompositorHandler for State {
 }
 
 delegate_compositor!(State);
+delegate_single_pixel_buffer!(State);


### PR DESCRIPTION
Partially resolves: https://github.com/games-on-whales/gow/pull/257

KDE Plasma is happy with this atleast, ~so I reckon Hyprland will be as well~. I'll test quickly though and edit this message.

Update: Hyprland is still borked, but hey, KDE works?