### PR TITLE
feat(nv12): negotiate the encoder's NV12 modifier

### DIFF
--- a/gst-plugin-wayland-display/src/waylandsrc/imp.rs
+++ b/gst-plugin-wayland-display/src/waylandsrc/imp.rs
@@ -537,6 +537,65 @@ impl ElementImpl for WaylandDisplaySrc {
     }
 }
 
+impl WaylandDisplaySrc {
+    /// Guard the NV12 export path: refuse a negotiated modifier the Vulkan converter can't
+    /// export, so a bad negotiation fails here with a clear error instead of green/garbled
+    /// frames downstream. Non-NV12 DMA caps (the compositor's RGBA dmabuf) pass untouched.
+    fn check_nv12_export(
+        &self,
+        caps: &gst::Caps,
+        info: &VideoInfoDmaDrm,
+    ) -> Result<(), gst::LoggableError> {
+        let is_nv12 = caps
+            .structure(0)
+            .and_then(|s| s.get::<String>("drm-format").ok())
+            .is_some_and(|f| f.starts_with("NV12"));
+        if !is_nv12 {
+            return Ok(());
+        }
+        let (render_path, prefer_nv12) = {
+            let s = self.settings.lock().unwrap();
+            (
+                s.render_node
+                    .clone()
+                    .unwrap_or_else(|| "/dev/dri/renderD128".into()),
+                s.nv12,
+            )
+        };
+        let minor = waylanddisplaycore::utils::vulkan_nv12::render_node_minor(&render_path);
+        let modifier = info.modifier();
+        let exportable = waylanddisplaycore::utils::vulkan_nv12::supported_nv12_modifiers(minor);
+        let encoder_pref = waylanddisplaycore::utils::va_query::import_nv12_modifier(&render_path);
+        tracing::info!(
+            "waylandsrc: NV12 export modifier {modifier:#x} on {render_path} \
+             (encoder imports {encoder_pref:#x?}, exportable {exportable:#x?})"
+        );
+        if !exportable.contains(&modifier) {
+            return Err(gst::loggable_error!(
+                CAT,
+                "negotiated NV12 modifier {modifier:#x} is not Vulkan-exportable on \
+                 {render_path} (exportable: {exportable:#x?})"
+            ));
+        }
+        // Direct `! vah265enc`: exporting anything but the encoder's own modifier makes it
+        // re-import (and radeonsi-VA then fails). Behind interpipe (`nv12=true`) a
+        // LINEAR/encoder mismatch is expected -- the consumer's vapostproc imports it -- so
+        // only flag it on the direct path.
+        if !prefer_nv12 {
+            if let Some(pref) = encoder_pref {
+                if pref != modifier {
+                    tracing::warn!(
+                        "waylandsrc: exporting NV12 modifier {modifier:#x} but the VA encoder \
+                         on {render_path} imports {pref:#x}; a direct encode needs a vapostproc \
+                         bridge"
+                    );
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
 impl BaseSrcImpl for WaylandDisplaySrc {
     #[cfg(feature = "cuda")]
     fn query(&self, query: &mut gst::QueryRef) -> bool {
@@ -640,31 +699,60 @@ impl BaseSrcImpl for WaylandDisplaySrc {
             }
         }
 
-        // NV12 via the in-process Vulkan converter: the compositor renders RGBA and
-        // Vulkan converts to an NV12 dmabuf. Advertise every NV12 modifier this GPU's
-        // Vulkan can export, so negotiation intersects with the encoder's accepted
-        // modifiers (e.g. the AMD VA tiled modifier) and the converter then exports
-        // that exact modifier -- no LINEAR-vs-tiled mismatch, no guessing. (modifier 0
-        // == LINEAR, advertised as bare "NV12"; INVALID is skipped.)
+        // NV12 via the in-process Vulkan converter: the compositor renders RGBA and Vulkan
+        // converts to an NV12 dmabuf. The modifier we advertise is the one downstream can
+        // import without a re-import, and we pick it deterministically rather than offering
+        // a list and hoping negotiation lands right (it can't behind interpipe -- there's no
+        // encoder in the pipeline to intersect with).
         const DRM_FORMAT_MOD_INVALID: u64 = 0x00ff_ffff_ffff_ffff;
-        // Query the same GPU the converter will run on (the compositor's render node), so
-        // the advertised modifiers match what we can actually export in a multi-GPU host.
-        let nv12_minor = {
-            let path = self
-                .settings
-                .lock()
-                .unwrap()
-                .render_node
-                .clone()
-                .unwrap_or_else(|| "/dev/dri/renderD128".into());
-            waylanddisplaycore::utils::vulkan_nv12::render_node_minor(&path)
+        const DRM_FORMAT_MOD_LINEAR: u64 = 0;
+        let (render_path, prefer_nv12) = {
+            let s = self.settings.lock().unwrap();
+            (
+                s.render_node
+                    .clone()
+                    .unwrap_or_else(|| "/dev/dri/renderD128".into()),
+                s.nv12,
+            )
         };
-        let mut nv12_caps = gst::Caps::new_empty();
-        for &m in waylanddisplaycore::utils::vulkan_nv12::supported_nv12_modifiers(nv12_minor) {
-            if m == DRM_FORMAT_MOD_INVALID {
-                continue;
+        // Match the GPU the converter runs on (the compositor's render node), so advertised
+        // modifiers are ones we can actually export on a multi-GPU host.
+        let nv12_minor = waylanddisplaycore::utils::vulkan_nv12::render_node_minor(&render_path);
+
+        // `nv12=true` is Wolf: `waylanddisplaysrc ! interpipesink`, the encoder sits behind
+        // interpipe so no caps negotiation reaches us. Pin LINEAR -- the one NV12 modifier
+        // every VA importer (the consumer's vapostproc) takes -- instead of a tiled/DCC
+        // modifier radeonsi-VA mis-imports into green frames. Direct (`! vah265enc`): order
+        // the encoder's own modifier (queried from the driver) first so negotiation lands on
+        // exactly what it wants, then LINEAR, then the rest the GPU can export.
+        let nv12_mods: Vec<u64> = if prefer_nv12 {
+            vec![DRM_FORMAT_MOD_LINEAR]
+        } else {
+            let exportable =
+                waylanddisplaycore::utils::vulkan_nv12::supported_nv12_modifiers(nv12_minor);
+            let encoder_pref =
+                waylanddisplaycore::utils::va_query::import_nv12_modifier(&render_path);
+            let mut ordered: Vec<u64> = Vec::new();
+            if let Some(p) = encoder_pref {
+                if p != DRM_FORMAT_MOD_INVALID && exportable.contains(&p) {
+                    ordered.push(p);
+                }
             }
-            let drm = if m == 0 {
+            if exportable.contains(&DRM_FORMAT_MOD_LINEAR) {
+                ordered.push(DRM_FORMAT_MOD_LINEAR);
+            }
+            let rest: Vec<u64> = exportable
+                .iter()
+                .copied()
+                .filter(|m| *m != DRM_FORMAT_MOD_INVALID && !ordered.contains(m))
+                .collect();
+            ordered.extend(rest);
+            ordered
+        };
+
+        let mut nv12_caps = gst::Caps::new_empty();
+        for m in nv12_mods {
+            let drm = if m == DRM_FORMAT_MOD_LINEAR {
                 "NV12".to_string()
             } else {
                 format!("NV12:0x{m:016x}")
@@ -684,7 +772,6 @@ impl BaseSrcImpl for WaylandDisplaySrc {
         // (e.g. an unconstrained interpipesink, as in Wolf) fixates on NV12 instead of
         // RGBA; RGBA stays appended as a fallback. Default: RGBA first (current behaviour),
         // with NV12 still offered for encoders that request it directly.
-        let prefer_nv12 = self.settings.lock().unwrap().nv12;
         let mut caps = if prefer_nv12 {
             nv12_caps.merge(caps);
             nv12_caps
@@ -796,7 +883,10 @@ impl BaseSrcImpl for WaylandDisplaySrc {
 
     fn set_caps(&self, caps: &gst::Caps) -> Result<(), gst::LoggableError> {
         let video_info = match VideoInfoDmaDrm::from_caps(caps) {
-            Ok(dma_video_info) => GstVideoInfo::DMA(dma_video_info),
+            Ok(dma_video_info) => {
+                self.check_nv12_export(caps, &dma_video_info)?;
+                GstVideoInfo::DMA(dma_video_info)
+            }
             #[cfg(feature = "cuda")]
             Err(_) => {
                 let base_video_info =

--- a/wayland-display-core/src/utils/mod.rs
+++ b/wayland-display-core/src/utils/mod.rs
@@ -1,6 +1,7 @@
 pub mod allocator;
 pub mod device;
 pub mod renderer;
+pub mod va_query;
 pub mod va_share;
 pub mod video_info;
 pub mod vulkan_nv12;

--- a/wayland-display-core/src/utils/va_query.rs
+++ b/wayland-display-core/src/utils/va_query.rs
@@ -1,0 +1,97 @@
+//! Ask the VA driver which NV12 DRM modifier its encoder imports.
+//!
+//! The encoder advertises exactly one NV12 modifier per render node: the one
+//! `gst_va_dmabuf_get_modifier_for_format` returns (gst-va creates a surface, exports it,
+//! and reads back `drm_format_modifier`). Our source has to export that same modifier for
+//! a direct `! vah265enc` to negotiate without a re-import. Behind interpipe there's no
+//! encoder to negotiate against, so we query the driver out of band instead of guessing.
+//!
+//! Loads the same `libgstva-1.0` as [`super::va_share`] and calls two public symbols, so a
+//! missing lib is a runtime warning, not a link error. Best-effort: any failure returns
+//! `None` and the caller treats the encoder's modifier as unknown.
+
+use libloading::Library;
+use std::ffi::CString;
+use std::os::raw::{c_char, c_int, c_uint, c_void};
+use std::sync::{Mutex, OnceLock};
+
+const GST_VIDEO_FORMAT_NV12: c_int = 23;
+// VASurfaceAttribUsageHint: encoder input (matches va_share's export hint).
+const VA_USAGE_HINT_ENCODER: c_uint = 0x0000_0002;
+/// `DRM_FORMAT_MOD_INVALID` -- gst-va's "driver has no modifier for this format".
+const DRM_FORMAT_MOD_INVALID: u64 = 0x00ff_ffff_ffff_ffff;
+
+type DisplayDrmNewFromPath = unsafe extern "C" fn(*const c_char) -> *mut c_void;
+type ModifierForFormat = unsafe extern "C" fn(*mut c_void, c_int, c_uint) -> u64;
+
+struct QueryLib {
+    _lib: Library,
+    display_new: DisplayDrmNewFromPath,
+    modifier_for_format: ModifierForFormat,
+}
+
+fn querylib() -> Option<&'static QueryLib> {
+    static LIB: OnceLock<Option<QueryLib>> = OnceLock::new();
+    LIB.get_or_init(|| match unsafe { load() } {
+        Ok(l) => Some(l),
+        Err(e) => {
+            tracing::warn!("va_query: encoder modifier probe disabled ({e})");
+            None
+        }
+    })
+    .as_ref()
+}
+
+unsafe fn load() -> Result<QueryLib, Box<dyn std::error::Error>> {
+    unsafe {
+        let lib = ["libgstva-1.0.so.0", "libgstva-1.0.so"]
+            .iter()
+            .find_map(|n| Library::new(n).ok())
+            .ok_or("libgstva-1.0 not found")?;
+        let display_new =
+            *lib.get::<DisplayDrmNewFromPath>(b"gst_va_display_drm_new_from_path\0")?;
+        let modifier_for_format =
+            *lib.get::<ModifierForFormat>(b"gst_va_dmabuf_get_modifier_for_format\0")?;
+        Ok(QueryLib {
+            _lib: lib,
+            display_new,
+            modifier_for_format,
+        })
+    }
+}
+
+/// The NV12 DRM modifier the VA encoder on `render_node` imports (its preferred encode-input
+/// layout), or `None` if libgstva is missing, the node has no VA driver, or the driver
+/// reports no modifier. `Some(0)` means LINEAR. Queried once per node and cached.
+pub fn import_nv12_modifier(render_node: &str) -> Option<u64> {
+    static CACHE: OnceLock<Mutex<Vec<(String, Option<u64>)>>> = OnceLock::new();
+    let mut guard = CACHE.get_or_init(|| Mutex::new(Vec::new())).lock().unwrap();
+    if let Some((_, m)) = guard.iter().find(|(n, _)| n == render_node) {
+        return *m;
+    }
+    let m = unsafe { query(render_node) };
+    guard.push((render_node.to_string(), m));
+    m
+}
+
+unsafe fn query(render_node: &str) -> Option<u64> {
+    let lib = querylib()?;
+    let path = CString::new(render_node).ok()?;
+    unsafe {
+        let display = (lib.display_new)(path.as_ptr());
+        if display.is_null() {
+            tracing::warn!("va_query: no VA display on {render_node}");
+            return None;
+        }
+        let modifier =
+            (lib.modifier_for_format)(display, GST_VIDEO_FORMAT_NV12, VA_USAGE_HINT_ENCODER);
+        // gst_va_display_drm_new_from_path returns a full ref (GstObject).
+        gst::glib::gobject_ffi::g_object_unref(display as *mut _);
+        if modifier == DRM_FORMAT_MOD_INVALID {
+            tracing::warn!("va_query: {render_node} VA encoder reports no NV12 modifier");
+            return None;
+        }
+        tracing::debug!("va_query: {render_node} VA encoder imports NV12 modifier {modifier:#x}");
+        Some(modifier)
+    }
+}

--- a/wayland-display-core/src/utils/vulkan_nv12.rs
+++ b/wayland-display-core/src/utils/vulkan_nv12.rs
@@ -329,30 +329,9 @@ impl VulkanNv12 {
             dev_props.vendor_id
         );
 
-        // PROTOTYPE (env-gated, off by default) -- VA-native-surface workaround for
-        // the RX 9070 / GFX12. There `vah265enc` negotiates *only* the AMD DCC NV12
-        // modifier for DMABuf, but radeonsi-VA cannot import radv's DCC metadata as an
-        // encode source, so the encoder fails to create its reconstruct picture. We
-        // can't change what the encoder negotiates, but we *can* change what we export:
-        // forcing the export image to LINEAR (which radeonsi-VA imports cleanly) lets
-        // `va_share` attach a real VA surface to the buffer, which the encoder then
-        // *reuses* (`gst_va_memory_peek_display`) instead of re-importing the dmabuf --
-        // so the negotiated DCC caps only label a buffer the encoder consumes via its VA
-        // surface. No-op where the encoder already negotiates LINEAR (7900 XTX / Intel),
-        // so it can't be validated there: run on a 9070 with
-        // `WAYLANDDISPLAY_VA_FORCE_LINEAR_EXPORT=1`.
-        let export_modifier = if implicit_sync
-            && export_modifier != DRM_FORMAT_MOD_LINEAR
-            && std::env::var_os("WAYLANDDISPLAY_VA_FORCE_LINEAR_EXPORT").is_some()
-        {
-            tracing::info!(
-                "VulkanNv12: VA_FORCE_LINEAR_EXPORT -- exporting LINEAR instead of \
-                 negotiated {export_modifier:#x} (9070 VA-surface workaround)"
-            );
-            DRM_FORMAT_MOD_LINEAR
-        } else {
-            export_modifier
-        };
+        // We export exactly the negotiated modifier (the caps layer already picked one the
+        // encoder imports -- LINEAR for the interpipe/vapostproc path, the encoder's own
+        // modifier for a direct `! vah265enc`). No env-gated override.
 
         let qfi = instance
             .get_physical_device_queue_family_properties(pd)


### PR DESCRIPTION
Stacks on #37. Answers the modifier question raised there.

#37 advertised every NV12 modifier and let negotiation pick. Behind interpipe nothing negotiates, so it picked a tiled modifier the consumer reads as green. Same modifier guess as wolf:stable.

This pins it instead of guessing:

- `nv12=true` advertises LINEAR only. No encoder in the pipeline to negotiate with, so pin the one modifier every VA importer takes. Kills the green.
- Direct `! vah265enc` orders the encoder's own modifier first, queried from the driver via `gst_va_dmabuf_get_modifier_for_format`. Negotiation lands where the encoder wants, not on merge order.
- Fail loud on a modifier we can't export, instead of garbled frames.
- Drops the env LINEAR hack.

New `va_query.rs` loads the same libgstva-1.0 as `va_share` and calls two public symbols. Missing lib is a runtime warning, not a link error.

Tested AMD 7900 XTX (renderD128):

- driver reports NV12 import modifier LINEAR
- direct `waylanddisplaysrc ! vah265enc` negotiates LINEAR, reaches EOS
- `nv12=true ! vapostproc ! VAMemory NV12 ! vah265enc ! vah265dec` decodes SMPTE clean, no green

Note: the 9070 case (encoder accepts only DCC) stays blocked by radv/radeonsi DCC interop. The 7900 XTX imports LINEAR directly, so direct encode works there. For Wolf, keep vapostproc on the consumer and set `nv12=true` on the producer (draft wolf PR to follow).
