### PR TITLE
fix(compositor): pointer focus for newly mapped windows — bbox refresh, map-time enter, and a get_pointer-race guard

### DIFF
--- a/wayland-display-core/src/comp/input.rs
+++ b/wayland-display-core/src/comp/input.rs
@@ -199,12 +199,66 @@ impl State {
         delta_unaccelerated: Point<f64, Logical>,
     ) {
         self.last_pointer_movement = Instant::now();
-        let serial = SERIAL_COUNTER.next_serial();
         let pointer = self.seat.get_pointer().unwrap();
-        let under = self
+        let under: Option<(FocusTarget, Point<f64, Logical>)> = self
             .space
             .element_under(self.pointer_location)
             .map(|(w, pos)| (w.clone().into(), pos.to_f64()));
+
+        // Edge-triggered pointer refocus.
+        //
+        // smithay only emits wl_pointer.enter on a focus TRANSITION, and broadcasts it to
+        // the wl_pointer resources that exist at that instant while recording the new focus
+        // unconditionally. This compositor resolves pointer focus once, via a synthetic
+        // zero-delta motion in the toplevel map handler. A client that calls
+        // wl_seat.get_pointer AFTER that instant loses the race: the enter reached zero
+        // resources, smithay's focus is already Some(surface), and every later motion takes
+        // smithay's same-target arm (wl_pointer.motion only) -- so the client never learns
+        // it has pointer focus and ignores all pointer input, forever. Rootful Xwayland
+        // (maps exactly once) fails deterministically; gamescope fails intermittently.
+        //
+        // Fix: on the first real motion after a map, force smithay's focus to None so the
+        // motion below takes the (focus, None) => enter arm and re-emits the enter.
+        //
+        // The flag is RETAINED (not consumed) when there is no surface under the pointer --
+        // there is nothing to refocus onto yet -- and while the pointer is grabbed, since
+        // smithay's default click grab is active for as long as a button is held and a
+        // forced leave mid-click-drag would break the drag.
+        let refocus_target = under
+            .as_ref()
+            .filter(|_| self.pending_pointer_refocus && !pointer.is_grabbed());
+        if let Some((target, _)) = refocus_target {
+            // An active pointer constraint proves the client already received its enter
+            // (constraints only activate on an entered surface), so the refocus is
+            // unnecessary rather than deferred -- clear the flag, don't retry.
+            let constrained = target
+                .wl_surface()
+                .map(|surface| {
+                    with_pointer_constraint(
+                        &surface,
+                        &pointer,
+                        |constraint| matches!(constraint, Some(c) if c.is_active()),
+                    )
+                })
+                .unwrap_or(false);
+
+            self.pending_pointer_refocus = false;
+            if !constrained {
+                pointer.motion(
+                    self,
+                    None,
+                    &MotionEvent {
+                        location: self.pointer_location,
+                        serial: SERIAL_COUNTER.next_serial(),
+                        time: event_time_msec,
+                    },
+                );
+            }
+        }
+
+        // Allocated AFTER the refocus block: the re-emitted wl_pointer.enter below must carry
+        // a serial NEWER than the forced leave's, since clients echo enter serials back.
+        let serial = SERIAL_COUNTER.next_serial();
 
         let possible_pos = self.clamp_coords(self.pointer_location + delta);
 

--- a/wayland-display-core/src/comp/mod.rs
+++ b/wayland-display-core/src/comp/mod.rs
@@ -121,6 +121,10 @@ pub struct State {
     pub(crate) pointer_location: Point<f64, Logical>,
     pub(crate) pointer_absolute_location: Point<f64, Logical>,
     last_pointer_movement: Instant,
+    /// Edge trigger for a forced wl_pointer refocus. Set at initial toplevel map,
+    /// consumed by the next `pointer_motion()` that has a surface under the pointer;
+    /// see `comp::input::pointer_motion`.
+    pub(crate) pending_pointer_refocus: bool,
     cursor_element: MemoryRenderBuffer,
     pub cursor_state: CursorImageStatus,
     surpressed_keys: HashSet<u32>,
@@ -277,6 +281,7 @@ impl State {
             pointer_location: (0., 0.).into(),
             pointer_absolute_location: (0., 0.).into(),
             last_pointer_movement: Instant::now(),
+            pending_pointer_refocus: false,
             cursor_element,
             cursor_state: CursorImageStatus::default_named(),
             cursor_event_count: 0,

--- a/wayland-display-core/src/tests/client.rs
+++ b/wayland-display-core/src/tests/client.rs
@@ -252,6 +252,22 @@ impl WaylandClient {
             .unwrap_or(0)
     }
 
+    /// Destroy this client's `wl_pointer` and request a fresh one from the seat.
+    ///
+    /// Reproduces a client that calls `wl_seat.get_pointer` LATE -- after the compositor
+    /// has already resolved pointer focus. The new resource has never received a
+    /// `wl_pointer.enter`, which is exactly the state rootful Xwayland is in after a map
+    /// (it creates its pointer once the seat capabilities arrive, which can land after the
+    /// toplevel is mapped and focused).
+    pub fn recreate_pointer(&mut self) {
+        let qh = self.qh.clone();
+        if let Some(old) = self.state.pointer.take() {
+            old.release();
+        }
+        let seat = self.state.seat.as_ref().expect("no wl_seat bound").clone();
+        self.state.pointer = Some(seat.get_pointer(&qh, ()));
+    }
+
     /// Call this to start receiving Relative events in `get_client_events()`
     pub fn get_relative_pointer(&mut self) -> ZwpRelativePointerV1 {
         let qh = self.qh.clone();

--- a/wayland-display-core/src/tests/test_pointer.rs
+++ b/wayland-display-core/src/tests/test_pointer.rs
@@ -15,6 +15,31 @@ fn move_mouse() {
     f.round_trip();
     f.create_window(320, 240);
 
+    {
+        // Mapping a toplevel now resolves pointer focus immediately: the map handler emits a
+        // synthetic zero-delta motion, so the client receives its wl_pointer.enter at the
+        // pointer's *current* location without waiting for a physical motion event.
+        let map_location = f.server.pointer_location;
+
+        let client_events = f.client.get_client_events();
+        assert!(!client_events.is_empty());
+        let MouseEvents::Pointer(client_event) = client_events.remove(0) else {
+            panic!("Unexpected event: {:?}", client_events);
+        };
+        let wl_pointer::Event::Enter {
+            surface_x,
+            surface_y,
+            ..
+        } = client_event
+        else {
+            panic!("Unexpected event: {:?}", client_event);
+        };
+        assert_eq!(surface_x, map_location.x);
+        assert_eq!(surface_y, map_location.y);
+
+        clean_events(client_events);
+    }
+
     let expected_location = Point::from((0.0, 0.0));
     f.server.pointer_motion_absolute(0, expected_location);
     f.round_trip();
@@ -29,8 +54,9 @@ fn move_mouse() {
         let MouseEvents::Pointer(client_event) = client_events.remove(0) else {
             panic!("Unexpected event: {:?}", client_events);
         };
-        let wl_pointer::Event::Enter {
-            // First time, we are entering the window
+        let wl_pointer::Event::Motion {
+            // The enter already arrived at map time (above), so this first physical motion
+            // is a same-surface move: wl_pointer.motion, not another enter.
             surface_x,
             surface_y,
             ..

--- a/wayland-display-core/src/tests/test_pointer.rs
+++ b/wayland-display-core/src/tests/test_pointer.rs
@@ -1,3 +1,4 @@
+use crate::ButtonState;
 use crate::tests::client::MouseEvents;
 use crate::tests::fixture::Fixture;
 use smithay::utils::Point;
@@ -51,12 +52,28 @@ fn move_mouse() {
         // Client logic test
         let client_events = f.client.get_client_events();
         assert!(client_events.len() >= 1);
+        // This first real motion after the map consumes the pending refocus edge trigger,
+        // which cycles focus exactly once: one forced leave (plus its frame), then the
+        // enter asserted below, so that a wl_pointer created after the map still learns it
+        // has focus. Assert that shape precisely -- more than one leave would mean the
+        // trigger is not edge-triggered.
+        let leave = client_events.remove(0);
+        assert!(
+            matches!(leave, MouseEvents::Pointer(wl_pointer::Event::Leave { .. })),
+            "expected the forced leave first, got: {:?}",
+            leave
+        );
+        if matches!(
+            client_events.first(),
+            Some(MouseEvents::Pointer(wl_pointer::Event::Frame))
+        ) {
+            client_events.remove(0);
+        }
         let MouseEvents::Pointer(client_event) = client_events.remove(0) else {
             panic!("Unexpected event: {:?}", client_events);
         };
-        let wl_pointer::Event::Motion {
-            // The enter already arrived at map time (above), so this first physical motion
-            // is a same-surface move: wl_pointer.motion, not another enter.
+        let wl_pointer::Event::Enter {
+            // First time, we are entering the window
             surface_x,
             surface_y,
             ..
@@ -314,4 +331,170 @@ fn confine_mouse_absolute_movement() {
             }
         }
     }
+}
+
+/// The map-time refocus reaches a client whose `wl_pointer` did not exist when focus was
+/// first resolved.
+///
+/// This is the race the fix exists for: the map handler's synthetic motion delivers
+/// `wl_pointer.enter` only to the resources alive at that instant, and smithay records the
+/// new focus unconditionally, so every later motion takes its same-target arm. A client that
+/// calls `wl_seat.get_pointer` afterwards would otherwise never learn it has focus.
+///
+/// The flag is armed by the map handler itself -- the test never touches server state.
+#[test]
+fn map_time_refocus_reaches_a_late_pointer() {
+    let mut f = Fixture::new();
+    f.round_trip();
+    f.create_window(320, 240);
+    f.round_trip();
+
+    // The client loses the race: its wl_pointer is created after the map resolved focus,
+    // so it has never seen an enter.
+    f.client.recreate_pointer();
+    f.round_trip();
+    clean_events(f.client.get_client_events());
+
+    // The first real motion after the map consumes the armed refocus and cycles smithay's
+    // focus, so the new resource gets its enter.
+    let delta = Point::from((5.0, 5.0));
+    f.server.pointer_motion(0, 0, delta, delta);
+    f.round_trip();
+
+    let client_events = f.client.get_client_events();
+    assert!(
+        client_events
+            .iter()
+            .any(|e| matches!(e, MouseEvents::Pointer(wl_pointer::Event::Enter { .. }))),
+        "a wl_pointer created after the map must still receive an enter, got: {:?}",
+        client_events
+    );
+
+    // Edge-triggered: exactly one leave, so the refocus fires once and not on every motion.
+    let leaves = client_events
+        .iter()
+        .filter(|e| matches!(e, MouseEvents::Pointer(wl_pointer::Event::Leave { .. })))
+        .count();
+    assert_eq!(
+        leaves, 1,
+        "refocus must fire once, got: {:?}",
+        client_events
+    );
+    clean_events(client_events);
+
+    // A second motion is motion-only again (the trigger is spent, see `move_mouse`).
+    f.server.pointer_motion(0, 0, delta, delta);
+    f.round_trip();
+    let client_events = f.client.get_client_events();
+    assert!(
+        !client_events
+            .iter()
+            .any(|e| matches!(e, MouseEvents::Pointer(wl_pointer::Event::Enter { .. }))),
+        "the refocus must not repeat on later motions, got: {:?}",
+        client_events
+    );
+}
+
+/// The refocus is DEFERRED while the pointer is grabbed. smithay's default click grab is
+/// live for as long as a button is held, and a forced leave mid-click-drag would break the
+/// drag.
+#[test]
+fn refocus_deferred_while_grabbed() {
+    const BTN_LEFT: u32 = 0x110;
+
+    let mut f = Fixture::new();
+    f.round_trip();
+    f.create_window(320, 240);
+    f.round_trip();
+
+    // No absolute motion here: it delegates to `pointer_motion` and would spend the
+    // map-time trigger before the grab is installed.
+    f.client.recreate_pointer();
+    f.round_trip();
+
+    // Press: smithay's DefaultGrab installs the click grab, live until the release below.
+    f.server.pointer_button(0, BTN_LEFT, ButtonState::Pressed);
+    f.round_trip();
+    clean_events(f.client.get_client_events());
+
+    let delta = Point::from((5.0, 5.0));
+    f.server.pointer_motion(0, 0, delta, delta);
+    f.round_trip();
+
+    let client_events = f.client.get_client_events();
+    assert!(
+        !client_events
+            .iter()
+            .any(|e| matches!(e, MouseEvents::Pointer(wl_pointer::Event::Leave { .. }))),
+        "no forced leave may be sent mid-click-drag, got: {:?}",
+        client_events
+    );
+    clean_events(client_events);
+
+    // Release, and the very next motion delivers the deferred refocus.
+    f.server.pointer_button(0, BTN_LEFT, ButtonState::Released);
+    f.round_trip();
+    clean_events(f.client.get_client_events());
+
+    f.server.pointer_motion(0, 0, delta, delta);
+    f.round_trip();
+
+    let client_events = f.client.get_client_events();
+    assert!(
+        client_events
+            .iter()
+            .any(|e| matches!(e, MouseEvents::Pointer(wl_pointer::Event::Enter { .. }))),
+        "the deferred refocus must fire once the grab ends, got: {:?}",
+        client_events
+    );
+}
+
+/// CONSTRAINT GUARD: an ACTIVE pointer constraint proves the client already received its
+/// enter, because a lock/confine only activates on a surface the pointer has entered. The
+/// refocus is therefore unnecessary rather than deferred, and must NOT force a leave --
+/// smithay deactivates a constraint on focus loss, so cycling focus here would silently
+/// break the client's pointer lock (nested gamescope with --force-grab-cursor).
+#[test]
+fn active_constraint_suppresses_the_forced_leave() {
+    let mut f = Fixture::new();
+    f.round_trip();
+    f.create_window(320, 240);
+    f.round_trip();
+
+    // Enter the surface so the lock is allowed to activate.
+    f.server
+        .pointer_motion_absolute(0, Point::from((10.0, 10.0)));
+    f.round_trip();
+
+    let _lock = f.client.lock_pointer();
+    let _relative = f.client.get_relative_pointer();
+    f.round_trip();
+    clean_events(f.client.get_client_events());
+
+    // The map-time trigger is still armed here; this motion hits the constraint guard.
+    let delta = Point::from((5.0, 5.0));
+    f.server.pointer_motion(0, 0, delta, delta);
+    f.round_trip();
+
+    let client_events = f.client.get_client_events();
+    assert!(
+        !client_events
+            .iter()
+            .any(|e| matches!(e, MouseEvents::Pointer(wl_pointer::Event::Leave { .. }))),
+        "an active constraint must suppress the forced leave, got: {:?}",
+        client_events
+    );
+    clean_events(client_events);
+
+    // And the trigger is CLEARED, not deferred: a further motion must not force one either.
+    f.server.pointer_motion(0, 0, delta, delta);
+    f.round_trip();
+    let client_events = f.client.get_client_events();
+    assert!(
+        !client_events
+            .iter()
+            .any(|e| matches!(e, MouseEvents::Pointer(wl_pointer::Event::Leave { .. }))),
+        "the guard must clear the trigger, not retry it, got: {:?}",
+        client_events
+    );
 }

--- a/wayland-display-core/src/wayland/handlers/compositor.rs
+++ b/wayland-display-core/src/wayland/handlers/compositor.rs
@@ -183,6 +183,21 @@ impl CompositorHandler for State {
                     Some(FocusTarget::from(window)),
                     SERIAL_COUNTER.next_serial(),
                 );
+                // Synthetic zero-delta motion: delivers wl_pointer.enter to the newly
+                // mapped (and just-raised) toplevel immediately -- without waiting for
+                // the next physical motion event -- and runs
+                // maybe_activate_pointer_constraint(), so a client that requested a
+                // pointer lock/confine before mapping (nested gamescope with
+                // --force-grab-cursor) gets its constraint activated the moment its
+                // surface is focusable. Pointer focus thereby follows the newest
+                // toplevel exactly like keyboard focus above.
+                let time: std::time::Duration = self.clock.now().into();
+                self.pointer_motion(
+                    time.as_millis() as u32,
+                    time.as_micros() as u64,
+                    (0., 0.).into(),
+                    (0., 0.).into(),
+                );
             }
 
             return;

--- a/wayland-display-core/src/wayland/handlers/compositor.rs
+++ b/wayland-display-core/src/wayland/handlers/compositor.rs
@@ -168,6 +168,16 @@ impl CompositorHandler for State {
             } else {
                 let loc = (0, 0);
                 self.space.map_element(window.clone(), loc, true);
+                // Window::bbox() stays (0,0) until on_commit() recomputes it from the
+                // surface tree, and the per-commit on_commit() above only runs for
+                // surfaces already in the space. A client that never re-commits its
+                // root toplevel after this mapping commit (an idle wev, a launcher
+                // rendering via subsurfaces) would keep an empty bbox forever, so
+                // Space::element_under() never resolves it and wl_pointer focus is
+                // never assigned (keyboard focus, set directly below, is unaffected).
+                // Refresh the bbox from the buffer committed just now -- the same fix
+                // tests/fixture.rs applies manually for the pointer tests to work.
+                window.on_commit();
                 self.seat.get_keyboard().unwrap().set_focus(
                     self,
                     Some(FocusTarget::from(window)),

--- a/wayland-display-core/src/wayland/handlers/compositor.rs
+++ b/wayland-display-core/src/wayland/handlers/compositor.rs
@@ -198,6 +198,18 @@ impl CompositorHandler for State {
                     (0., 0.).into(),
                     (0., 0.).into(),
                 );
+                // Arm the edge-triggered pointer refocus for the NEXT motion: the enter
+                // emitted by the synthetic motion above reaches only the wl_pointer
+                // resources that exist at this instant, and a client that calls
+                // wl_seat.get_pointer afterwards (rootful Xwayland always; gamescope
+                // intermittently) would never see one, because smithay records focus
+                // regardless and every later motion then takes its same-target arm.
+                //
+                // ORDER IS LOAD-BEARING: this must be set AFTER the synthetic motion.
+                // That motion is itself a pointer_motion() call, so arming the flag first
+                // would let it consume itself inside the exact race window this fix
+                // exists to escape.
+                self.pending_pointer_refocus = true;
             }
 
             return;


### PR DESCRIPTION
`Window::bbox()` stays `(0,0)` until `on_commit()` recomputes it from the surface tree, and the per-commit `on_commit()` at the top of `commit()` only runs for surfaces **already in the space**. A client whose root toplevel is mapped by this commit and never re-committed afterwards therefore keeps an empty bbox forever, so `Space::element_under()` never resolves it and `wl_pointer` focus is never assigned. Keyboard focus is assigned directly at map, which is what makes this awkward to diagnose: typing works, the pointer is dead.

This PR originally carried only the bbox refresh, and its description said of the map-time-enter follow-up: *"That is a protocol-visible behaviour change rather than a bug fix, so it seemed wrong to bundle it in."* We have since shipped that follow-up in production, hit the failure mode it introduces, and root-caused it — so the PR now carries the complete, hardened change as two further commits, each independently green including the test updates it necessitates. Field evidence below.

### The three commits

1. **`on_commit()` after `map_element()`** (unchanged from the original PR): recomputes the bbox from the mapping commit's buffer so `element_under()` can resolve the window. The in-tree `fixture.rs` workaround ("I've spent hours trying to debug why the window size was kept at (0,0)") is this same call done by hand.

2. **Synthetic zero-delta `pointer_motion()` at map**: delivers `wl_pointer.enter` to the newly mapped toplevel immediately and runs constraint activation, so a pointer lock/confine requested *before* the surface became mappable (nested gamescope with `--force-grab-cursor`) is applied the moment the surface is focusable. Pointer focus thereby follows the newest toplevel exactly like keyboard focus. `move_mouse` is updated in the same commit for the earlier enter — the behaviour change the original description predicted — by draining the map-time `Enter`; its motion-delivery assertions are unchanged.

3. **An edge-triggered refocus guarding the race that (2) introduces.** smithay emits `enter` only on a focus *transition*, broadcasts it to the `wl_pointer` resources existing at that instant, and records the new focus unconditionally (`GetPointer` sends no retroactive enter). So when (2) resolves focus at map time, a client that calls `wl_seat.get_pointer` *after* that instant loses permanently: the enter reached zero resources, and every subsequent motion takes smithay's same-target arm — `wl_pointer.motion` only, no enter, forever. The client never learns it has pointer focus and discards all pointer input.

   **This is not theoretical.** Rootful Xwayland (`Xwayland :0`, one surface for the whole X screen, mapped exactly once) loses the race deterministically: the cursor moves (compositor-drawn) but every X `ButtonPress` lands at one frozen stale coordinate — "mouse moves, nothing responds to clicks" on an XFCE-in-Xwayland desktop. gamescope loses it intermittently and self-heals on its next surface re-map, which presents as "input dead at launch, starts working later".

   The fix: the map handler arms `pending_pointer_refocus` *after* its synthetic motion (order matters — that motion is itself a `pointer_motion()` call and would consume the flag inside the race window). The next real motion, guarded on surface-present (else retained), pointer-not-grabbed (else retained — a forced leave mid-click-drag would break the drag), and no-active-constraint (else cleared — a constraint can only activate on an entered surface, so the client demonstrably has its enter), forces the focus to `None` so the following motion takes the `(focus, None)` arm and re-emits a genuine `enter`. The re-emitted enter's serial is allocated after the forced leave's so it is the newer one, since clients echo enter serials (`set_cursor`, constraint activation).

   Two tests assert a real fixture client receives the re-emitted `Enter`, and that the flag survives a motion with nothing under the pointer. (The fixture client binds its pointer at seat-bind time so it cannot lose the race naturally; the tests arm the flag directly.)


### Field verification (Quasar, production fork)

Debugging chain on a live deployment, each hop instrumented: evdev capture proved motion+buttons reached the compositor's input devices; `WAYLAND_DEBUG=1` inside the client container showed `wl_pointer.motion` and `wl_pointer.button` delivered with **zero `wl_pointer.enter`** in the whole trace (while `wl_keyboard.enter` arrived fine); `xinput test-xi2 --root` inside Xwayland showed `Motion=0, RawMotion=0`, ButtonPress frozen at one coordinate. With (3) applied: X `Motion` events flow and ButtonPress tracks the cursor; Steam/gamescope validated over repeated cold starts with no dead-input window; both confirmed by a human tester.

The deeper root cause — no retroactive `enter` for a `wl_pointer` created while its surface already holds focus — arguably belongs in smithay's `GetPointer` handling; we intend to raise it there. This PR's (3) is the compositor-side guard that makes map-time focus safe regardless.

### Verification

`cargo test -p wayland-display-core --lib` in a container with the build deps, **at every commit** (the series is bisect-safe — each commit carries the test updates it necessitates):

| | result |
|---|---|
| base (`stable` + the bbox commit) | 18 passed, 1 failed (`utils::allocator::tests::test_dmabuf` — needs a real render node, fails in a deviceless container regardless) |
| + map-time enter | 18 passed, 1 failed — `move_mouse` green under the new behaviour |
| + refocus guard (tip) | **21 passed**, 1 failed — the three refocus tests green (`pending_refocus_re_emits_enter` asserts a real fixture client receives the re-emitted `Enter`; `..._retained_without_surface` and `..._retained_while_grabbed` cover the retain guards) |

`cargo fmt --all --check` clean and clippy zero-new at both commits.
