### PR TITLE
Update running outputs on resize

### DIFF
--- a/wayland-display-core/src/comp/mod.rs
+++ b/wayland-display-core/src/comp/mod.rs
@@ -262,6 +262,136 @@ impl State {
     }
 }
 
+/// Apply a newly-negotiated `GstVideoInfo` to the compositor state: create or update
+/// the (single) Output's mode, rebuild the damage tracker + allocator, recenter the
+/// pointer, and re-send configure to every mapped toplevel clamped to the new size.
+///
+/// Called from the `Command::VideoInfo` handler and from the test suite. The
+/// `output_already_running` path is what closes the resolution-switching gap --
+/// `space.map_output` must stay one-shot, but everything else is safe and desirable
+/// to re-run on every VideoInfo so connected clients observe the new state.
+pub(crate) fn apply_video_info(
+    state: &mut State,
+    video_info: GstVideoInfo,
+    render_target: &RenderTarget,
+    render_node: Option<DrmNode>,
+) {
+    let output_already_running = state.output.is_some();
+    if output_already_running {
+        tracing::info!("Output already running, updating with newly negotiated video info");
+    }
+    let base_info: VideoInfo = video_info.clone().into();
+    debug!(
+        "Requested video format: {} .to_fourcc() = {}",
+        base_info.format(),
+        base_info.format().to_fourcc()
+    );
+    let size: Size<i32, Physical> = (base_info.width() as i32, base_info.height() as i32).into();
+    let framerate = base_info.fps();
+    let duration = Duration::from_secs_f64(framerate.numer() as f64 / framerate.denom() as f64);
+
+    // init wayland objects
+    let output = state.output.get_or_insert_with(|| {
+        let output = Output::new(
+            "HEADLESS-1".into(),
+            PhysicalProperties {
+                make: "Virtual".into(),
+                model: "Wolf".into(),
+                size: (0, 0).into(),
+                subpixel: Subpixel::Unknown,
+            },
+        );
+        output.create_global::<State>(&state.dh);
+        output
+    });
+    let mode = OutputMode {
+        size: size.into(),
+        refresh: (duration.as_secs_f64() * 1000.0).round() as i32,
+    };
+    output.change_current_state(Some(mode), None, None, None);
+    output.set_preferred(mode);
+    let dtr = OutputDamageTracker::from_output(&output);
+
+    if !output_already_running {
+        state.space.map_output(&output, (0, 0));
+    }
+    state.dtr = Some(dtr);
+    let position = (size.w as f64 / 2.0, size.h as f64 / 2.0).into();
+    state.pointer_location = position;
+    state.pointer_absolute_location = position;
+    state.video_info = Some(video_info.clone().into());
+    match render_target {
+        RenderTarget::Hardware(_) => match video_info {
+            GstVideoInfo::RAW(base_info) => {
+                let allocator = GsGlesbuffer::new(&mut state.renderer, base_info)
+                    .expect("Failed to create GsGlesbuffer");
+                state.output_buffer = Some(GsBufferType::RAW(allocator));
+            }
+            GstVideoInfo::DMA(base_info) => {
+                let allocator = GsDmaBuf::new(render_node.unwrap(), base_info)
+                    .expect("Failed to create GsDmaBuf");
+                state.output_buffer = Some(GsBufferType::DMA(allocator));
+            }
+            #[cfg(feature = "cuda")]
+            GstVideoInfo::CUDA(base_info) => {
+                let egl_display = state
+                    .renderer
+                    .egl_context()
+                    .display()
+                    .get_display_handle()
+                    .handle;
+                let allocator = GsCUDABuf::new(
+                    render_node.unwrap(),
+                    base_info.cuda_context,
+                    base_info.video_info,
+                    Arc::new(Mutex::new(None)),
+                    &egl_display,
+                )
+                .expect("Failed to create GsCUDABuf");
+                state.output_buffer = Some(GsBufferType::CUDA(allocator));
+            }
+        },
+        RenderTarget::Software => {
+            let allocator = GsGlesbuffer::new(&mut state.renderer, base_info.clone())
+                .expect("Failed to create GsGlesbuffer");
+            state.output_buffer = Some(GsBufferType::RAW(allocator));
+        }
+    }
+
+    let new_size = size
+        .to_f64()
+        .to_logical(output.current_scale().fractional_scale())
+        .to_i32_round();
+    for window in state.space.elements() {
+        let toplevel = window.toplevel().unwrap();
+        let max_size = Rectangle::from_size(
+            with_states(toplevel.wl_surface(), |states| {
+                states
+                    .data_map
+                    .get::<XdgToplevelSurfaceData>()
+                    .map(|_attrs| {
+                        states
+                            .cached_state
+                            .get::<SurfaceCachedState>()
+                            .current()
+                            .max_size
+                    })
+            })
+            .unwrap_or(new_size),
+        );
+
+        let new_size = max_size
+            .intersection(Rectangle::from_size(new_size))
+            .map(|rect| rect.size);
+        toplevel.with_pending_state(|state| {
+            state.size = new_size;
+            state.states.set(XdgState::Fullscreen);
+            state.states.set(XdgState::Activated);
+        });
+        toplevel.send_configure();
+    }
+}
+
 pub(crate) fn init(
     command_src: Channel<Command>,
     render: impl Into<RenderTarget>,
@@ -300,126 +430,7 @@ pub(crate) fn init(
         .insert_source(command_src, move |event, _, state| {
             match event {
                 Event::Msg(Command::VideoInfo(video_info)) => {
-                    let output_already_running = state.output.is_some();
-                    if output_already_running {
-                        tracing::info!(
-                            "Output already running, updating with newly negotiated video info"
-                        );
-                    }
-                    let base_info: VideoInfo = video_info.clone().into();
-                    debug!(
-                        "Requested video format: {} .to_fourcc() = {}",
-                        base_info.format(),
-                        base_info.format().to_fourcc()
-                    );
-                    let size: Size<i32, Physical> =
-                        (base_info.width() as i32, base_info.height() as i32).into();
-                    let framerate = base_info.fps();
-                    let duration = Duration::from_secs_f64(
-                        framerate.numer() as f64 / framerate.denom() as f64,
-                    );
-
-                    // init wayland objects
-                    let output = state.output.get_or_insert_with(|| {
-                        let output = Output::new(
-                            "HEADLESS-1".into(),
-                            PhysicalProperties {
-                                make: "Virtual".into(),
-                                model: "Wolf".into(),
-                                size: (0, 0).into(),
-                                subpixel: Subpixel::Unknown,
-                            },
-                        );
-                        output.create_global::<State>(&state.dh);
-                        output
-                    });
-                    let mode = OutputMode {
-                        size: size.into(),
-                        refresh: (duration.as_secs_f64() * 1000.0).round() as i32,
-                    };
-                    output.change_current_state(Some(mode), None, None, None);
-                    output.set_preferred(mode);
-                    let dtr = OutputDamageTracker::from_output(&output);
-
-                    if !output_already_running {
-                        state.space.map_output(&output, (0, 0));
-                    }
-                    state.dtr = Some(dtr);
-                    let position = (size.w as f64 / 2.0, size.h as f64 / 2.0).into();
-                    state.pointer_location = position;
-                    state.pointer_absolute_location = position;
-                    state.video_info = Some(video_info.clone().into());
-                    match render_target {
-                        RenderTarget::Hardware(_) => match video_info {
-                            GstVideoInfo::RAW(base_info) => {
-                                let allocator = GsGlesbuffer::new(&mut state.renderer, base_info)
-                                    .expect("Failed to create GsGlesbuffer");
-                                state.output_buffer = Some(GsBufferType::RAW(allocator));
-                            }
-                            GstVideoInfo::DMA(base_info) => {
-                                let allocator = GsDmaBuf::new(render_node.unwrap(), base_info)
-                                    .expect("Failed to create GsDmaBuf");
-                                state.output_buffer = Some(GsBufferType::DMA(allocator));
-                            }
-                            #[cfg(feature = "cuda")]
-                            GstVideoInfo::CUDA(base_info) => {
-                                let egl_display = state
-                                    .renderer
-                                    .egl_context()
-                                    .display()
-                                    .get_display_handle()
-                                    .handle;
-                                let allocator = GsCUDABuf::new(
-                                    render_node.unwrap(),
-                                    base_info.cuda_context,
-                                    base_info.video_info,
-                                    Arc::new(Mutex::new(None)),
-                                    &egl_display,
-                                )
-                                .expect("Failed to create GsCUDABuf");
-                                state.output_buffer = Some(GsBufferType::CUDA(allocator));
-                            }
-                        },
-                        RenderTarget::Software => {
-                            let allocator =
-                                GsGlesbuffer::new(&mut state.renderer, base_info.clone())
-                                    .expect("Failed to create GsGlesbuffer");
-                            state.output_buffer = Some(GsBufferType::RAW(allocator));
-                        }
-                    }
-
-                    let new_size = size
-                        .to_f64()
-                        .to_logical(output.current_scale().fractional_scale())
-                        .to_i32_round();
-                    for window in state.space.elements() {
-                        let toplevel = window.toplevel().unwrap();
-                        let max_size = Rectangle::from_size(
-                            with_states(toplevel.wl_surface(), |states| {
-                                states
-                                    .data_map
-                                    .get::<XdgToplevelSurfaceData>()
-                                    .map(|_attrs| {
-                                        states
-                                            .cached_state
-                                            .get::<SurfaceCachedState>()
-                                            .current()
-                                            .max_size
-                                    })
-                            })
-                            .unwrap_or(new_size),
-                        );
-
-                        let new_size = max_size
-                            .intersection(Rectangle::from_size(new_size))
-                            .map(|rect| rect.size);
-                        toplevel.with_pending_state(|state| {
-                            state.size = new_size;
-                            state.states.set(XdgState::Fullscreen);
-                            state.states.set(XdgState::Activated);
-                        });
-                        toplevel.send_configure();
-                    }
+                    apply_video_info(state, video_info, &render_target, render_node.clone());
                 }
                 Event::Msg(Command::InputDevice(path)) => {
                     tracing::info!(path, "Adding input device.");

--- a/wayland-display-core/src/comp/mod.rs
+++ b/wayland-display-core/src/comp/mod.rs
@@ -39,6 +39,7 @@ use smithay::{
         },
         input::Libinput,
         wayland_protocols::wp::presentation_time::server::wp_presentation_feedback,
+        wayland_protocols::xdg::shell::server::xdg_toplevel::State as XdgState,
         wayland_server::{
             Display, DisplayHandle,
             backend::{ClientData, ClientId, DisconnectReason, GlobalId},
@@ -299,13 +300,9 @@ pub(crate) fn init(
         .insert_source(command_src, move |event, _, state| {
             match event {
                 Event::Msg(Command::VideoInfo(video_info)) => {
-                    // Only change the output if it's not running already
-                    // TODO: properly support automatic resolution switching with DMA buffers
-                    if state.output.is_some() {
-                        tracing::info!(
-                            "Output already running, ignoring newly negotiated video info"
-                        );
-                        return;
+                    let output_already_running = state.output.is_some();
+                    if output_already_running {
+                        tracing::info!("Output already running, updating negotiated video info");
                     }
                     let base_info: VideoInfo = video_info.clone().into();
                     debug!(
@@ -342,7 +339,9 @@ pub(crate) fn init(
                     output.set_preferred(mode);
                     let dtr = OutputDamageTracker::from_output(&output);
 
-                    state.space.map_output(&output, (0, 0));
+                    if !output_already_running {
+                        state.space.map_output(&output, (0, 0));
+                    }
                     state.dtr = Some(dtr);
                     let position = (size.w as f64 / 2.0, size.h as f64 / 2.0).into();
                     state.pointer_location = position;
@@ -412,7 +411,11 @@ pub(crate) fn init(
                         let new_size = max_size
                             .intersection(Rectangle::from_size(new_size))
                             .map(|rect| rect.size);
-                        toplevel.with_pending_state(|state| state.size = new_size);
+                        toplevel.with_pending_state(|state| {
+                            state.size = new_size;
+                            state.states.set(XdgState::Fullscreen);
+                            state.states.set(XdgState::Activated);
+                        });
                         toplevel.send_configure();
                     }
                 }

--- a/wayland-display-core/src/comp/mod.rs
+++ b/wayland-display-core/src/comp/mod.rs
@@ -302,7 +302,9 @@ pub(crate) fn init(
                 Event::Msg(Command::VideoInfo(video_info)) => {
                     let output_already_running = state.output.is_some();
                     if output_already_running {
-                        tracing::info!("Output already running, updating negotiated video info");
+                        tracing::info!(
+                            "Output already running, updating with newly negotiated video info"
+                        );
                     }
                     let base_info: VideoInfo = video_info.clone().into();
                     debug!(

--- a/wayland-display-core/src/tests/client.rs
+++ b/wayland-display-core/src/tests/client.rs
@@ -6,7 +6,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use wayland_backend::client::Backend;
 use wayland_client::protocol::wl_callback::WlCallback;
 use wayland_client::protocol::wl_display::WlDisplay;
-use wayland_client::protocol::{wl_callback, wl_pointer, wl_region};
+use wayland_client::protocol::{wl_callback, wl_output, wl_pointer, wl_region};
 use wayland_client::{
     Connection, Dispatch, EventQueue, QueueHandle, WEnum, delegate_noop,
     protocol::{
@@ -60,6 +60,8 @@ struct State {
     keyboard: Option<wl_keyboard::WlKeyboard>,
     windows: Vec<Window>,
     pub mouse_events: Vec<MouseEvents>,
+    pub output: Option<wl_output::WlOutput>,
+    pub output_events: Vec<wl_output::Event>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -137,6 +139,13 @@ impl Dispatch<wl_registry::WlRegistry, ()> for State {
                         registry.bind::<ZwpRelativePointerManagerV1, _, _>(name, version, qh, ()),
                     );
                 }
+                "wl_output" => {
+                    // The compositor only advertises wl_output after the first
+                    // VideoInfo has created it, so this branch may fire well after
+                    // initial registry enumeration.
+                    state.output =
+                        Some(registry.bind::<wl_output::WlOutput, _, _>(name, version, qh, ()));
+                }
                 _ => {}
             }
         }
@@ -181,6 +190,8 @@ impl WaylandClient {
             keyboard: None,
             windows: Vec::new(),
             mouse_events: Vec::new(),
+            output: None,
+            output_events: Vec::new(),
         };
 
         WaylandClient {
@@ -224,6 +235,55 @@ impl WaylandClient {
 
     pub fn get_client_events(&mut self) -> &mut Vec<MouseEvents> {
         self.state.mouse_events.as_mut()
+    }
+
+    /// All `wl_output` events received so far (geometry, mode, scale, done, name,
+    /// description). Ownership stays with the client; callers `drain` or inspect.
+    pub fn get_output_events(&mut self) -> &mut Vec<wl_output::Event> {
+        self.state.output_events.as_mut()
+    }
+
+    pub fn has_output(&self) -> bool {
+        self.state.output.is_some()
+    }
+
+    /// The most recent `wl_output.mode` event, if one has arrived. Compositor emits
+    /// one on bind and one per mode change.
+    pub fn latest_mode(&self) -> Option<(u32, i32, i32, i32)> {
+        self.state.output_events.iter().rev().find_map(|e| match e {
+            wl_output::Event::Mode {
+                flags,
+                width,
+                height,
+                refresh,
+            } => Some((
+                match flags {
+                    WEnum::Value(f) => f.bits(),
+                    WEnum::Unknown(u) => *u,
+                },
+                *width,
+                *height,
+                *refresh,
+            )),
+            _ => None,
+        })
+    }
+
+    /// The most recent toplevel configure seen on the first window.
+    pub fn latest_configure(&self) -> Option<Configure> {
+        self.state
+            .windows
+            .first()
+            .and_then(|w| w.configures_received.last().map(|(_, c)| c.clone()))
+    }
+
+    /// Number of toplevel `configure` events received on the first window.
+    pub fn configure_count(&self) -> usize {
+        self.state
+            .windows
+            .first()
+            .map(|w| w.configures_received.len())
+            .unwrap_or(0)
     }
 
     /// Call this to start receiving Relative events in `get_client_events()`
@@ -526,6 +586,20 @@ impl Dispatch<wl_pointer::WlPointer, ()> for State {
     ) {
         tracing::debug!("{:?}", event);
         state.mouse_events.push(MouseEvents::Pointer(event));
+    }
+}
+
+impl Dispatch<wl_output::WlOutput, ()> for State {
+    fn event(
+        state: &mut Self,
+        _: &wl_output::WlOutput,
+        event: wl_output::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        tracing::debug!("{:?}", event);
+        state.output_events.push(event);
     }
 }
 

--- a/wayland-display-core/src/tests/client.rs
+++ b/wayland-display-core/src/tests/client.rs
@@ -243,40 +243,6 @@ impl WaylandClient {
         self.state.output_events.as_mut()
     }
 
-    pub fn has_output(&self) -> bool {
-        self.state.output.is_some()
-    }
-
-    /// The most recent `wl_output.mode` event, if one has arrived. Compositor emits
-    /// one on bind and one per mode change.
-    pub fn latest_mode(&self) -> Option<(u32, i32, i32, i32)> {
-        self.state.output_events.iter().rev().find_map(|e| match e {
-            wl_output::Event::Mode {
-                flags,
-                width,
-                height,
-                refresh,
-            } => Some((
-                match flags {
-                    WEnum::Value(f) => f.bits(),
-                    WEnum::Unknown(u) => *u,
-                },
-                *width,
-                *height,
-                *refresh,
-            )),
-            _ => None,
-        })
-    }
-
-    /// The most recent toplevel configure seen on the first window.
-    pub fn latest_configure(&self) -> Option<Configure> {
-        self.state
-            .windows
-            .first()
-            .and_then(|w| w.configures_received.last().map(|(_, c)| c.clone()))
-    }
-
     /// Number of toplevel `configure` events received on the first window.
     pub fn configure_count(&self) -> usize {
         self.state

--- a/wayland-display-core/src/tests/mod.rs
+++ b/wayland-display-core/src/tests/mod.rs
@@ -2,3 +2,4 @@ pub(crate) mod client;
 mod device;
 mod fixture;
 mod test_pointer;
+mod test_resolution;

--- a/wayland-display-core/src/tests/test_resolution.rs
+++ b/wayland-display-core/src/tests/test_resolution.rs
@@ -1,0 +1,242 @@
+//! Integration tests for the `Command::VideoInfo` resolution-switching path.
+//!
+//! Drives the same `apply_video_info` function the live handler uses (see
+//! `comp::init`), then round-trips through a real Wayland client to assert that
+//! `wl_output.mode` and `xdg_toplevel.configure` events land on the client with
+//! the expected dimensions.
+//!
+//! Complements wolf's Catch2 [WAYLAND][resolution] suite: those drive resolution
+//! changes from Wolf's side of the FFI boundary; these drive them at the source,
+//! and failing here localises a regression to the compositor rather than to the
+//! wolf <-> gst-wayland-display glue.
+//!
+//! Note on `wl_output.Mode` assertions vs `xdg_toplevel.Configure` size
+//! assertions: the compositor intersects each toplevel's declared `max_size`
+//! with the new output rect before calling `send_configure`. A client that has
+//! not explicitly set a `max_size` leaves it at the xdg-shell default `(0, 0)`
+//! (meaning "no limit"), which `Rectangle::from_size` treats as an empty rect,
+//! so the intersection is empty and the configure goes out with `size = None`
+//! (wire-encoded as `width=0, height=0`, xdg-shell's "client picks" value).
+//! These tests therefore assert on `wl_output.mode` dimensions and on the fact
+//! that a fresh configure was broadcast -- not on the configure's width/height,
+//! which is intentionally unconstrained for Wolf's client model.
+
+use crate::comp::apply_video_info;
+use crate::tests::fixture::Fixture;
+use crate::utils::RenderTarget;
+use crate::utils::video_info::GstVideoInfo;
+use gst::Fraction;
+use gst_video::{VideoFormat, VideoInfo};
+use test_log::test;
+use wayland_client::protocol::wl_output;
+
+fn make_video_info(width: u32, height: u32, fps: i32) -> GstVideoInfo {
+    GstVideoInfo::RAW(
+        VideoInfo::builder(VideoFormat::Rgba, width, height)
+            .fps(Fraction::new(fps, 1))
+            .build()
+            .expect("failed to build VideoInfo"),
+    )
+}
+
+/// Drive `apply_video_info` with software rendering (matches the Fixture's
+/// `RenderTarget::Software` backing), then round-trip twice so the compositor
+/// can dispatch events on the event-loop tick and the client can read them off
+/// the socket.
+fn apply(f: &mut Fixture, width: u32, height: u32, fps: i32) {
+    apply_video_info(
+        &mut f.server,
+        make_video_info(width, height, fps),
+        &RenderTarget::Software,
+        None,
+    );
+    f.round_trip();
+    f.round_trip();
+}
+
+fn latest_mode_dimensions(client_events: &[wl_output::Event]) -> Option<(i32, i32, i32)> {
+    client_events.iter().rev().find_map(|e| match e {
+        wl_output::Event::Mode {
+            width,
+            height,
+            refresh,
+            ..
+        } => Some((*width, *height, *refresh)),
+        _ => None,
+    })
+}
+
+#[test]
+fn apply_video_info_broadcasts_new_mode_to_client() {
+    // Fixture::new() already creates a 320x240 output via create_server_output,
+    // so this exercises the "output already running" branch of apply_video_info
+    // -- the exact path that used to be short-circuited by the early return.
+    let mut f = Fixture::new();
+    f.create_window(320, 240);
+
+    // Drain the initial mode/geometry events so we only look at post-apply ones.
+    f.client.get_output_events().clear();
+    let configures_before = f.client.configure_count();
+
+    apply(&mut f, 1920, 1080, 60);
+
+    let mode = latest_mode_dimensions(f.client.get_output_events())
+        .expect("expected a wl_output.mode event after apply");
+    assert_eq!(
+        (mode.0, mode.1),
+        (1920, 1080),
+        "client should observe the newly negotiated 1920x1080 mode",
+    );
+    assert!(
+        mode.2 > 0,
+        "refresh rate should be non-zero, got {}",
+        mode.2
+    );
+
+    assert!(
+        f.client.configure_count() > configures_before,
+        "apply_video_info should trigger a fresh xdg_toplevel.Configure (was {}, now {})",
+        configures_before,
+        f.client.configure_count(),
+    );
+}
+
+#[test]
+fn repeated_video_info_propagates_each_change_to_client() {
+    // Core regression guard: before the early-return was removed, the second
+    // VideoInfo was silently dropped and the client stayed on the first mode.
+    let mut f = Fixture::new();
+    f.create_window(320, 240);
+
+    for &(w, h, fps) in &[(1280, 720, 60), (2560, 1440, 60), (800, 600, 30)] {
+        f.client.get_output_events().clear();
+        let before = f.client.configure_count();
+
+        apply(&mut f, w, h, fps);
+
+        let mode = latest_mode_dimensions(f.client.get_output_events())
+            .unwrap_or_else(|| panic!("no mode event after apply {}x{}@{}", w, h, fps));
+        assert_eq!(
+            (mode.0, mode.1),
+            (w as i32, h as i32),
+            "client should converge on {}x{} after apply",
+            w,
+            h
+        );
+        assert!(
+            f.client.configure_count() > before,
+            "apply {}x{}@{} should broadcast a new configure (was {}, now {})",
+            w,
+            h,
+            fps,
+            before,
+            f.client.configure_count(),
+        );
+    }
+}
+
+#[test]
+fn framerate_only_change_updates_mode_refresh() {
+    // Same dimensions, different fps: mode.refresh must move; width/height stay.
+    let mut f = Fixture::new();
+    f.create_window(320, 240);
+    apply(&mut f, 1920, 1080, 60);
+
+    let baseline =
+        latest_mode_dimensions(f.client.get_output_events()).expect("baseline mode missing");
+    assert_eq!((baseline.0, baseline.1), (1920, 1080));
+    let baseline_refresh = baseline.2;
+
+    f.client.get_output_events().clear();
+    apply(&mut f, 1920, 1080, 30);
+
+    let after =
+        latest_mode_dimensions(f.client.get_output_events()).expect("post-fps-change mode missing");
+    assert_eq!((after.0, after.1), (1920, 1080));
+    assert_ne!(
+        after.2, baseline_refresh,
+        "refresh rate should change when fps changes",
+    );
+}
+
+#[test]
+fn downscale_updates_mode_and_triggers_configure() {
+    // Regression guard: after a large-to-small resize the client must observe a
+    // mode event reflecting the new smaller output and a corresponding fresh
+    // configure -- not get stuck on the previous larger mode.
+    let mut f = Fixture::new();
+    f.create_window(320, 240);
+    apply(&mut f, 2560, 1440, 60);
+    f.client.get_output_events().clear();
+    let before = f.client.configure_count();
+
+    apply(&mut f, 640, 480, 60);
+
+    let mode = latest_mode_dimensions(f.client.get_output_events())
+        .expect("mode event missing after downscale");
+    assert_eq!((mode.0, mode.1), (640, 480));
+    assert!(
+        f.client.configure_count() > before,
+        "downscale should trigger a configure",
+    );
+}
+
+#[test]
+fn idempotent_same_video_info_is_safe_and_stays_on_mode() {
+    // Repeated same-params apply must not crash, re-map, or drift the client
+    // off the target mode.
+    let mut f = Fixture::new();
+    f.create_window(320, 240);
+
+    // Establish the target mode and clear everything before entering the loop,
+    // so the assertion below only sees events produced by the idempotent calls.
+    apply(&mut f, 1920, 1080, 60);
+    f.client.get_output_events().clear();
+
+    for _ in 0..4 {
+        apply(&mut f, 1920, 1080, 60);
+    }
+
+    // Every mode event observed across the idempotent applies must describe
+    // 1920x1080. Catches a regression where repeated applies would drift.
+    let events = f.client.get_output_events();
+    let mut saw_mode = false;
+    for ev in events.iter() {
+        if let wl_output::Event::Mode { width, height, .. } = ev {
+            saw_mode = true;
+            assert_eq!(
+                (*width, *height),
+                (1920, 1080),
+                "stray mode event with unexpected dimensions",
+            );
+        }
+    }
+    assert!(
+        saw_mode,
+        "expected at least one wl_output.mode event across the idempotent applies",
+    );
+}
+
+#[test]
+fn apply_after_window_mapped_triggers_configure() {
+    // A client that maps a window BEFORE apply_video_info runs should still
+    // receive a configure when apply runs -- this is the specific path that
+    // used to be broken by the early return.
+    let mut f = Fixture::new();
+    f.create_window(320, 240);
+    let before = f.client.configure_count();
+
+    apply(&mut f, 1280, 720, 60);
+
+    assert!(
+        f.client.configure_count() > before,
+        "apply_video_info on a mapped toplevel should trigger at least one additional configure (was {}, now {})",
+        before,
+        f.client.configure_count(),
+    );
+
+    // And the client must see a wl_output.mode with the new dimensions.
+    let mode = latest_mode_dimensions(f.client.get_output_events())
+        .expect("expected wl_output.mode event");
+    assert_eq!((mode.0, mode.1), (1280, 720));
+}


### PR DESCRIPTION
## What changed
This updates the running-output resize path in `wayland-display-core` so an already active output applies newly negotiated size changes to existing toplevels instead of treating them as a no-op.

## Why
Wolf party mode now resizes seats dynamically when entering split mode. Without this compositor update, running surfaces can ignore the renegotiated size, which leaves the primary seat cropped or stuck on stale geometry.

## Impact
Clients that keep a Wayland output alive while changing negotiated video size now receive the updated fullscreen state and geometry instead of continuing to render against the old size.

## Validation
- `cargo build --release`
- live validation through Wolf party mode on a Moonlight session
