### PR TITLE
fix(cuda): free the transfer-full pool config that pinned the GstCudaContext

### DIFF
--- a/gst-plugin-wayland-display/src/waylandsrc/imp.rs
+++ b/gst-plugin-wayland-display/src/waylandsrc/imp.rs
@@ -671,7 +671,13 @@ impl BaseSrcImpl for WaylandDisplaySrc {
 
         match pool {
             Ok(pool) => {
-                let caps = unsafe { gst::Caps::from_glib_full(outcaps.unwrap().as_ptr()) };
+                // The allocation query only lends us its caps (`query.get()` borrows), so
+                // adopt it with `from_glib_none`. `from_glib_full` consumed a reference we
+                // never owned, leaving the negotiated caps one short. Paired with the
+                // `gst_structure_free` in `CUDABufferPool::get_updated_size()`: the pool
+                // config holds a ref on this same caps, so releasing the config copy while
+                // the over-unref is present drops the caps below its true count.
+                let caps = unsafe { gst::Caps::from_glib_none(outcaps.unwrap().as_ptr()) };
                 let stream = cuda_ctx.stream().expect("failed to get CUDA stream");
                 pool.configure(&caps, &stream, size, min, max)
                     .expect("failed to configure CUDA pool");

--- a/wayland-display-core/src/utils/allocator/cuda/mod.rs
+++ b/wayland-display-core/src/utils/allocator/cuda/mod.rs
@@ -280,6 +280,22 @@ impl CUDABufferPool {
                 ptr::null_mut(),
                 ptr::null_mut(),
             );
+            // `gst_buffer_pool_get_config()` is (transfer full) -- it returns a fresh
+            // `gst_structure_copy()` of the pool's config and the caller must free it.
+            // (`configure()` above is safe because `gst_buffer_pool_set_config()` consumes
+            // its copy.) The copy also re-refs every field value, including the
+            // `cuda-stream` `GstCudaStream` that `configure()` installed, and
+            // `gst_cuda_stream_new()` holds a `gst_object_ref()` on its `GstCudaContext`.
+            // Leaking this structure therefore pins the CUDA context for the lifetime of
+            // the process, and nothing can reclaim it: the retaining structure is detached
+            // from every object, so no teardown path reaches it.
+            //
+            // Must stay paired with the `Caps::from_glib_none` fix in
+            // `waylandsrc/imp.rs::decide_allocation` -- that borrowed caps pointer used to
+            // be adopted with `from_glib_full`, leaving the negotiated caps one reference
+            // short. This config copy holds a ref on the same caps, so freeing it here
+            // while that over-unref is present drops the caps below its true count.
+            gst::ffi::gst_structure_free(config);
         }
         Ok(size)
     }


### PR DESCRIPTION
`CUDABufferPool::get_updated_size()` calls `gst_buffer_pool_get_config()` and never frees the
result. That function is **`(transfer full)`** — it returns a fresh `gst_structure_copy()` of the
pool's config and the caller owns it. The sibling `configure()` makes the same call but hands its
copy to `gst_buffer_pool_set_config()`, which consumes it, so `get_updated_size()` is the only
leaking caller.

The leak is not just a stray `GstStructure`. `gst_structure_copy()` copies every field value, and
`configure()` has just installed a `cuda-stream` field via
`gst_buffer_pool_config_set_cuda_stream()`. `GST_TYPE_CUDA_STREAM` is a boxed type whose copy/free
are `gst_mini_object_ref`/`gst_mini_object_unref`, so the copy takes a new reference on the
`GstCudaStream` — and `gst_cuda_stream_new()` holds `gst_object_ref (context)` on its
`GstCudaContext`, released only in `_gst_cuda_stream_free()`. The retaining chain:

```
leaked GstStructure (config copy)  ->  cuda-stream field  ->  GstCudaStream  ->  GstCudaContext
```

`decide_allocation()` negotiates more than once per stream, so several config copies leak per
stream, each pinning the stream object and through it one reference to the CUDA context.

### Impact depends on who owns the context

When `waylanddisplaysrc` creates its own context it is process-lifetime anyway and the leak is
invisible — which is probably why this has gone unnoticed. When the application **injects one per
session** via `gst_element_set_context()` (the sharing path this element already supports through
`cuda-device-id`), that session's `GstCudaContext` is never finalized: roughly **500 MiB of VRAM
plus one `cuda-EvtHandlr` driver thread leaked per session**, growing linearly. I hit it as an
unbounded VRAM staircase across sessions on a multi-session host.

### Second hunk, and why it must land with the first

Same function: the allocation query's caps was adopted with `Caps::from_glib_full`, consuming a
reference the element never owned and leaving the negotiated caps one short. That is latent while
the config copy leaks, because the copy holds a compensating reference on the *same* caps.

Fix only the leak and the caps drops below its true count. The failure is quiet and misleading:
streams still negotiate, connect and decode at full frame rate, but buffers are never released and
every session's pipelines are retained. On my leak-only build: 843 MiB VRAM, ~3000 live
`GstMemory`, ~1000 live `GstBuffer` and 6 live `GstPipeline` after two sessions, plus one
`free_priv_data: object finalizing but still has 1 parents` per session. So the two hunks are one
change; splitting them is worse than neither.

### Why it is hard to see with the leaks tracer

Worth recording for the next person: a `GstStructure` is not refcounted and `GstCudaStream` is a
`GstMiniObject`, so `leaks(filters=GstObject)` shows one `GstCudaContext` alive at **ref-count 1
with no `GstObject` retaining it** — which reads as an impossible leak. `filters=` also restricts
what the tracer *tracks*, so hand-naming candidate types still hides holders you did not guess.
Running `leaks` **unfiltered** is what made the chain visible: after one session it reported
exactly three live objects (`GstCudaStream`, `GstCudaContext`, `GstContext`).

Because the leaked structure is detached from every object, no teardown path can reach it. For
anyone who suspects a lifecycle bug here: the element's own lifecycle is fine — instrumented builds
confirm `CUDAContext::drop` runs and the compositor's `GsCUDABuf` drops, and clearing the element's
context reference in `stop()` changes nothing.

### Verification

RTX 5090, `waylanddisplaysrc ! cudaconvert ! nvcudah264enc` behind an `interpipe` boundary, with
the application injecting one `GstCudaContext` per session; `leaks` tracer unfiltered, `SIGUSR1`
dump 35 s after each teardown had settled.

| | before | after |
|---|---|---|
| live `GstCudaStream` after 1 session | 1 | 0 |
| live `GstCudaStream` after 2 sessions | 2 | 0 |
| `GstCudaContext` ref-count | 2 after 1 session, 3 after 2 (+1 per session) | flat at 1 across 3 sessions |
| settled VRAM | rising per session | flat |
| GStreamer criticals / `free_priv_data` warnings | 0 | 0 |
| stream health | decoding, 59–60 fps | decoding, 59–60 fps |

The residual ref-count of 1 is my own reference to the injected context — by design, not a leak.

Also compile-verified against this branch's base with `--features cuda`.

### Note for #37

The same two lines are present, unchanged, on `feat/vulkan-encode` (`cuda/mod.rs` is
byte-identical between the two branches), and this patch applies cleanly there too. Exposure is
highest on that branch, since Vulkan hosts fall back to the NVENC/CUDA path for AV1. Fixing it
here means #37 inherits it on its next rebase.
