### PR TITLE
refactor: stop advertising legacy wl_drm when dmabuf v4 feedback is available

### DIFF
--- a/wayland-display-core/src/comp/mod.rs
+++ b/wayland-display-core/src/comp/mod.rs
@@ -107,7 +107,7 @@ pub struct State {
     pub(crate) output_buffer: Option<GsBufferType>,
     render_node: Option<DrmNode>,
     pub renderer: GlesRenderer,
-    dmabuf_global: Option<(DmabufGlobal, GlobalId)>,
+    dmabuf_global: Option<(DmabufGlobal, Option<GlobalId>)>,
     last_render: Option<Instant>,
 
     // management
@@ -178,25 +178,51 @@ impl State {
             let dmabuf_default_feedback =
                 DmabufFeedbackBuilder::new(node.dev_id(), formats.clone()).build();
 
-            let dmabuf_global = if let Ok(default_feedback) = dmabuf_default_feedback {
-                dmabuf_state.create_global_with_default_feedback::<State>(&dh, &default_feedback)
-            } else {
-                tracing::warn!("Failed to create default feedback for dmabuf, falling back to v3");
-                dmabuf_state.create_global::<State>(&dh, formats.clone())
-            };
+            let (dmabuf_global, has_default_feedback) =
+                if let Ok(default_feedback) = dmabuf_default_feedback {
+                    (
+                        dmabuf_state
+                            .create_global_with_default_feedback::<State>(&dh, &default_feedback),
+                        true,
+                    )
+                } else {
+                    tracing::warn!(
+                        "Failed to create default feedback for dmabuf, falling back to v3"
+                    );
+                    (dmabuf_state.create_global::<State>(&dh, formats.clone()), false)
+                };
 
             match renderer.bind_wl_display(&dh) {
                 Ok(_) => tracing::info!("EGL hardware-acceleration enabled"),
                 Err(err) => tracing::info!(?err, "Failed to initialize EGL hardware-acceleration"),
             }
 
-            // wl_drm (mesa protocol, so we don't need EGL_WL_bind_display)
-            let wl_drm_global = create_drm_global::<State>(
-                &dh,
-                node.dev_path().expect("Failed to determine DrmNode path?"),
-                formats.clone(),
-                &dmabuf_global,
-            );
+            // wl_drm is a legacy mesa protocol superseded by zwp_linux_dmabuf_v1
+            // v4 feedback for device discovery. Advertising both globals breaks
+            // nested wlroots compositors (e.g. sway): wlroots binds both, each
+            // path reports a render device, and the duplicate trips
+            // `assert(wl->drm_render_name == NULL)` in backend/wayland/backend.c.
+            // Mutter and KWin dropped wl_drm entirely; only advertise it when
+            // dmabuf v4 feedback is unavailable, or when explicitly requested
+            // for old clients via GST_WAYLAND_DISPLAY_ADVERTISE_WL_DRM=1.
+            let advertise_wl_drm = std::env::var("GST_WAYLAND_DISPLAY_ADVERTISE_WL_DRM")
+                .map(|v| matches!(v.trim(), "1" | "true" | "yes" | "on"))
+                .unwrap_or(false);
+
+            let wl_drm_global = if advertise_wl_drm || !has_default_feedback {
+                Some(create_drm_global::<State>(
+                    &dh,
+                    node.dev_path().expect("Failed to determine DrmNode path?"),
+                    formats.clone(),
+                    &dmabuf_global,
+                ))
+            } else {
+                tracing::info!(
+                    "Skipping legacy wl_drm global (dmabuf v4 feedback active); \
+                     set GST_WAYLAND_DISPLAY_ADVERTISE_WL_DRM=1 to restore it"
+                );
+                None
+            };
 
             Some((dmabuf_global, wl_drm_global))
         } else {


### PR DESCRIPTION
## What this changes

`wl_drm` is a legacy Mesa protocol, superseded by `zwp_linux_dmabuf_v1` v4 feedback for render-device discovery — Mutter and KWin have already dropped it entirely. Today the compositor advertises **both** `wl_drm` and dmabuf v4 default feedback at the same time, which is redundant.

This PR stops advertising `wl_drm` when the dmabuf v4 default-feedback global is created successfully:

* skip `create_drm_global` when v4 default feedback is available;
* keep `wl_drm` on the dmabuf **v3** fallback path, where clients still need it for device discovery;
* add an opt-in escape hatch for legacy clients — `GST_WAYLAND_DISPLAY_ADVERTISE_WL_DRM=1` restores the previous behavior.

## Scope / history (please read)

I originally opened this believing it fixed a nested-wlroots (sway) startup abort — `assert(wl->drm_render_name == NULL)` at `backend/wayland/backend.c:311`. Per @JBailes's review, **that justification does not hold up**: wlroots 0.19 already handles `wl_drm` and dmabuf-v4 feedback coexisting (it destroys the `wl_drm` global and resets `drm_render_name` to `NULL` before reading the device from the v4 `main_device`), and the logs I attached don't actually contain that assert. Thanks for the careful read.

So, taking @JBailes's suggestion to split this up:

* **This PR no longer claims to fix that crash.** It stands on its own as a cleanup that matches what Mutter/KWin already did and removes a redundant legacy global, with an env opt-out for old clients.
* The problem actually visible in my logs is **separate** and unrelated to `wl_drm`: inside the session pod, wlroots can't resolve the `main_device` dev_id advertised in the v4 feedback (`render/wlr_renderer.c:249 drmGetDevices2 failed`, `backend/wayland/backend.c:166 drmGetDeviceFromDevId failed`), and sway later dies on `output.c:525 Failed to commit output WL-1` (no outputs connected). That's a DRM-node-in-namespace issue; I'll investigate and raise it on its own rather than bundling it here.

## Testing

Build only (`cargo check`) — this is purely a protocol-advertisement change and I'm intentionally **not** attaching a crash-fix claim to it. Happy to add the env hatch behind a different name or default if you'd prefer.
