### PR TITLE
fix(vulkan): actually fall back to tiled when a LINEAR encode-src alloc fails

### DIFF
--- a/wayland-display-core/src/utils/vulkan_share.rs
+++ b/wayland-display-core/src/utils/vulkan_share.rs
@@ -483,11 +483,26 @@ pub fn alloc_encode_src_buffer(
             .initial_layout(vk::ImageLayout::UNDEFINED)
             .push_next(&mut profile_list);
 
-        let mem_ptr = gstvk::gst_vulkan_image_memory_alloc_with_image_info(
+        let mut mem_ptr = gstvk::gst_vulkan_image_memory_alloc_with_image_info(
             device.to_glib_none().0,
             &image_info as *const vk::ImageCreateInfo as *mut _,
             vk::MemoryPropertyFlags::DEVICE_LOCAL,
         );
+        if mem_ptr.is_null() && linear_encsrc {
+            // The tiled-fallback promised above: some encoders (NVIDIA Vulkan-Video)
+            // reject a LINEAR encode-src image outright, so a failed LINEAR alloc must
+            // not kill the whole vulkan output -- retry with the tiled default.
+            tracing::warn!(
+                "vulkan_share: LINEAR encode-src alloc failed (WOLF_VULKAN_LINEAR_ENCSRC) -- \
+                 falling back to tiled (OPTIMAL)"
+            );
+            let image_info = image_info.tiling(vk::ImageTiling::OPTIMAL);
+            mem_ptr = gstvk::gst_vulkan_image_memory_alloc_with_image_info(
+                device.to_glib_none().0,
+                &image_info as *const vk::ImageCreateInfo as *mut _,
+                vk::MemoryPropertyFlags::DEVICE_LOCAL,
+            );
+        }
         if mem_ptr.is_null() {
             tracing::warn!("vulkan_share: gst_vulkan_image_memory_alloc_with_image_info failed");
             return None;

--- a/wayland-display-core/src/utils/vulkan_share.rs
+++ b/wayland-display-core/src/utils/vulkan_share.rs
@@ -447,15 +447,13 @@ pub fn alloc_encode_src_buffer(
         // (green band / shifted image). Allocating the encode-src LINEAR makes the
         // scratch->encode-src copy LINEAR->LINEAR (no swizzle change), avoiding that path --
         // *if* the GFX12 VCN encoder accepts a linear input image. Opt-in (the tiled default
-        // works on RDNA3 and on a fixed radv); falls back to tiled if the linear alloc fails.
+        // works on RDNA3 and on a fixed radv); falls back to tiled if the LINEAR *allocation*
+        // fails (a driver that accepts the LINEAR image but corrupts or fails at encode time
+        // is not covered by the fallback).
         let linear_encsrc = std::env::var("WOLF_VULKAN_LINEAR_ENCSRC")
             .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
             .unwrap_or(false);
         let tiling = if linear_encsrc {
-            tracing::info!(
-                "vulkan_share: encode-src tiling=LINEAR (WOLF_VULKAN_LINEAR_ENCSRC) -- copy is \
-                 LINEAR->LINEAR, avoids the GFX12 swizzle-mode copy"
-            );
             vk::ImageTiling::LINEAR
         } else {
             vk::ImageTiling::OPTIMAL
@@ -488,6 +486,7 @@ pub fn alloc_encode_src_buffer(
             &image_info as *const vk::ImageCreateInfo as *mut _,
             vk::MemoryPropertyFlags::DEVICE_LOCAL,
         );
+        let mut effective_tiling = tiling;
         if mem_ptr.is_null() && linear_encsrc {
             // The tiled-fallback promised above: some encoders (NVIDIA Vulkan-Video)
             // reject a LINEAR encode-src image outright, so a failed LINEAR alloc must
@@ -497,6 +496,7 @@ pub fn alloc_encode_src_buffer(
                  falling back to tiled (OPTIMAL)"
             );
             let image_info = image_info.tiling(vk::ImageTiling::OPTIMAL);
+            effective_tiling = vk::ImageTiling::OPTIMAL;
             mem_ptr = gstvk::gst_vulkan_image_memory_alloc_with_image_info(
                 device.to_glib_none().0,
                 &image_info as *const vk::ImageCreateInfo as *mut _,
@@ -506,6 +506,12 @@ pub fn alloc_encode_src_buffer(
         if mem_ptr.is_null() {
             tracing::warn!("vulkan_share: gst_vulkan_image_memory_alloc_with_image_info failed");
             return None;
+        }
+        if linear_encsrc {
+            tracing::info!(
+                "vulkan_share: encode-src allocated with tiling={:?} (WOLF_VULKAN_LINEAR_ENCSRC)",
+                effective_tiling
+            );
         }
 
         // Our converter always leaves this image in VIDEO_ENCODE_SRC layout (it CPU-waits the


### PR DESCRIPTION
`WOLF_VULKAN_LINEAR_ENCSRC`'s comment promises the knob is safe because it "falls back to tiled if the linear alloc fails", but the code does not do that: when `gst_vulkan_image_memory_alloc_with_image_info` returns null for the LINEAR image, `alloc_encode_src_buffer` simply returns `None`. That fails `VulkanNv12::new_on_shared` ("encode-src image allocation failed") and the session's entire Vulkan output fails to be created.

Verified live on an RTX 5090 (2026-07-24): NVIDIA's Vulkan-Video encoder **rejects** a LINEAR encode-src image, so setting the knob on an NVIDIA host hard-failed every session instead of degrading gracefully.

This implements the documented behaviour: if the LINEAR allocation returns null while `WOLF_VULKAN_LINEAR_ENCSRC` is set, warn and retry the identical allocation with `vk::ImageTiling::OPTIMAL`. A genuine allocation failure still returns `None` after the retry, and the non-knob path is byte-identical because the retry branch is gated on `linear_encsrc`.

Scope of the safety claim: the fallback only covers a driver that rejects the LINEAR image at allocation time. A driver that accepts the LINEAR image and then corrupts or fails at `vkCmdEncodeVideo` is not covered. So on a mixed-GPU fleet the knob degrades gracefully for allocation-time rejection (the NVIDIA case above), nothing more.

Build-verified on this branch's head (`43d4c25`).
