### PR TITLE
feat(comp): explicit sync (linux-drm-syncobj-v1)

### DIFF
--- a/wayland-display-core/src/comp/mod.rs
+++ b/wayland-display-core/src/comp/mod.rs
@@ -207,28 +207,34 @@ impl State {
         };
 
         let drm_syncobj_state = if let RenderTarget::Hardware(node) = render_target {
-            match std::fs::OpenOptions::new()
-                .read(true)
-                .write(true)
-                .open(node.dev_path().expect("Failed to determine DrmNode path?"))
-            {
-                Ok(file) => {
-                    let device_fd = DrmDeviceFd::new(DeviceFd::from(OwnedFd::from(file)));
-                    if supports_syncobj_eventfd(&device_fd) {
-                        tracing::info!("Enabling explicit sync (linux-drm-syncobj-v1)");
-                        Some(DrmSyncobjState::new::<State>(&dh, device_fd))
-                    } else {
+            match node.dev_path() {
+                Some(path) => match std::fs::OpenOptions::new()
+                    .read(true)
+                    .write(true)
+                    .open(&path)
+                {
+                    Ok(file) => {
+                        let device_fd = DrmDeviceFd::new(DeviceFd::from(OwnedFd::from(file)));
+                        if supports_syncobj_eventfd(&device_fd) {
+                            tracing::info!("Enabling explicit sync (linux-drm-syncobj-v1)");
+                            Some(DrmSyncobjState::new::<State>(&dh, device_fd))
+                        } else {
+                            tracing::warn!(
+                                "DRM device does not support syncobj eventfd; explicit sync disabled"
+                            );
+                            None
+                        }
+                    }
+                    Err(err) => {
                         tracing::warn!(
-                            "DRM device does not support syncobj eventfd; explicit sync disabled"
+                            ?err,
+                            "Failed to open render node for syncobj; explicit sync disabled"
                         );
                         None
                     }
-                }
-                Err(err) => {
-                    tracing::warn!(
-                        ?err,
-                        "Failed to open render node for syncobj; explicit sync disabled"
-                    );
+                },
+                None => {
+                    tracing::warn!("Render node has no device path; explicit sync disabled");
                     None
                 }
             }

--- a/wayland-display-core/src/comp/mod.rs
+++ b/wayland-display-core/src/comp/mod.rs
@@ -12,7 +12,7 @@ use smithay::wayland::single_pixel_buffer::SinglePixelBufferState;
 use smithay::{
     backend::{
         allocator::{Fourcc, dmabuf::Dmabuf},
-        drm::DrmNode,
+        drm::{DrmDeviceFd, DrmNode},
         libinput::LibinputInputBackend,
         renderer::{
             Bind,
@@ -45,10 +45,11 @@ use smithay::{
             backend::{ClientData, ClientId, DisconnectReason, GlobalId},
         },
     },
-    utils::{Clock, Logical, Monotonic, Physical, Point, Rectangle, Size, Transform},
+    utils::{Clock, DeviceFd, Logical, Monotonic, Physical, Point, Rectangle, Size, Transform},
     wayland::{
         compositor::{CompositorClientState, CompositorState, with_states},
         dmabuf::{DmabufGlobal, DmabufState},
+        drm_syncobj::{DrmSyncobjState, supports_syncobj_eventfd},
         output::OutputManagerState,
         pointer_constraints::PointerConstraintsState,
         presentation::PresentationState,
@@ -60,6 +61,7 @@ use smithay::{
         viewporter::ViewporterState,
     },
 };
+use std::os::fd::OwnedFd;
 use std::sync::Mutex;
 use std::{
     collections::HashSet,
@@ -128,6 +130,7 @@ pub struct State {
     // wayland state
     pub dh: DisplayHandle,
     pub compositor_state: CompositorState,
+    pub drm_syncobj_state: Option<DrmSyncobjState>,
     pub data_device_state: DataDeviceState,
     pub dmabuf_state: DmabufState,
     output_state: OutputManagerState,
@@ -203,6 +206,36 @@ impl State {
             None
         };
 
+        let drm_syncobj_state = if let RenderTarget::Hardware(node) = render_target {
+            match std::fs::OpenOptions::new()
+                .read(true)
+                .write(true)
+                .open(node.dev_path().expect("Failed to determine DrmNode path?"))
+            {
+                Ok(file) => {
+                    let device_fd = DrmDeviceFd::new(DeviceFd::from(OwnedFd::from(file)));
+                    if supports_syncobj_eventfd(&device_fd) {
+                        tracing::info!("Enabling explicit sync (linux-drm-syncobj-v1)");
+                        Some(DrmSyncobjState::new::<State>(&dh, device_fd))
+                    } else {
+                        tracing::warn!(
+                            "DRM device does not support syncobj eventfd; explicit sync disabled"
+                        );
+                        None
+                    }
+                }
+                Err(err) => {
+                    tracing::warn!(
+                        ?err,
+                        "Failed to open render node for syncobj; explicit sync disabled"
+                    );
+                    None
+                }
+            }
+        } else {
+            None
+        };
+
         let cursor_element = MemoryRenderBuffer::from_memory(
             MemoryBuffer::from_slice(CURSOR_DATA_BYTES, Fourcc::Abgr8888, (64, 64)),
             1,
@@ -247,6 +280,7 @@ impl State {
 
             dh: dh.clone(),
             compositor_state,
+            drm_syncobj_state,
             data_device_state,
             dmabuf_state,
             output_state,

--- a/wayland-display-core/src/wayland/handlers/compositor.rs
+++ b/wayland-display-core/src/wayland/handlers/compositor.rs
@@ -12,7 +12,12 @@ use smithay::{
     utils::SERIAL_COUNTER,
     wayland::{
         buffer::BufferHandler,
-        compositor::{CompositorClientState, CompositorHandler, CompositorState, with_states},
+        compositor::{
+            BufferAssignment, CompositorClientState, CompositorHandler, CompositorState,
+            SurfaceAttributes, add_blocker, add_pre_commit_hook, with_states,
+        },
+        dmabuf::get_dmabuf,
+        drm_syncobj::DrmSyncobjCachedState,
         seat::WaylandFocus,
         shell::xdg::{SurfaceCachedState, XdgPopupSurfaceData, XdgToplevelSurfaceData},
     },
@@ -31,6 +36,48 @@ impl CompositorHandler for State {
 
     fn client_compositor_state<'a>(&self, client: &'a Client) -> &'a CompositorClientState {
         &client.get_data::<ClientState>().unwrap().compositor_state
+    }
+
+    fn new_surface(&mut self, surface: &WlSurface) {
+        add_pre_commit_hook::<Self, _>(surface, move |state, _dh, surface| {
+            let mut acquire_point = None;
+            let maybe_dmabuf = with_states(surface, |surface_data| {
+                acquire_point.clone_from(
+                    &surface_data
+                        .cached_state
+                        .get::<DrmSyncobjCachedState>()
+                        .pending()
+                        .acquire_point,
+                );
+                surface_data
+                    .cached_state
+                    .get::<SurfaceAttributes>()
+                    .pending()
+                    .buffer
+                    .as_ref()
+                    .and_then(|assignment| match assignment {
+                        BufferAssignment::NewBuffer(buffer) => get_dmabuf(buffer).cloned().ok(),
+                        _ => None,
+                    })
+            });
+            if maybe_dmabuf.is_some() {
+                if let Some(acquire_point) = acquire_point {
+                    if let Ok((blocker, source)) = acquire_point.generate_blocker() {
+                        if let Some(client) = surface.client() {
+                            let res = state.handle.insert_source(source, move |_, _, data| {
+                                let dh = data.dh.clone();
+                                data.client_compositor_state(&client)
+                                    .blocker_cleared(data, &dh);
+                                Ok(())
+                            });
+                            if res.is_ok() {
+                                add_blocker(surface, blocker);
+                            }
+                        }
+                    }
+                }
+            }
+        });
     }
 
     fn commit(&mut self, surface: &WlSurface) {

--- a/wayland-display-core/src/wayland/handlers/compositor.rs
+++ b/wayland-display-core/src/wayland/handlers/compositor.rs
@@ -3,10 +3,10 @@ use smithay::{
     delegate_compositor, delegate_single_pixel_buffer,
     desktop::PopupKind,
     reexports::{
+        calloop::Interest,
         wayland_protocols::xdg::shell::server::xdg_toplevel::State as XdgState,
         wayland_server::{
-            Client,
-            Resource,
+            Client, Resource,
             protocol::{wl_buffer::WlBuffer, wl_surface::WlSurface},
         },
     },
@@ -61,7 +61,8 @@ impl CompositorHandler for State {
                         _ => None,
                     })
             });
-            if maybe_dmabuf.is_some() {
+            if let Some(dmabuf) = maybe_dmabuf {
+                // Explicit sync: block the commit on the client's acquire timeline point.
                 if let Some(acquire_point) = acquire_point {
                     if let Ok((blocker, source)) = acquire_point.generate_blocker() {
                         if let Some(client) = surface.client() {
@@ -73,7 +74,23 @@ impl CompositorHandler for State {
                             });
                             if res.is_ok() {
                                 add_blocker(surface, blocker);
+                                return;
                             }
+                        }
+                    }
+                }
+                // Implicit sync fallback: the client isn't using linux-drm-syncobj-v1,
+                // so block on the dmabuf's implicit read-fence instead.
+                if let Ok((blocker, source)) = dmabuf.generate_blocker(Interest::READ) {
+                    if let Some(client) = surface.client() {
+                        let res = state.handle.insert_source(source, move |_, _, data| {
+                            let dh = data.dh.clone();
+                            data.client_compositor_state(&client)
+                                .blocker_cleared(data, &dh);
+                            Ok(())
+                        });
+                        if res.is_ok() {
+                            add_blocker(surface, blocker);
                         }
                     }
                 }

--- a/wayland-display-core/src/wayland/handlers/compositor.rs
+++ b/wayland-display-core/src/wayland/handlers/compositor.rs
@@ -6,6 +6,7 @@ use smithay::{
         wayland_protocols::xdg::shell::server::xdg_toplevel::State as XdgState,
         wayland_server::{
             Client,
+            Resource,
             protocol::{wl_buffer::WlBuffer, wl_surface::WlSurface},
         },
     },

--- a/wayland-display-core/src/wayland/handlers/drm_syncobj.rs
+++ b/wayland-display-core/src/wayland/handlers/drm_syncobj.rs
@@ -1,0 +1,14 @@
+use smithay::{
+    delegate_drm_syncobj,
+    wayland::drm_syncobj::{DrmSyncobjHandler, DrmSyncobjState},
+};
+
+use crate::comp::State;
+
+impl DrmSyncobjHandler for State {
+    fn drm_syncobj_state(&mut self) -> Option<&mut DrmSyncobjState> {
+        self.drm_syncobj_state.as_mut()
+    }
+}
+
+delegate_drm_syncobj!(State);

--- a/wayland-display-core/src/wayland/handlers/mod.rs
+++ b/wayland-display-core/src/wayland/handlers/mod.rs
@@ -1,6 +1,7 @@
 pub mod compositor;
 pub mod data_device;
 pub mod dmabuf;
+pub mod drm_syncobj;
 pub mod output;
 pub mod pointer_constraints;
 pub mod presentation;


### PR DESCRIPTION
> Consider this an idea/draft PR — it's one of the issues I've been hitting with Blackwell + the 610 drivers, and I was teaching myself Rust along the way. Happy to iterate.

## Problem

Without explicit sync, the compositor relies on **implicit** dmabuf fences to know when a client has finished rendering into a buffer. NVIDIA's driver doesn't do implicit sync, so the compositor can sample a half-rendered buffer — the flicker/tearing/jerk class of artifacts. I can reproduce this on NVIDIA where it doesn't happen on AMD (e.g. Bravely Default: Flying Fairy tears/jerks when moving quickly around maps). Vulkan is explicit by design and NVIDIA needs it; NVIDIA's new dma-buf platform lib ([egl-wayland2](https://github.com/NVIDIA/egl-wayland2)) calls out `linux-drm-syncobj-v1` as required "for full functionality… without it you may get reduced performance and out-of-order frames."

## What this does

Implements `wp_linux_drm_syncobj_manager_v1` (explicit sync) in the compositor, mirroring the smithay anvil integration:

- On a hardware render target, open the render node as a `DrmDeviceFd` and, when it supports syncobj eventfd, advertise a `DrmSyncobjState` global (`comp/mod.rs`); otherwise log and disable.
- A `new_surface` pre-commit hook installs an **acquire-point blocker**: a buffer is presented only once its explicit-sync fence signals (`handlers/compositor.rs`).
- **Implicit-fence fallback**: when a client *isn't* using explicit sync, fall back to blocking the commit on the dmabuf's implicit read-fence (`Interest::READ`), matching anvil. This means dmabuf clients get correct commit-time sync whether or not they speak `linux-drm-syncobj-v1`.
- Release points are signalled automatically by smithay (`DrmSyncobjCachedState::merge_into` / destruction hook) — no manual signalling needed.

Empirically this removes the tearing/jerking for me on the NVIDIA 610 drivers.

## Caveats

- This depends on what the target compositor reports in our nested setup — sway/gamescope have to support the protocol for a client to actually use it. `WAYLAND_DEBUG=client|server` is useful to watch the negotiation.
- 610/Blackwell has a few other rough edges I'm still looking at (XDG behaviour, block-linear render buffers — the latter tracked in games-on-whales/wolf#417). Those are intentionally **not** in this PR anymore; it's now purely explicit sync.

## Refs

- games-on-whales/wolf#417 (block-linear, separate)
- https://github.com/NVIDIA/egl-wayland2
