### PR TITLE
fix(vulkan): clear PTS on recycled encode-src ring buffers so do_timestamp restamps

### DIFF
--- a/wayland-display-core/src/utils/vulkan_nv12.rs
+++ b/wayland-display-core/src/utils/vulkan_nv12.rs
@@ -1462,8 +1462,31 @@ impl VulkanNv12 {
 
     /// The just-converted NV12 export slot as a gst buffer. Returns the slot's cached
     /// buffer (ref-counted) so the VA encoder reuses one stable surface per slot.
+    ///
+    /// The slot's `GstBuffer` is allocated once and reused every `RING` frames, so a
+    /// bare `.clone()` also carries the timestamps stamped onto it on its *previous* use.
+    /// `waylanddisplaysrc` runs `set_do_timestamp(true)`, which only stamps a buffer whose
+    /// PTS is `NONE`; a recycled buffer whose PTS is already set is left untouched — so the
+    /// exported timestamps degenerate to the ring's ~4 recurring values (non-monotonic,
+    /// duplicated across frames), which a downstream RTP payloader turns into RTP timestamps
+    /// that libwebrtc's PacketBuffer cannot assemble (VULKAN-WORKLOG 2026-07-06 root cause).
+    /// The RGBx/DMABuf output paths never hit this because they build a *fresh* `GstBuffer`
+    /// (PTS `NONE`) every frame. Clear the recycled buffer's timing metadata so BaseSrc's
+    /// `do_timestamp` re-stamps it with the current running-time each frame, exactly like
+    /// those paths. Only touches PTS/DTS/duration — the memory and video meta are untouched.
+    ///
+    /// Scoped to the `encode_src` (Vulkan `memory:VulkanImage` → `vulkanh264enc`) path only.
+    /// The VA compositor-NV12 dmabuf path (`encode_src == false`, GW-02) is left byte-identical
+    /// as it rides clean today; only the vulkan output path's timestamping changes.
     pub fn to_gst_buffer(&self) -> Result<GstBuffer, Err> {
-        Ok(self.outputs[self.cur].buffer.clone())
+        let mut buffer = self.outputs[self.cur].buffer.clone();
+        if self.encode_src {
+            let b = buffer.make_mut();
+            b.set_pts(gst::ClockTime::NONE);
+            b.set_dts(gst::ClockTime::NONE);
+            b.set_duration(gst::ClockTime::NONE);
+        }
+        Ok(buffer)
     }
 }
 

--- a/wayland-display-core/src/utils/vulkan_nv12.rs
+++ b/wayland-display-core/src/utils/vulkan_nv12.rs
@@ -923,6 +923,26 @@ impl VulkanNv12 {
                 std::thread::sleep(std::time::Duration::from_micros(100));
                 waited += 1;
             }
+            // The slot's persistent GstBuffer is reused every RING frames and still carries
+            // the timestamps stamped onto it on its previous use. BaseSrc's do_timestamp only
+            // stamps a buffer whose PTS is NONE, so without a reset the exported PTS degenerate
+            // to the ring's ~4 recurring values (non-monotonic, duplicated), which downstream
+            // RTP payloading turns into timestamps libwebrtc cannot assemble. Reset the timing
+            // metadata here, right after the reuse gate, where the slot is uniquely owned on
+            // the normal path -- resetting in to_gst_buffer via make_mut() would copy the
+            // refcount-2 buffer and blind the gate above (the copy keeps outputs[idx].buffer
+            // at refcount 1 forever). On the gate's 1s-timeout escape the slot is NOT uniquely
+            // owned; get_mut() returns None and the reset is skipped (the stream is already
+            // degraded there, and an in-place write to a shared header would be worse).
+            if let Some(b) = self.outputs[idx].buffer.get_mut() {
+                b.set_pts(gst::ClockTime::NONE);
+                b.set_dts(gst::ClockTime::NONE);
+                b.set_duration(gst::ClockTime::NONE);
+            } else {
+                tracing::warn!(
+                    "VulkanNv12: encode-src slot {idx} PTS reset skipped (buffer still shared)"
+                );
+            }
         }
 
         // Ensure this slot's cached RGBA import matches the current dmabuf. Built once per
