### PR TITLE
feat(cuda): dmabuftocuda for Nvidia NV12 encode

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,21 @@ In order to support this we leverage `gst-cuda-1.0` which adds a single build de
 At runtime, you'll need to have access to `libcuda.so` but only to access and use `CUDAMemory`; you can still use
 `DMABuf` when running this plugin on a platform that doesn't support it.
 
+### NV12 dmabuf → CUDA (`dmabuftocuda`)
+
+For the Vulkan NV12 path, the source emits an **NV12 DMABuf** (converted in-process by the Vulkan
+converter) and `dmabuftocuda` imports it into CUDA late, right before the encoder — also gated behind the
+`cuda` feature:
+
+```bash
+gst-launch-1.0 waylanddisplaysrc ! 'video/x-raw(memory:DMABuf),format=DMA_DRM,drm-format=NV12,width=1920,height=1080,framerate=60/1' ! queue ! dmabuftocuda ! nvh265enc ! nvh265dec ! autovideosink
+```
+
+The `! queue !` before `dmabuftocuda` is recommended: it runs the source's render+convert and the
+DMABuf→CUDA import on separate threads. `dmabuftocuda` caches the EGLImage/CUDA registration per
+DMABuf (the converter cycles a small ring), so the per-frame cost is just the CUDA copy and the element
+is no longer a serial bottleneck — but the `queue` still lets the two stages overlap.
+
 ## Run without a GPU
 
 If you don't have a GPU, you can still run this plugin without it; just use the option `render_node=software` to enable it. Example pipeline:

--- a/gst-plugin-wayland-display/Cargo.toml
+++ b/gst-plugin-wayland-display/Cargo.toml
@@ -18,7 +18,7 @@ default = []
 static = []
 capi = []
 doc = []
-cuda = []
+cuda = ["wayland-display-core/cuda"]
 
 [dependencies]
 gst.workspace = true

