### PR TITLE
fix: devcontainer podman build

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update -y \
                libwayland-dev libwayland-server0 libinput-dev libxkbcommon-dev libgbm-dev \
                librust-gstreamer-allocators-dev
 
-ARG RUST_VERSION=1.89.0
+ARG RUST_VERSION=1.96.0
 ENV RUST_VERSION=$RUST_VERSION
 ENV PATH="$HOME/.cargo/bin:${PATH}"
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -27,8 +27,6 @@ RUN apt-get update -y \
                libwayland-dev libwayland-server0 libinput-dev libxkbcommon-dev libgbm-dev \
                librust-gstreamer-allocators-dev
 
-ARG RUST_VERSION=1.96.0
-ENV RUST_VERSION=$RUST_VERSION
 ENV PATH="$HOME/.cargo/bin:${PATH}"
 
 USER $UNAME
@@ -38,8 +36,5 @@ RUN <<_INSTALL_RUST
 set -e
 
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-rustup install $RUST_VERSION
-rustup default $RUST_VERSION
-
 cargo install cargo-c
 _INSTALL_RUST

--- a/.devcontainer/default/devcontainer.json
+++ b/.devcontainer/default/devcontainer.json
@@ -1,11 +1,11 @@
 {
-  "name": "gst-wayland-comp-dev",
+  "name": "gst-wayland-comp-dev (default)",
   "build": {
-    "context": "..",
-    "dockerfile": "Dockerfile"
+    "context": "../..",
+    "dockerfile": "../Dockerfile"
   },
   "features": {},
-  "runArgs": ["--device", "nvidia.com/gpu=all"],
+  "privileged": true,
   "containerEnv": {
     "XDG_RUNTIME_DIR": "/home/retro/"
   },

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,11 +5,7 @@
     "dockerfile": "Dockerfile"
   },
   "features": {},
-  "runArgs": ["--runtime=nvidia"],
-  "hostRequirements": {
-    "gpu": true
-  },
-  "privileged": true,
+  "runArgs": ["--device", "nvidia.com/gpu=all"],
   "containerEnv": {
     "XDG_RUNTIME_DIR": "/home/retro/"
   },

--- a/.devcontainer/nvidia/devcontainer.json
+++ b/.devcontainer/nvidia/devcontainer.json
@@ -1,0 +1,23 @@
+{
+  "name": "gst-wayland-comp-dev (nvidia)",
+  "build": {
+    "context": "../..",
+    "dockerfile": "../Dockerfile"
+  },
+  "features": {},
+  "runArgs": ["--device", "nvidia.com/gpu=all"],
+  "privileged": true,
+  "containerEnv": {
+    "XDG_RUNTIME_DIR": "/home/retro/"
+  },
+  "remoteEnv": {
+    "XDG_RUNTIME_DIR": "/tmp/sockets",
+    "RUST_BACKTRACE": "full",
+    "RUST_LOG": "INFO"
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": ["rust-lang.rust-analyzer"]
+    }
+  }
+}


### PR DESCRIPTION
There were a few issues I ran into building this devcontainer with podman. First: `cargo-c` has bumped its minimum required rust version to `1.93` https://github.com/lu-zero/cargo-c/blob/e7a5919aaba93e3bcff0932fc830cec654aeca36/Cargo.toml#L12-L13 causing the install in the Dockerfile to fail. Second: the `--runtime=nvidia` is legacy and the new recommend method of accessing the GPU inside the container is through the CDI https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/cdi-support.html which does not require `privileged` to be true or `hostRequirements` to be set.