### PR TITLE
feat(waylandsrc): add await-listener to defer caps negotiation until a consumer connects

### DIFF
--- a/gst-plugin-wayland-display/src/waylandsrc/imp.rs
+++ b/gst-plugin-wayland-display/src/waylandsrc/imp.rs
@@ -12,8 +12,9 @@ use gst_video::{NavigationEvent, VideoCapsBuilder, VideoFormat, VideoInfo, Video
 use once_cell::sync::Lazy;
 use std::collections::HashMap;
 use std::ops::DerefMut;
-use std::sync::atomic::{AtomicBool, AtomicPtr, Ordering};
-use std::sync::{Arc, LazyLock, Mutex};
+#[cfg(feature = "cuda")]
+use std::sync::atomic::AtomicPtr;
+use std::sync::{Arc, Condvar, LazyLock, Mutex};
 use tracing_subscriber::Registry;
 use tracing_subscriber::layer::SubscriberExt;
 #[cfg(feature = "cuda")]
@@ -34,8 +35,17 @@ pub struct WaylandDisplaySrc {
     settings: Mutex<Settings>,
     command_tx: Sender<Command>,
     command_rx: Mutex<Option<Channel<Command>>>,
-    /// Set by unlock() to abort a pending await-listener wait in negotiate().
-    await_abort: AtomicBool,
+    /// Coordinates the await-listener wait in negotiate(). `abort` is set by
+    /// unlock() to break the wait; the condvar is notified by event() when a
+    /// downstream RECONFIGURE arrives and by unlock() on abort, so negotiate()
+    /// parks on the event instead of busy-polling.
+    await_state: Mutex<AwaitState>,
+    await_cv: Condvar,
+}
+
+#[derive(Default)]
+struct AwaitState {
+    abort: bool,
 }
 
 impl Default for WaylandDisplaySrc {
@@ -46,7 +56,8 @@ impl Default for WaylandDisplaySrc {
             settings: Mutex::new(Settings::default()),
             command_tx,
             command_rx: Mutex::new(Some(command_rx)),
-            await_abort: AtomicBool::new(false),
+            await_state: Mutex::new(AwaitState::default()),
+            await_cv: Condvar::new(),
         }
     }
 }