--- a/gst-plugin-wayland-display/src/dmabuftocuda/imp.rs
+++ b/gst-plugin-wayland-display/src/dmabuftocuda/imp.rs
@@ -1,0 +1,375 @@
+use std::sync::atomic::{AtomicBool, AtomicPtr, Ordering};
+use std::sync::{Arc, Mutex};
+
+use gst::glib;
+use gst::prelude::*;
+use gst::subclass::prelude::*;
+use gst_base::prelude::*;
+use gst_base::subclass::base_transform::{BaseTransformMode, GenerateOutputSuccess};
+use gst_base::subclass::prelude::*;
+use gst_video::{VideoFormat, VideoInfoDmaDrm};
+use once_cell::sync::Lazy;
+
+use waylanddisplaycore::utils::allocator::cuda::{
+    self, CAPS_FEATURE_MEMORY_CUDA_MEMORY, CUDABufferPool, CUDAContext, CudaUploader,
+    GstCudaContext,
+};
+
+#[derive(Default)]
+struct Settings {
+    render_node: Option<String>,
+}
+
+/// Per-caps negotiated state.
+struct Negotiated {
+    in_info: VideoInfoDmaDrm,
+    pool: CUDABufferPool,
+}
+
+// Field order matters for Drop: the CUDA buffer pool (in `negotiated`) and the
+// uploader must drop before `cuda_context`, since they reference the context.
+#[derive(Default)]
+pub struct DmabufToCuda {
+    settings: Mutex<Settings>,
+    negotiated: Mutex<Option<Negotiated>>,
+    uploader: Mutex<Option<CudaUploader>>,
+    cuda_context: Mutex<Option<Arc<Mutex<CUDAContext>>>>,
+    cuda_raw_ptr: AtomicPtr<GstCudaContext>,
+    // Set while acquiring the context, so the re-entrant set_context that
+    // gst_cuda_ensure_element_context triggers doesn't create a second wrapper.
+    acquiring: AtomicBool,
+}
+
+static CAT: Lazy<gst::DebugCategory> = Lazy::new(|| {
+    gst::DebugCategory::new(
+        "dmabuftocuda",
+        gst::DebugColorFlags::empty(),
+        Some("Wayland display NV12 DMABuf to CUDA uploader"),
+    )
+});
+
+impl DmabufToCuda {
+    /// Acquire (or reuse) a CUDA context shared with the rest of the pipeline.
+    fn ensure_cuda_context(&self) -> Option<Arc<Mutex<CUDAContext>>> {
+        if let Some(ctx) = self.cuda_context.lock().unwrap().as_ref() {
+            return Some(ctx.clone());
+        }
+        let elem = self.obj().upcast_ref::<gst::Element>().to_owned();
+        let raw = self.cuda_raw_ptr.as_ptr();
+        // gst_cuda_ensure_element_context re-enters set_context; block it from
+        // creating a competing wrapper for the same context.
+        self.acquiring.store(true, Ordering::SeqCst);
+        let result = CUDAContext::new_from_gstreamer(&elem, -1, raw);
+        self.acquiring.store(false, Ordering::SeqCst);
+        match result {
+            Ok(ctx) => {
+                let mut guard = self.cuda_context.lock().unwrap();
+                // A re-entrant set_context may already have stored one.
+                if let Some(existing) = guard.as_ref() {
+                    return Some(existing.clone());
+                }
+                let arc = Arc::new(Mutex::new(ctx));
+                *guard = Some(arc.clone());
+                Some(arc)
+            }
+            Err(e) => {
+                gst::error!(CAT, imp = self, "Failed to acquire CUDA context: {e}");
+                None
+            }
+        }
+    }
+
+    fn convert(&self, inbuf: &gst::Buffer) -> Result<gst::Buffer, gst::FlowError> {
+        let neg_guard = self.negotiated.lock().unwrap();
+        let neg = neg_guard.as_ref().ok_or(gst::FlowError::NotNegotiated)?;
+        let uploader_guard = self.uploader.lock().unwrap();
+        let uploader = uploader_guard
+            .as_ref()
+            .ok_or(gst::FlowError::NotNegotiated)?;
+        let cuda_guard = self.cuda_context.lock().unwrap();
+        let cuda_arc = cuda_guard.as_ref().ok_or(gst::FlowError::NotNegotiated)?;
+        let ctx = cuda_arc.lock().unwrap();
+
+        uploader
+            .upload(inbuf, &neg.in_info, &ctx, Some(&neg.pool))
+            .map_err(|e| {
+                gst::error!(CAT, imp = self, "dmabuf -> CUDA failed: {e}");
+                gst::FlowError::Error
+            })
+    }
+}
+
+/// DMABuf sink caps constrained to NV12, one structure per NV12 modifier this GPU's
+/// Vulkan can export -- the exact same `drm-format` strings `waylanddisplaysrc`
+/// advertises. Without this the sink would offer a bare `DMA_DRM` superset, the source
+/// would fixate on its preferred RGBA, and `reconstruct_nv12_dmabuf` would then receive a
+/// single-plane RGBA buffer it can't handle. (modifier 0 == LINEAR == bare "NV12".)
+fn nv12_dmabuf_caps(
+    width: Option<i32>,
+    height: Option<i32>,
+    framerate: Option<gst::Fraction>,
+    target_minor: Option<u32>,
+) -> gst::Caps {
+    const DRM_FORMAT_MOD_INVALID: u64 = 0x00ff_ffff_ffff_ffff;
+    let build_one = |drm: String| {
+        let mut b = gst_video::VideoCapsBuilder::new()
+            .features([gstreamer_allocators::CAPS_FEATURE_MEMORY_DMABUF])
+            .format(VideoFormat::DmaDrm)
+            .field("drm-format", drm);
+        if let Some(w) = width {
+            b = b.width(w);
+        }
+        if let Some(h) = height {
+            b = b.height(h);
+        }
+        if let Some(fr) = framerate {
+            b = b.framerate(fr);
+        }
+        b.build()
+    };
+    let drms: Vec<String> =
+        waylanddisplaycore::utils::vulkan_nv12::supported_nv12_modifiers(target_minor)
+            .iter()
+            .copied()
+            .filter(|&m| m != DRM_FORMAT_MOD_INVALID)
+            .map(|m| {
+                if m == 0 {
+                    "NV12".to_string()
+                } else {
+                    format!("NV12:0x{m:016x}")
+                }
+            })
+            .collect();
+    // Always offer at least bare NV12 (LINEAR), so negotiation works even if the
+    // modifier query came back empty.
+    let mut iter = drms.into_iter();
+    let mut caps = build_one(iter.next().unwrap_or_else(|| "NV12".to_string()));
+    for drm in iter {
+        caps.merge(build_one(drm));
+    }
+    caps
+}
+
+/// Build the opposite-direction caps, carrying over width/height/framerate. The DMABuf
+/// (sink) side is constrained to NV12 -- see [`nv12_dmabuf_caps`].
+fn transformed_caps(caps: &gst::Caps, to_cuda: bool, target_minor: Option<u32>) -> gst::Caps {
+    let s = caps.structure(0);
+    let width = s.and_then(|s| s.get::<i32>("width").ok());
+    let height = s.and_then(|s| s.get::<i32>("height").ok());
+    let framerate = s.and_then(|s| s.get::<gst::Fraction>("framerate").ok());
+    if to_cuda {
+        let mut builder = gst_video::VideoCapsBuilder::new()
+            .features([CAPS_FEATURE_MEMORY_CUDA_MEMORY])
+            .format(VideoFormat::Nv12);
+        if let Some(w) = width {
+            builder = builder.width(w);
+        }
+        if let Some(h) = height {
+            builder = builder.height(h);
+        }
+        if let Some(fr) = framerate {
+            builder = builder.framerate(fr);
+        }
+        builder.build()
+    } else {
+        nv12_dmabuf_caps(width, height, framerate, target_minor)
+    }
+}
+
+#[glib::object_subclass]
+impl ObjectSubclass for DmabufToCuda {
+    const NAME: &'static str = "GstDmabufToCuda";
+    type Type = super::DmabufToCuda;
+    type ParentType = gst_base::BaseTransform;
+}
+
+impl ObjectImpl for DmabufToCuda {
+    fn properties() -> &'static [glib::ParamSpec] {
+        static PROPERTIES: Lazy<Vec<glib::ParamSpec>> = Lazy::new(|| {
+            vec![
+                glib::ParamSpecString::builder("render-node")
+                    .nick("Render node")
+                    .blurb("DRM render node of the GPU that produced the dmabuf (e.g. /dev/dri/renderD128)")
+                    .build(),
+            ]
+        });
+        PROPERTIES.as_ref()
+    }
+
+    fn set_property(&self, _id: usize, value: &glib::Value, pspec: &glib::ParamSpec) {
+        match pspec.name() {
+            "render-node" => {
+                self.settings.lock().unwrap().render_node = value.get().expect("type checked");
+            }
+            _ => unimplemented!(),
+        }
+    }
+
+    fn property(&self, _id: usize, pspec: &glib::ParamSpec) -> glib::Value {
+        match pspec.name() {
+            "render-node" => self.settings.lock().unwrap().render_node.to_value(),
+            _ => unimplemented!(),
+        }
+    }
+}
+
+impl GstObjectImpl for DmabufToCuda {}
+
+impl ElementImpl for DmabufToCuda {
+    fn metadata() -> Option<&'static gst::subclass::ElementMetadata> {
+        static ELEMENT_METADATA: Lazy<gst::subclass::ElementMetadata> = Lazy::new(|| {
+            gst::subclass::ElementMetadata::new(
+                "Wayland display DMABuf to CUDA uploader",
+                "Filter/Video/Converter",
+                "Imports an NV12 DMABuf into CUDA memory via EGLImage (convert to CUDA late)",
+                "Games on Whales",
+            )
+        });
+        Some(&*ELEMENT_METADATA)
+    }
+
+    fn pad_templates() -> &'static [gst::PadTemplate] {
+        static PAD_TEMPLATES: Lazy<Vec<gst::PadTemplate>> = Lazy::new(|| {
+            let sink_caps = gst_video::VideoCapsBuilder::new()
+                .features([gstreamer_allocators::CAPS_FEATURE_MEMORY_DMABUF])
+                .format(VideoFormat::DmaDrm)
+                .build();
+            let src_caps = gst_video::VideoCapsBuilder::new()
+                .features([CAPS_FEATURE_MEMORY_CUDA_MEMORY])
+                .format(VideoFormat::Nv12)
+                .build();
+            vec![
+                gst::PadTemplate::new(
+                    "sink",
+                    gst::PadDirection::Sink,
+                    gst::PadPresence::Always,
+                    &sink_caps,
+                )
+                .unwrap(),
+                gst::PadTemplate::new(
+                    "src",
+                    gst::PadDirection::Src,
+                    gst::PadPresence::Always,
+                    &src_caps,
+                )
+                .unwrap(),
+            ]
+        });
+        PAD_TEMPLATES.as_ref()
+    }
+
+    fn set_context(&self, context: &gst::Context) {
+        // Skip while ensure_cuda_context is mid-acquire: gst_cuda_ensure_element_context
+        // re-enters here, and creating a second wrapper for the same context would
+        // over-unref it at teardown. Also skip if we already have one.
+        if !self.acquiring.load(Ordering::SeqCst) {
+            let mut guard = self.cuda_context.lock().unwrap();
+            if guard.is_none() {
+                let elem = self.obj().upcast_ref::<gst::Element>().to_owned();
+                let raw = self.cuda_raw_ptr.as_ptr();
+                if let Ok(ctx) = CUDAContext::new_from_set_context(&elem, context, -1, raw) {
+                    *guard = Some(Arc::new(Mutex::new(ctx)));
+                }
+            }
+        }
+        self.parent_set_context(context)
+    }
+}
+
+impl BaseTransformImpl for DmabufToCuda {
+    const MODE: BaseTransformMode = BaseTransformMode::NeverInPlace;
+    const PASSTHROUGH_ON_SAME_CAPS: bool = false;
+    const TRANSFORM_IP_ON_PASSTHROUGH: bool = false;
+
+    fn transform_caps(
+        &self,
+        direction: gst::PadDirection,
+        caps: &gst::Caps,
+        filter: Option<&gst::Caps>,
+    ) -> Option<gst::Caps> {
+        // Sink is DMABuf NV12, Src is CUDAMemory NV12.
+        let to_cuda = direction == gst::PadDirection::Sink;
+        // Query NV12 export modifiers on the GPU that produced the dmabuf (this element's
+        // render node), so a multi-GPU host advertises the right set.
+        let target_minor = self
+            .settings
+            .lock()
+            .unwrap()
+            .render_node
+            .as_deref()
+            .and_then(waylanddisplaycore::utils::vulkan_nv12::render_node_minor);
+        let mut result = transformed_caps(caps, to_cuda, target_minor);
+        if let Some(filter) = filter {
+            result = filter.intersect_with_mode(&result, gst::CapsIntersectMode::First);
+        }
+        Some(result)
+    }
+
+    fn query(&self, direction: gst::PadDirection, query: &mut gst::QueryRef) -> bool {
+        if query.type_() == gst::QueryType::Context {
+            if let Some(ctx) = self.cuda_context.lock().unwrap().as_ref() {
+                let ctx = ctx.lock().unwrap();
+                let elem = self.obj();
+                return cuda::gst_cuda_handle_context_query_wrapped(
+                    elem.upcast_ref::<gst::Element>(),
+                    query,
+                    &ctx,
+                );
+            }
+        }
+        BaseTransformImplExt::parent_query(self, direction, query)
+    }
+
+    fn start(&self) -> Result<(), gst::ErrorMessage> {
+        let render_node = self.settings.lock().unwrap().render_node.clone();
+        let uploader = CudaUploader::new(render_node.as_deref());
+        *self.uploader.lock().unwrap() = Some(uploader);
+        self.ensure_cuda_context();
+        Ok(())
+    }
+
+    fn stop(&self) -> Result<(), gst::ErrorMessage> {
+        // Release the pool and uploader, but keep the CUDA context: downstream CUDA
+        // buffers may still reference it until they are freed.
+        *self.negotiated.lock().unwrap() = None;
+        *self.uploader.lock().unwrap() = None;
+        Ok(())
+    }
+
+    fn set_caps(&self, incaps: &gst::Caps, outcaps: &gst::Caps) -> Result<(), gst::LoggableError> {
+        let in_info = VideoInfoDmaDrm::from_caps(incaps)
+            .map_err(|_| gst::loggable_error!(CAT, "invalid input caps {incaps}"))?;
+
+        let cuda_arc = self
+            .ensure_cuda_context()
+            .ok_or_else(|| gst::loggable_error!(CAT, "no CUDA context"))?;
+        let cuda_ctx = cuda_arc.lock().unwrap();
+
+        // Configure the output pool with the negotiated (fixed) src caps.
+        let pool = CUDABufferPool::new(&cuda_ctx)
+            .map_err(|e| gst::loggable_error!(CAT, "cuda pool: {e}"))?;
+        pool.configure(
+            outcaps,
+            cuda_ctx
+                .stream()
+                .ok_or_else(|| gst::loggable_error!(CAT, "no cuda stream"))?,
+            in_info.size() as u32,
+            0,
+            0,
+        )
+        .map_err(|e| gst::loggable_error!(CAT, "configure pool: {e}"))?;
+        pool.activate()
+            .map_err(|e| gst::loggable_error!(CAT, "activate pool: {e}"))?;
+        drop(cuda_ctx);
+
+        *self.negotiated.lock().unwrap() = Some(Negotiated { in_info, pool });
+        Ok(())
+    }
+
+    fn generate_output(&self) -> Result<GenerateOutputSuccess, gst::FlowError> {
+        match self.take_queued_buffer() {
+            Some(buffer) => Ok(GenerateOutputSuccess::Buffer(self.convert(&buffer)?)),
+            None => Ok(GenerateOutputSuccess::NoOutput),
+        }
+    }
+}

