### PR TITLE
fix(cuda): free the transfer-full pool config that pinned the GstCudaContext (for feat/vulkan-encode)

### DIFF
--- a/gst-plugin-wayland-display/src/waylandsrc/imp.rs
+++ b/gst-plugin-wayland-display/src/waylandsrc/imp.rs
@@ -1116,7 +1116,13 @@ impl BaseSrcImpl for WaylandDisplaySrc {
 
         match pool {
             Ok(pool) => {
-                let caps = unsafe { gst::Caps::from_glib_full(outcaps.unwrap().as_ptr()) };
+                // The allocation query only lends us its caps (`query.get()` borrows), so
+                // adopt it with `from_glib_none`. `from_glib_full` consumed a reference we
+                // never owned, leaving the negotiated caps one short. Paired with the
+                // `gst_structure_free` in `CUDABufferPool::get_updated_size()`: the pool
+                // config holds a ref on this same caps, so releasing the config copy while
+                // the over-unref is present drops the caps below its true count.
+                let caps = unsafe { gst::Caps::from_glib_none(outcaps.unwrap().as_ptr()) };
                 let stream = cuda_ctx.stream().expect("failed to get CUDA stream");
                 pool.configure(&caps, &stream, size, min, max)
                     .expect("failed to configure CUDA pool");

--- a/wayland-display-core/src/utils/allocator/cuda/mod.rs
+++ b/wayland-display-core/src/utils/allocator/cuda/mod.rs
@@ -280,6 +280,22 @@ impl CUDABufferPool {
                 ptr::null_mut(),
                 ptr::null_mut(),
             );
+            // `gst_buffer_pool_get_config()` is (transfer full) -- it returns a fresh
+            // `gst_structure_copy()` of the pool's config and the caller must free it.
+            // (`configure()` above is safe because `gst_buffer_pool_set_config()` consumes
+            // its copy.) The copy also re-refs every field value, including the
+            // `cuda-stream` `GstCudaStream` that `configure()` installed, and
+            // `gst_cuda_stream_new()` holds a `gst_object_ref()` on its `GstCudaContext`.
+            // Leaking this structure therefore pins the CUDA context for the lifetime of
+            // the process, and nothing can reclaim it: the retaining structure is detached
+            // from every object, so no teardown path reaches it.
+            //
+            // Must stay paired with the `Caps::from_glib_none` fix in
+            // `waylandsrc/imp.rs::decide_allocation` -- that borrowed caps pointer used to
+            // be adopted with `from_glib_full`, leaving the negotiated caps one reference
+            // short. This config copy holds a ref on the same caps, so freeing it here
+            // while that over-unref is present drops the caps below its true count.
+            gst::ffi::gst_structure_free(config);
         }
         Ok(size)
     }


### PR DESCRIPTION
Same fix as #42, applied directly to `feat/vulkan-encode` so this branch does not have to wait for a rebase to pick it up. Take whichever is more convenient — or close this one if you would rather let #42 flow in naturally.

Both bugs predate this branch (they entered in `63688e6`, 2025-10-08, and `wayland-display-core/src/utils/allocator/cuda/mod.rs` is byte-identical between `stable` and this branch), but **exposure is highest here**, because a Vulkan host falls back to the NVENC/CUDA path for AV1.

### The leak

`CUDABufferPool::get_updated_size()` calls `gst_buffer_pool_get_config()` and never frees the result. That function is **`(transfer full)`** — a fresh `gst_structure_copy()` of the pool's config that the caller owns. The sibling `configure()` makes the same call but hands its copy to `gst_buffer_pool_set_config()`, which consumes it, so `get_updated_size()` is the only leaking caller.

`gst_structure_copy()` copies every field value, and `configure()` has just installed a `cuda-stream` field via `gst_buffer_pool_config_set_cuda_stream()`. `GST_TYPE_CUDA_STREAM` is a boxed type whose copy/free are `gst_mini_object_ref`/`gst_mini_object_unref`, so the copy takes a new reference on the `GstCudaStream` — and `gst_cuda_stream_new()` holds `gst_object_ref (context)` on its `GstCudaContext`, released only in `_gst_cuda_stream_free()`:

```
leaked GstStructure (config copy)  ->  cuda-stream field  ->  GstCudaStream  ->  GstCudaContext
```

`decide_allocation()` negotiates more than once per stream, so several config copies leak per stream, each pinning the stream object and through it one reference to the CUDA context. When the element creates its own context this is invisible (process-lifetime anyway). When the application injects one per session via `gst_element_set_context()`, that session's context is never finalized: roughly **500 MiB of VRAM plus one `cuda-EvtHandlr` driver thread leaked per session**, growing linearly.

### Second hunk, and why it must land with the first

Same function: the allocation query's caps was adopted with `Caps::from_glib_full`, consuming a reference the element never owned and leaving the negotiated caps one short. That is latent while the config copy leaks, because the copy holds a compensating reference on the *same* caps.

Fix only the leak and the caps drops below its true count. The failure is quiet: streams still negotiate, connect and decode at full frame rate, but buffers are never released and every session's pipelines are retained (measured on my leak-only build: 843 MiB VRAM, ~3000 live `GstMemory`, ~1000 live `GstBuffer` and 6 live `GstPipeline` after two sessions, plus one `free_priv_data: object finalizing but still has 1 parents` per session).

### Verification — on this branch

Built from this branch's head with `--features cuda` and run on an RTX 5090: `waylanddisplaysrc ! cudaconvert ! nvcudah264enc` behind an `interpipe` boundary, application-injected per-session `GstCudaContext`, `leaks` tracer unfiltered, `SIGUSR1` dump 35 s after each teardown had settled.

| | before | after |
|---|---|---|
| live `GstCudaStream` after 1 session | 1 | 0 |
| live `GstCudaStream` after 2 sessions | 2 | 0 |
| `GstCudaContext` ref-count | 2 after 1 session, 3 after 2 (+1 per session) | flat at 1 across 3 sessions |
| settled VRAM | rising per session | flat |
| GStreamer criticals / `free_priv_data` warnings | 0 | 0 |
| stream health | decoding, 59–60 fps | decoding, 59–60 fps |

The residual ref-count of 1 is my own reference to the injected context — by design, not a leak.

### Finding it

Worth recording, because the standard recipe hides it: a `GstStructure` is not refcounted and `GstCudaStream` is a `GstMiniObject`, so `leaks(filters=GstObject)` shows one `GstCudaContext` alive at ref-count 1 with **no `GstObject` retaining it**, which reads as an impossible leak. `filters=` also restricts what the tracer *tracks*, so hand-naming candidate types still hides holders you did not guess. Running `leaks` **unfiltered** is what made the chain visible.

Because the leaked structure is detached from every object, no teardown path can reach it — the element's own lifecycle is fine (`CUDAContext::drop` runs, `GsCUDABuf` drops, and clearing the element's context reference in `stop()` changes nothing).