@@ -652,16 +663,10 @@ impl BaseSrcImpl for WaylandDisplaySrc {
             // inspecting formats, so this stays fully format-agnostic. The
             // wayland compositor runs on its own thread, so the application keeps
             // rendering while we wait.
-            self.await_abort.store(false, Ordering::SeqCst);
+            self.await_state.lock().unwrap().abort = false;
             let baseline = src_pad.peer_query_caps(None);
             tracing::debug!("await-listener: baseline downstream caps {}", baseline);
             loop {
-                if self.await_abort.load(Ordering::SeqCst) {
-                    return Err(gst::loggable_error!(
-                        CAT,
-                        "Negotiation aborted while awaiting a downstream consumer"
-                    ));
-                }
                 let peer = src_pad.peer_query_caps(None);
                 if !peer.is_empty() && peer != baseline {
                     tracing::info!(
@@ -670,7 +675,22 @@ impl BaseSrcImpl for WaylandDisplaySrc {
                     );
                     break;
                 }
-                std::thread::sleep(std::time::Duration::from_millis(100));
+                let guard = self.await_state.lock().unwrap();
+                if guard.abort {
+                    return Err(gst::loggable_error!(
+                        CAT,
+                        "Negotiation aborted while awaiting a downstream consumer"
+                    ));
+                }
+                // Park until event() signals a downstream RECONFIGURE or
+                // unlock() aborts. The timeout is a safety net: RECONFIGURE is
+                // not guaranteed to cross a decoupling boundary (e.g.
+                // interpipe), so re-check the caps query periodically rather
+                // than relying on the event alone.
+                let _ = self
+                    .await_cv
+                    .wait_timeout(guard, std::time::Duration::from_millis(500))
+                    .unwrap();
             }
         }
         self.parent_negotiate()
@@ -679,16 +699,24 @@ impl BaseSrcImpl for WaylandDisplaySrc {
     fn unlock(&self) -> Result<(), gst::ErrorMessage> {
         // Interrupt a pending await-listener wait in negotiate() so state
         // changes (e.g. shutdown) don't block on a consumer that never arrives.
-        self.await_abort.store(true, Ordering::SeqCst);
+        self.await_state.lock().unwrap().abort = true;
+        self.await_cv.notify_all();
         self.parent_unlock()
     }
 
     fn unlock_stop(&self) -> Result<(), gst::ErrorMessage> {
-        self.await_abort.store(false, Ordering::SeqCst);
+        self.await_state.lock().unwrap().abort = false;
         self.parent_unlock_stop()
     }
 
     fn event(&self, event: &Event) -> bool {
+        // A downstream RECONFIGURE is the real trigger for the await-listener
+        // wait in negotiate(): wake it so it re-checks the caps query
+        // immediately instead of waiting out the poll fallback.
+        if let gst::EventView::Reconfigure(_) = event.view() {
+            let _guard = self.await_state.lock().unwrap();
+            self.await_cv.notify_all();
+        }
         if self.handle_event(&event) {
             return true;
         }

--- a/gst-plugin-wayland-display/src/waylandsrc/imp.rs
+++ b/gst-plugin-wayland-display/src/waylandsrc/imp.rs
@@ -12,7 +12,7 @@ use gst_video::{NavigationEvent, VideoCapsBuilder, VideoFormat, VideoInfo, Video
 use once_cell::sync::Lazy;
 use std::collections::HashMap;
 use std::ops::DerefMut;
-use std::sync::atomic::AtomicPtr;
+use std::sync::atomic::{AtomicBool, AtomicPtr, Ordering};
 use std::sync::{Arc, LazyLock, Mutex};
 use tracing_subscriber::Registry;
 use tracing_subscriber::layer::SubscriberExt;
@@ -34,6 +34,8 @@ pub struct WaylandDisplaySrc {
     settings: Mutex<Settings>,
     command_tx: Sender<Command>,
     command_rx: Mutex<Option<Channel<Command>>>,
+    /// Set by unlock() to abort a pending await-listener wait in negotiate().
+    await_abort: AtomicBool,
 }
 
 impl Default for WaylandDisplaySrc {
@@ -44,6 +46,7 @@ impl Default for WaylandDisplaySrc {
             settings: Mutex::new(Settings::default()),
             command_tx,
             command_rx: Mutex::new(Some(command_rx)),
+            await_abort: AtomicBool::new(false),
         }
     }
 }
@@ -53,6 +56,7 @@ pub struct Settings {
     render_node: Option<String>,
     input_devices: Vec<String>,
     disable_intel_workaround: bool,
+    await_listener: bool,
     #[cfg(feature = "cuda")]
     cuda_context: Option<Arc<Mutex<cuda::CUDAContext>>>,
     #[cfg(feature = "cuda")]
@@ -274,6 +278,18 @@ impl ObjectImpl for WaylandDisplaySrc {
                     )
                     .default_value(false)
                     .build(),
+                glib::ParamSpecBoolean::builder("await-listener")
+                    .nick("Await downstream listener")
+                    .blurb(
+                        "Defer caps negotiation until downstream advertises concrete caps (i.e. a \
+                         consumer is connected). This lets the output format be chosen jointly with \
+                         the consumer instead of fixing an arbitrary default before anything is \
+                         connected. Intended for decoupled setups (e.g. behind an interpipesink) \
+                         where the producer starts before the consumer. The wayland compositor runs \
+                         regardless, so the application can render while negotiation is deferred.",
+                    )
+                    .default_value(false)
+                    .build(),
             ]
         });
 
@@ -337,6 +353,10 @@ impl ObjectImpl for WaylandDisplaySrc {
                 settings.disable_intel_workaround =
                     value.get::<bool>().expect("Type checked upstream");
             }
+            "await-listener" => {
+                let mut settings = self.settings.lock().unwrap();
+                settings.await_listener = value.get::<bool>().expect("Type checked upstream");
+            }
             _ => unreachable!(),
         }
     }
@@ -370,6 +390,10 @@ impl ObjectImpl for WaylandDisplaySrc {
             "disable-intel-workaround" => {
                 let settings = self.settings.lock().unwrap();
                 settings.disable_intel_workaround.to_value()
+            }
+            "await-listener" => {
+                let settings = self.settings.lock().unwrap();
+                settings.await_listener.to_value()
             }
             _ => unreachable!(),
         }
