### PR TITLE
Raise Wayland display max buffer size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -354,9 +354,9 @@ dependencies = [
 
 [[package]]
 name = "dlib"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
+checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
 dependencies = [
  "libloading",
 ]
@@ -1219,9 +1219,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.37.5"
+version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "memchr",
 ]
@@ -1785,9 +1785,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-backend"
-version = "0.3.11"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673a33c33048a5ade91a6b139580fa174e19fb0d23f396dca9fa15f2e1e49b35"
+checksum = "2857dd20b54e916ec7253b3d6b4d5c4d7d4ca2c33c2e11c6c76a99bd8744755d"
 dependencies = [
  "cc",
  "downcast-rs",
@@ -1829,6 +1829,7 @@ dependencies = [
  "wayland-client",
  "wayland-protocols",
  "wayland-scanner",
+ "wayland-server",
 ]
 
 [[package]]
@@ -1872,9 +1873,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-scanner"
-version = "0.31.7"
+version = "0.31.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54cb1e9dc49da91950bdfd8b848c49330536d9d1fb03d4bfec8cae50caa50ae3"
+checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
 dependencies = [
  "proc-macro2",
  "quick-xml",
@@ -1883,9 +1884,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-server"
-version = "0.31.10"
+version = "0.31.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcbd4f3aba6c9fba70445ad2a484c0ef0356c1a9459b1e8e435bedc1971a6222"
+checksum = "cc1846eb04c49182e04f4a099e2a830a2b745610bbc1d61246e206f29c7000a0"
 dependencies = [
  "bitflags 2.9.1",
  "downcast-rs",
@@ -1896,9 +1897,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-sys"
-version = "0.31.7"
+version = "0.31.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34949b42822155826b41db8e5d0c1be3a2bd296c747577a43a3e6daefc296142"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
 dependencies = [
  "dlib",
  "libc",

--- a/wayland-display-core/Cargo.toml
+++ b/wayland-display-core/Cargo.toml
@@ -21,8 +21,9 @@ gst.workspace = true
 gst-video.workspace = true
 tracing.workspace = true
 once_cell.workspace = true
-wayland-backend = "0.3.10"
-wayland-scanner = "0.31.6"
+wayland-backend = "0.3.15"
+wayland-server = { version = "0.31.13", features = ["libwayland_1_23"] }
+wayland-scanner = "0.31.10"
 gstreamer-allocators = { version = "0.23.2", package = "gstreamer-allocators", features = ["v1_24", "v1_16"] }
 libloading = { version = "0.8.9", optional = true }
 

--- a/wayland-display-core/src/comp/mod.rs
+++ b/wayland-display-core/src/comp/mod.rs
@@ -274,17 +274,14 @@ pub(crate) fn init(
     let mut event_loop = EventLoop::<State>::try_new().expect("Unable to create event_loop");
 
     let display = Display::<State>::new().unwrap();
+    let dh = display.handle();
+    dh.set_default_max_buffer_size(10 * 1024 * 1024);
     // init input backend
     let libinput_context = Libinput::new_from_path(NixInterface);
     let input_context = libinput_context.clone();
     let libinput_backend = LibinputInputBackend::new(libinput_context);
 
-    let mut state = State::new(
-        &render_target,
-        &display.handle(),
-        &input_context,
-        event_loop.handle(),
-    );
+    let mut state = State::new(&render_target, &dh, &input_context, event_loop.handle());
 
     // init event loop
     state


### PR DESCRIPTION
## Summary
- Update Wayland crates and enable `wayland-server` with `libwayland_1_23`.
- Set the compositor display default max buffer size to 10 MiB before state initialization.
- Mirrors the relevant behavior from https://github.com/linuxserver/pixelflux/commit/ffc2d4daef02726857174fd3a6b158a53ac09c5c.

## Verification
Fresh CTs were created on the Proxmox host for verification. CT120 was not used.

- CT900 Intel RPL-S, host render node `/dev/dri/renderD129`: `test_dmabuf` passed.
- CT900 Intel: `cargo test --locked -p wayland-display-core --lib -- --skip test_dmabuf` passed, 12 passed.
- CT901 AMD Radeon RX 7900 XTX, host render node `/dev/dri/renderD130`: `test_dmabuf` passed.
- CT902 NVIDIA GeForce RTX 5080, host render node `/dev/dri/renderD128`: installed matching NVIDIA 595.71.05 userspace-only from the NVIDIA runfile, mapped `/dev/nvidia*` and `/dev/nvidia-caps`, and verified `nvidia-smi` plus `eglinfo -B` report NVIDIA EGL on 595.71.05.
- CT902 NVIDIA: non-dmabuf library suite passed with `XDG_RUNTIME_DIR=/tmp/gwd-xdg`, 12 passed.
- CT900: `cargo check --workspace --all-targets` passed, and feature tree confirmed `wayland-server/libwayland_1_23` enables `wayland-backend/libwayland_server_1_23`.

## NVIDIA AB24 Linear note
`utils::allocator::tests::test_dmabuf` still fails on NVIDIA after the CT was converted into a valid NVIDIA EGL environment. The failure is:

- `DrmFourcc(AB24), Modifier: Linear`
- `GL_INVALID_OPERATION ... EGLImage not supported`
- panic at `wayland-display-core/src/utils/allocator/mod.rs:682`, `assertion failed: bind_result.is_ok()`

This was also reproduced against a clean `HEAD` baseline before this change, using the same CT902 NVIDIA environment and `GBM_BACKEND=nvidia-drm`. Therefore the NVIDIA AB24 Linear import issue predates this PR and is not introduced by the Wayland max-buffer change.

CT900, CT901, and CT902 are left running for inspection.