@@ -1463,30 +1483,14 @@ impl VulkanNv12 {
     /// The just-converted NV12 export slot as a gst buffer. Returns the slot's cached
     /// buffer (ref-counted) so the VA encoder reuses one stable surface per slot.
     ///
-    /// The slot's `GstBuffer` is allocated once and reused every `RING` frames, so a
-    /// bare `.clone()` also carries the timestamps stamped onto it on its *previous* use.
-    /// `waylanddisplaysrc` runs `set_do_timestamp(true)`, which only stamps a buffer whose
-    /// PTS is `NONE`; a recycled buffer whose PTS is already set is left untouched — so the
-    /// exported timestamps degenerate to the ring's ~4 recurring values (non-monotonic,
-    /// duplicated across frames), which a downstream RTP payloader turns into RTP timestamps
-    /// that libwebrtc's PacketBuffer cannot assemble (VULKAN-WORKLOG 2026-07-06 root cause).
-    /// The RGBx/DMABuf output paths never hit this because they build a *fresh* `GstBuffer`
-    /// (PTS `NONE`) every frame. Clear the recycled buffer's timing metadata so BaseSrc's
-    /// `do_timestamp` re-stamps it with the current running-time each frame, exactly like
-    /// those paths. Only touches PTS/DTS/duration — the memory and video meta are untouched.
-    ///
-    /// Scoped to the `encode_src` (Vulkan `memory:VulkanImage` → `vulkanh264enc`) path only.
-    /// The VA compositor-NV12 dmabuf path (`encode_src == false`, GW-02) is left byte-identical
-    /// as it rides clean today; only the vulkan output path's timestamping changes.
+    /// On the `encode_src` path the returned buffer's PTS is `NONE` in normal steady state:
+    /// `convert_inner` resets the recycled slot's timing metadata right after the reuse gate,
+    /// so BaseSrc's `do_timestamp` re-stamps it with the current running-time each frame
+    /// (matching the RGBx/DMABuf paths, which build a fresh `GstBuffer` every frame). On the
+    /// gate's 1s-timeout escape the reset is skipped (buffer still shared) and the PTS may be
+    /// stale; `convert_inner` warns when that happens.
     pub fn to_gst_buffer(&self) -> Result<GstBuffer, Err> {
-        let mut buffer = self.outputs[self.cur].buffer.clone();
-        if self.encode_src {
-            let b = buffer.make_mut();
-            b.set_pts(gst::ClockTime::NONE);
-            b.set_dts(gst::ClockTime::NONE);
-            b.set_duration(gst::ClockTime::NONE);
-        }
-        Ok(buffer)
+        Ok(self.outputs[self.cur].buffer.clone())
     }
 }
 


### PR DESCRIPTION
`VulkanNv12::to_gst_buffer()` returns a bare clone of the current ring slot's persistent `GstBuffer`. `waylanddisplaysrc` runs with `set_do_timestamp(true)`, which only stamps a buffer whose PTS is `GST_CLOCK_TIME_NONE` — and a recycled slot buffer still carries the PTS from its previous use, so `do_timestamp` skips it.

With the default ring depth of 4, the exported PTS therefore degenerate to four recurring values, non-monotonic and duplicated across frames. Live trace on my host: **99.9% of frames shared a timestamp with another frame, 25% were non-monotonic, and exactly four distinct RTP timestamps cycled forever.**

Downstream that is fatal for WebRTC: `rtph264pay` derives RTP timestamps from those PTS, and libwebrtc's `PacketBuffer` cannot assemble the result. The browser dropped roughly **60% of frames at the decode stage** on a clean LAN with zero packet loss (`framesAssembledFromMultiplePackets` 39.7%, versus 99.9% on the VA path). The stream looks black or frozen while `video.videoWidth` is set and `currentTime` advances, so it is easy to misread as a negotiation problem.

The RGBx and DMABuf output paths never hit this because each builds a fresh `GstBuffer` (PTS `NONE`) every frame. This restores the same behaviour for the Vulkan path: clear PTS/DTS/duration on the recycled buffer before returning it, so `do_timestamp` re-stamps it with the current running time each frame.

Scoped to the `encode_src` case, so the compositor-NV12 dmabuf path (`encode_src == false`) is byte-identical. Only timing metadata is reset — the buffer's memory and video meta are untouched.

Build-verified on this branch's head (`43d4c25`). This fix has been running in my deployment since 2026-07-06.