--- a/gst-plugin-wayland-display/src/dmabuftocuda/mod.rs
+++ b/gst-plugin-wayland-display/src/dmabuftocuda/mod.rs
@@ -1,0 +1,17 @@
+use gst::glib;
+use gst::prelude::*;
+
+mod imp;
+
+glib::wrapper! {
+    pub struct DmabufToCuda(ObjectSubclass<imp::DmabufToCuda>) @extends gst_base::BaseTransform, gst::Element, gst::Object;
+}
+
+pub fn register(plugin: &gst::Plugin) -> Result<(), glib::BoolError> {
+    gst::Element::register(
+        Some(plugin),
+        "dmabuftocuda",
+        gst::Rank::NONE,
+        DmabufToCuda::static_type(),
+    )
+}

--- a/gst-plugin-wayland-display/src/lib.rs
+++ b/gst-plugin-wayland-display/src/lib.rs
@@ -2,11 +2,15 @@ use gst::glib;
 #[cfg(feature = "cuda")]
 use waylanddisplaycore::utils::allocator::cuda;
 
+#[cfg(feature = "cuda")]
+mod dmabuftocuda;
 pub mod utils;
 mod waylandsrc;
 
 fn plugin_init(plugin: &gst::Plugin) -> Result<(), glib::BoolError> {
     waylandsrc::register(plugin)?;
+    #[cfg(feature = "cuda")]
+    dmabuftocuda::register(plugin)?;
     tracing_subscriber::fmt::try_init().ok();
     #[cfg(feature = "cuda")]
     match cuda::init_cuda() {

--- a/gst-plugin-wayland-display/src/waylandsrc/imp.rs
+++ b/gst-plugin-wayland-display/src/waylandsrc/imp.rs
@@ -909,22 +909,37 @@ impl BaseSrcImpl for WaylandDisplaySrc {
                     tracing::info!(
                         "Acquiring a CudaContext from the pipeline, you can manually set the `cuda-device-id` property to override this behavior"
                     );
-                    let cuda_raw_ptr = {
+                    let (cuda_raw_ptr, already_have) = {
                         let settings = self.settings.lock().unwrap();
-                        settings.cuda_raw_ptr.as_ptr()
+                        (
+                            settings.cuda_raw_ptr.as_ptr(),
+                            settings.cuda_context.is_some(),
+                        )
                     };
-                    match CUDAContext::new_from_gstreamer(&elem, -1, cuda_raw_ptr) {
-                        Ok(cuda_context) => {
-                            let mut settings = self.settings.lock().unwrap();
-                            if settings.cuda_context.is_none() {
-                                tracing::info!("Acquired a CudaContext via new_from_gstreamer");
-                                settings.cuda_context = Some(Arc::new(Mutex::new(cuda_context)));
-                            } else {
-                                tracing::info!("Acquired a CudaContext via set_context");
+                    // Only actively acquire when set_context hasn't already provided one.
+                    // Calling new_from_gstreamer when the element already has a context is a
+                    // ref-neutral no-op that hands back a *second* CUDAContext aliasing the
+                    // kept one (it owns no ref); dropping that alias would gst_object_unref a
+                    // ref we don't own, free the context early, and crash teardown when the
+                    // GstContext structure later unrefs the now-dead object.
+                    if already_have {
+                        tracing::info!("Acquired a CudaContext via set_context");
+                    } else {
+                        match CUDAContext::new_from_gstreamer(&elem, -1, cuda_raw_ptr) {
+                            Ok(cuda_context) => {
+                                let mut settings = self.settings.lock().unwrap();
+                                if settings.cuda_context.is_none() {
+                                    tracing::info!("Acquired a CudaContext via new_from_gstreamer");
+                                    settings.cuda_context =
+                                        Some(Arc::new(Mutex::new(cuda_context)));
+                                } else {
+                                    // set_context won a race; this is an unowned alias.
+                                    std::mem::forget(cuda_context);
+                                }
                             }
-                        }
-                        Err(err) => {
-                            gst::warning!(CAT, "Failed to acquire a CudaContext: {}", err);
+                            Err(err) => {
+                                gst::warning!(CAT, "Failed to acquire a CudaContext: {}", err);
+                            }
                         }
                     }
                 }

--- a/gst-plugin-wayland-display/tests/encode.rs
+++ b/gst-plugin-wayland-display/tests/encode.rs
@@ -152,6 +152,27 @@ fn intel_va_encode_to_eos() {
     .expect("Intel VA encode");
 }
 
+#[cfg(feature = "cuda")]
+#[test]
+#[ignore = "needs an Nvidia GPU + cuda feature + nvcodec; run via ci/harness.sh gpu"]
+fn nvidia_cuda_encode_to_eos() {
+    init();
+    let Some(node) = render_node_for(&["nvidia"]) else {
+        skip!("no Nvidia render node")
+    };
+    if !have("nvh265enc") || !have("dmabuftocuda") {
+        skip!("no nvh265enc/dmabuftocuda");
+    }
+    // Explicit resolution: nvh265enc has no width floor, so an unconstrained
+    // pipeline fixates to 1x1 and the converter builds 1x1 images.
+    run_to_eos(&format!(
+        "waylanddisplaysrc render-node={node} num-buffers=20 ! \
+         video/x-raw(memory:DMABuf),format=DMA_DRM,drm-format=NV12,width=1280,height=720,framerate=60/1 ! \
+         dmabuftocuda render-node={node} ! nvh265enc ! fakesink"
+    ))
+    .expect("Nvidia CUDA encode");
+}
+
 /// The converter advertises a usable NV12 modifier set for a present GPU --
 /// the precondition for any encoder negotiating with the source.
 #[test]

--- a/wayland-display-core/src/utils/allocator/cuda/mod.rs
+++ b/wayland-display-core/src/utils/allocator/cuda/mod.rs
@@ -4,7 +4,7 @@ use gst::glib::ffi as glib_ffi;
 use gst::glib::translate::ToGlibPtr;
 use gst::query::Allocation;
 use gst::{Buffer as GstBuffer, Context, Element, QueryRef};
-use gst_video::{VideoInfoDmaDrm, VideoMeta};
+use gst_video::{VideoFormat, VideoInfoDmaDrm, VideoMeta};
 use smithay::backend::allocator::Buffer;
 use smithay::backend::allocator::dmabuf::Dmabuf;
 use smithay::backend::egl;
@@ -142,6 +142,158 @@ impl Drop for EGLImage {
     }
 }
 
+/// Convert an already-filled external dmabuf (e.g. the NV12 buffer the compositor
+/// produced) into a CUDAMemory gst buffer, importing it via EGLImage and copying
+/// each plane on-GPU. This is the "convert to CUDA late" step for the Nvidia encode
+/// branch: the dmabuf flows through the system unchanged across all vendors, and
+/// only the Nvidia consumer maps it into CUDA right before the encoder. Works for
+/// any plane layout EGLImage::from handles (NV12 today, P010 for 10-bit/HDR).
+pub fn external_dmabuf_to_cuda_buffer(
+    dmabuf: &Dmabuf,
+    video_info: VideoInfoDmaDrm,
+    egl_display: &EGLDisplay,
+    cuda_context: &CUDAContext,
+    buffer_pool: Option<&CUDABufferPool>,
+) -> Result<GstBuffer, Box<dyn std::error::Error>> {
+    let egl_image = EGLImage::from(dmabuf, egl_display)?;
+    let cuda_image = CUDAImage::from(egl_image, cuda_context)?;
+    cuda_image.to_gst_buffer(video_info, cuda_context, buffer_pool)
+}
+
+/// Owns an EGLDisplay and turns incoming NV12 DMABuf gst buffers into CUDAMemory
+/// gst buffers - the "convert to CUDA late" step for the Nvidia encode branch. This
+/// keeps all smithay/EGL handling in the core so the gst plugin only deals with gst
+/// and CUDA types.
+pub struct CudaUploader {
+    egl: std::sync::Arc<smithay::backend::egl::EGLDisplay>,
+    /// EGLImage + CUDA registration cache keyed by the input dmabuf's primary fd. The
+    /// upstream converter cycles a small ring of dmabufs (one fd per ring slot), so an
+    /// incoming buffer's fd is one of a handful of stable values. Caching turns the
+    /// per-frame `eglCreateImageKHR` + `cuGraphicsEGLRegisterImage` (both expensive) into
+    /// a one-time cost per ring slot; per frame we only re-map and copy the
+    /// (updated-in-place) registered image. The registration stays valid because it maps
+    /// the dmabuf memory, which the converter overwrites in place each frame.
+    cache: std::sync::Mutex<std::collections::HashMap<i32, CUDAImage>>,
+}
+
+// The EGLDisplay is Send+Sync (it lives in the shared EGL_DISPLAYS cache); the cached
+// CUDAImages are only ever touched under the element's serialising lock.
+unsafe impl Send for CudaUploader {}
+
+impl CudaUploader {
+    /// Create an uploader bound to the given render node (or auto-selected when None).
+    pub fn new(render_node_path: Option<&str>) -> Self {
+        let node = render_node_path.and_then(|p| smithay::backend::drm::DrmNode::from_path(p).ok());
+        CudaUploader {
+            egl: crate::utils::renderer::setup_egl_display(node),
+            cache: std::sync::Mutex::new(std::collections::HashMap::new()),
+        }
+    }
+
+    /// Convert the incoming NV12 dmabuf gst buffer into a CUDAMemory gst buffer, reusing a
+    /// cached EGLImage/CUDA registration for the buffer's fd when possible.
+    pub fn upload(
+        &self,
+        inbuf: &gst::BufferRef,
+        in_info: &VideoInfoDmaDrm,
+        cuda_context: &CUDAContext,
+        buffer_pool: Option<&CUDABufferPool>,
+    ) -> Result<GstBuffer, Box<dyn std::error::Error>> {
+        let key = dmabuf_primary_fd(inbuf).ok_or("no dmabuf fd on input buffer")?;
+        let mut cache = self.cache.lock().unwrap();
+        if !cache.contains_key(&key) {
+            let dmabuf = reconstruct_nv12_dmabuf(inbuf, in_info)
+                .ok_or("failed to reconstruct NV12 dmabuf")?;
+            let raw_display = self.egl.get_display_handle().handle;
+            let egl_image = EGLImage::from(&dmabuf, &raw_display)?;
+            let cuda_image = CUDAImage::from(egl_image, cuda_context)?;
+            cache.insert(key, cuda_image);
+        }
+        // Per frame: re-map the cached registration (reflects the converter's in-place
+        // write) and copy into a fresh pooled CUDA buffer.
+        cache
+            .get(&key)
+            .unwrap()
+            .to_gst_buffer(in_info.clone(), cuda_context, buffer_pool)
+    }
+}
+
+/// The fd backing a gst buffer's first dmabuf memory -- the cache key (stable per
+/// converter ring slot).
+fn dmabuf_primary_fd(inbuf: &gst::BufferRef) -> Option<i32> {
+    let mem = inbuf.peek_memory(0);
+    let fd = unsafe { gstreamer_allocators::ffi::gst_dmabuf_memory_get_fd(mem.as_ptr() as *mut _) };
+    if fd < 0 { None } else { Some(fd) }
+}
+
+/// Rebuild a single 2-plane NV12 Dmabuf from a gst buffer's dmabuf memories (the
+/// inverse of Nv12Target::to_gst_buffer). Handles both the 2-memory layout the
+/// compositor produces (one plane per fd) and a single contiguous memory.
+pub(crate) fn reconstruct_nv12_dmabuf(
+    inbuf: &gst::BufferRef,
+    in_info: &VideoInfoDmaDrm,
+) -> Option<Dmabuf> {
+    use smithay::backend::allocator::dmabuf::DmabufFlags;
+    use smithay::reexports::drm::buffer::DrmFourcc;
+    use smithay::reexports::gbm::Modifier;
+    use std::os::fd::BorrowedFd;
+
+    let width = in_info.width();
+    let height = in_info.height();
+    let modifier = Modifier::from(in_info.modifier());
+    let vmeta = inbuf.meta::<VideoMeta>();
+    // Only 2-plane NV12 is supported. Bail cleanly (caller turns this into a
+    // FlowError) rather than indexing past the plane arrays below if a non-NV12
+    // buffer ever reaches here -- e.g. a single-plane RGBA buffer.
+    if let Some(m) = vmeta.as_ref() {
+        if m.format() != VideoFormat::Nv12 || m.n_planes() < 2 {
+            tracing::warn!(
+                "reconstruct_nv12_dmabuf: expected 2-plane NV12, got {:?} with {} plane(s)",
+                m.format(),
+                m.n_planes()
+            );
+            return None;
+        }
+    }
+    let stride = |plane: usize| -> u32 {
+        vmeta
+            .as_ref()
+            .map(|m| m.stride()[plane] as u32)
+            .unwrap_or(width)
+    };
+    let offset = |plane: usize| -> u32 {
+        vmeta
+            .as_ref()
+            .map(|m| m.offset()[plane] as u32)
+            .unwrap_or(0)
+    };
+
+    let n_mem = inbuf.n_memory();
+    let mut builder = Dmabuf::builder(
+        (width as i32, height as i32),
+        DrmFourcc::Nv12,
+        modifier,
+        DmabufFlags::empty(),
+    );
+    for plane in 0..2usize {
+        let (mem, off) = if n_mem >= 2 {
+            (inbuf.peek_memory(plane), 0u32)
+        } else {
+            (inbuf.peek_memory(0), offset(plane))
+        };
+        let raw_fd =
+            unsafe { gstreamer_allocators::ffi::gst_dmabuf_memory_get_fd(mem.as_ptr() as *mut _) };
+        if raw_fd < 0 {
+            return None;
+        }
+        let owned = unsafe { BorrowedFd::borrow_raw(raw_fd) }
+            .try_clone_to_owned()
+            .ok()?;
+        builder.add_plane(owned, plane as u32, off, stride(plane));
+    }
+    builder.build()
+}
+
 pub const CAPS_FEATURE_MEMORY_CUDA_MEMORY: &str = "memory:CUDAMemory"; // TODO: get it from FFI from gstcudamemory.h (https://github.com/GStreamer/gstreamer/blob/9d6abcc18cc9a60a212966a2daaf4a1af243f5da/subprojects/gst-plugins-bad/gst-libs/gst/cuda/gstcudamemory.h#L113-L121)
 
 pub fn init_cuda() -> Result<(), String> {
@@ -170,6 +322,11 @@ pub struct CUDAContext {
 
 impl Drop for CUDAContext {
     fn drop(&mut self) {
+        // Release the CUDA stream first: destroying a stream pushes its parent
+        // context, which must still be a valid GstCudaContext at that point.
+        // Dropping the context before the stream triggers GST_IS_CUDA_CONTEXT
+        // failures (and a use-after-free) during teardown.
+        self.stream = None;
         unsafe {
             gst::ffi::gst_object_unref(self.ptr as *mut gst::ffi::GstObject);
         }

--- a/wayland-display-core/src/utils/allocator/mod.rs
+++ b/wayland-display-core/src/utils/allocator/mod.rs
@@ -984,6 +984,92 @@ mod tests {
         assert_eq!(buf_meta.n_planes(), 1);
     }
 
+    /// Validates the "convert to CUDA late" step on real Nvidia hardware: the
+    /// compositor produces an NV12 dmabuf, which is reconstructed into a single
+    /// 2-plane NV12 dmabuf and imported into CUDA via EGLImage, then copied
+    /// plane-by-plane into a CUDAMemory buffer ready for nvh265enc. Nvidia only.
+    #[cfg(feature = "cuda")]
+    #[test]
+    #[ignore = "needs an Nvidia GPU + CUDA; run via ci/harness.sh gpu"]
+    fn test_nv12_to_cuda() {
+        test_init();
+        if cuda::init_cuda().is_err() {
+            skip!("CUDA not available");
+        }
+        let Some(render_node) = pick_render_node(&["nvidia"]) else {
+            skip!("no Nvidia render node");
+        };
+        let mut renderer = setup_renderer(Some(render_node));
+        let (w, h) = (256u32, 256u32);
+
+        let caps = gst_video::VideoCapsBuilder::new()
+            .features([gstreamer_allocators::CAPS_FEATURE_MEMORY_DMABUF])
+            .format(VideoFormat::DmaDrm)
+            .field("drm-format", "NV12")
+            .width(w as i32)
+            .height(h as i32)
+            .pixel_aspect_ratio(1.into())
+            .framerate(gst::Fraction::new(30, 1))
+            .build();
+        let video_info = VideoInfoDmaDrm::from_caps(&caps).expect("video info");
+
+        // Produce the NV12 dmabuf the way the compositor does now: render the
+        // scene into the RGBA target, let the Vulkan converter export NV12, then
+        // reconstruct a single 2-plane NV12 dmabuf (exactly what dmabuftocuda
+        // builds from an incoming gst buffer).
+        let nv12buf =
+            GsNv12Buf::new(&mut renderer, render_node, video_info.clone()).expect("nv12 buf");
+        let mut rgba = nv12buf.rgba.clone();
+        let mut buffer = GsBufferType::NV12(nv12buf);
+        let buffer_clone = buffer.clone();
+        let mut target = buffer.bind(&mut renderer).expect("bind nv12 rgba target");
+        render_into(&mut renderer, &mut rgba, w as i32, h as i32);
+        let gst_buffer = buffer_clone
+            .to_gs_buffer(&mut target, &mut renderer)
+            .expect("convert rgba -> nv12");
+        let nv12 = cuda::reconstruct_nv12_dmabuf(gst_buffer.as_ref(), &video_info)
+            .expect("reconstruct nv12 dmabuf");
+
+        // Late conversion: NV12 dmabuf -> CUDAMemory.
+        let cuda_ctx = CUDAContext::new(0).expect("cuda context");
+        let cuda_caps = gst_video::VideoCapsBuilder::new()
+            .features([cuda::CAPS_FEATURE_MEMORY_CUDA_MEMORY])
+            .format(VideoFormat::Nv12)
+            .width(w as i32)
+            .height(h as i32)
+            .pixel_aspect_ratio(1.into())
+            .framerate(gst::Fraction::new(30, 1))
+            .build();
+        let pool = CUDABufferPool::new(&cuda_ctx).expect("pool");
+        pool.configure(
+            &cuda_caps,
+            cuda_ctx.stream().expect("cuda stream"),
+            video_info.size() as u32,
+            0,
+            0,
+        )
+        .expect("configure pool");
+        pool.activate().expect("activate pool");
+
+        let egl_display = renderer.egl_context().display().get_display_handle().handle;
+        let gst_buffer = cuda::external_dmabuf_to_cuda_buffer(
+            &nv12,
+            video_info.clone(),
+            &egl_display,
+            &cuda_ctx,
+            Some(&pool),
+        )
+        .expect("dmabuf -> cuda");
+
+        let nv12_size = (w * h + w * h / 2) as usize;
+        println!(
+            "nv12->cuda OK: buffer size = {} (>= NV12 {})",
+            gst_buffer.size(),
+            nv12_size
+        );
+        assert!(gst_buffer.size() >= nv12_size, "CUDA NV12 buffer too small");
+    }
+
     #[test]
     fn test_gst_video_format_conversions() {
         test_init();

--- a/wayland-display-core/src/utils/renderer/mod.rs
+++ b/wayland-display-core/src/utils/renderer/mod.rs
@@ -19,13 +19,16 @@ pub fn get_egl_device_for_node(drm_node: &DrmNode) -> EGLDevice {
         .expect("Unable to find EGLDevice for drm-node")
 }
 
-pub fn setup_renderer(render_node: Option<DrmNode>) -> GlesRenderer {
+/// Create (or reuse) the EGLDisplay for a render node, shared with `setup_renderer`
+/// via the EGL_DISPLAYS cache. Used by the late dmabuf->CUDA element, which needs an
+/// EGLDisplay to import dmabufs but no GlesRenderer.
+pub fn setup_egl_display(render_node: Option<DrmNode>) -> Arc<EGLDisplay> {
     let mut displays = EGL_DISPLAYS.lock().unwrap();
     let maybe_display = displays
         .get(&render_node)
         .and_then(|weak_display| weak_display.upgrade());
 
-    let egl = match maybe_display {
+    match maybe_display {
         Some(display) => display,
         None => {
             let device = match render_node.as_ref() {
@@ -45,7 +48,11 @@ pub fn setup_renderer(render_node: Option<DrmNode>) -> GlesRenderer {
             displays.insert(render_node, Arc::downgrade(&display));
             display
         }
-    };
+    }
+}
+
+pub fn setup_renderer(render_node: Option<DrmNode>) -> GlesRenderer {
+    let egl = setup_egl_display(render_node);
     let context = EGLContext::new(&egl).expect("Failed to initialize EGL context");
     let renderer = unsafe { GlesRenderer::new(context) }.expect("Failed to initialize renderer");
     renderer


### PR DESCRIPTION
Nvidia path. Stacks on #37.

waylanddisplaysrc ! dmabuftocuda ! nvh265enc. Behind the cuda feature.

dmabuftocuda does the late NV12 dmabuf to CUDA upload for nvenc. EGLImage and CUDA registration cached per ring fd, so per frame is just the copy. Sink negotiates NV12 only, so the source can't fixate RGBA and panic. Also fixes the cuda feature wiring (broken on stable) and a context teardown double-unref. The new code is behind the cuda feature.

Tested to EOS, 20 frames:
- Nvidia 5080, dmabuftocuda ! nvh265enc
- AMD 7900 XTX and Intel UHD 770, VA encode still green