@@ -608,7 +632,60 @@ impl BaseSrcImpl for WaylandDisplaySrc {
     }
 
     fn negotiate(&self) -> Result<(), gst::LoggableError> {
+        let await_listener = self.settings.lock().unwrap().await_listener;
+        if await_listener {
+            let Some(src_pad) = self.obj().static_pad("src") else {
+                return self.parent_negotiate();
+            };
+            // Fixing caps with no consumer connected would force an arbitrary
+            // default format that a consumer attaching later might be unable to
+            // ingest (the classic symptom is a converter such as vapostproc
+            // rejecting the chosen drm-format with not-negotiated). Defer until a
+            // consumer is connected, then negotiate jointly so the format is one
+            // both sides support.
+            //
+            // Detection: with nothing connected, the downstream caps query is
+            // answered transparently by the decoupling element (e.g. an
+            // interpipesink with no listeners), reflecting only static elements
+            // like a capsfilter. When a consumer connects it intersects its own
+            // caps in, changing the answer. We watch for that change rather than
+            // inspecting formats, so this stays fully format-agnostic. The
+            // wayland compositor runs on its own thread, so the application keeps
+            // rendering while we wait.
+            self.await_abort.store(false, Ordering::SeqCst);
+            let baseline = src_pad.peer_query_caps(None);
+            tracing::debug!("await-listener: baseline downstream caps {}", baseline);
+            loop {
+                if self.await_abort.load(Ordering::SeqCst) {
+                    return Err(gst::loggable_error!(
+                        CAT,
+                        "Negotiation aborted while awaiting a downstream consumer"
+                    ));
+                }
+                let peer = src_pad.peer_query_caps(None);
+                if !peer.is_empty() && peer != baseline {
+                    tracing::info!(
+                        "Downstream caps changed (consumer connected), negotiating jointly: {}",
+                        peer
+                    );
+                    break;
+                }
+                std::thread::sleep(std::time::Duration::from_millis(100));
+            }
+        }
         self.parent_negotiate()
+    }
+
+    fn unlock(&self) -> Result<(), gst::ErrorMessage> {
+        // Interrupt a pending await-listener wait in negotiate() so state
+        // changes (e.g. shutdown) don't block on a consumer that never arrives.
+        self.await_abort.store(true, Ordering::SeqCst);
+        self.parent_unlock()
+    }
+
+    fn unlock_stop(&self) -> Result<(), gst::ErrorMessage> {
+        self.await_abort.store(false, Ordering::SeqCst);
+        self.parent_unlock_stop()
     }
 
     fn event(&self, event: &Event) -> bool {


### PR DESCRIPTION
## Problem

When `waylanddisplaysrc` feeds a decoupled consumer through an `interpipesink` (as Wolf does for streaming), the producer pipeline starts and **fixes its output format before any consumer is listening**. With a generic producer cap such as `video/x-raw(memory:DMABuf)`, the compositor settles on the first advertised drm-format, which on both AMD and Intel is a 64-bit float format (`AB4H`). Downstream converters like `vapostproc` can't ingest it, so negotiation fails with `not-negotiated` once the client actually connects. Live renegotiation can't recover it: the in-flight buffer and the producer capsfilter are already anchored to the bad format.

## Fix

Add an opt-in `await-listener` property (default `false`, so existing behaviour is unchanged). When enabled, `negotiate()` waits until the downstream caps query changes (a consumer connected and intersected its own caps in) before fixing caps. The format is then chosen **jointly** with the consumer, so it's one both sides support.

Detection watches for the downstream caps **change** rather than inspecting formats, so it stays fully format-agnostic and keeps working as GPUs add new formats. The wayland compositor runs on its own thread, so the application keeps rendering while negotiation is deferred, and `unlock()` aborts the wait so state changes never block on a consumer that never arrives.

## Testing

Verified on real hardware via a producer/consumer interpipe harness (producer started first, consumer attached ~1.5s later, matching Wolf's lifecycle):

- **Intel VAAPI** (vapostproc + vah265enc): default-off reproduces the `not-negotiated` failure; `await-listener=true` negotiates jointly and produces H265 (exit 0).
- **AMD** (the originally reported GPU, vapostproc + vah265enc): `await-listener=true` produces H265 (exit 0); the producer correctly does not fixate early.
- Clean shutdown with `await-listener=true` and no consumer ever attaching (no hang).

Consumed by games-on-whales/wolf to fix DMA-BUF zero-copy negotiation (PR #419).