### PR TITLE
fix(vulkan): replace guessed struct offsets with a header-compiled bridge; plug two leaks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1858,6 +1858,7 @@ version = "0.2.0"
 dependencies = [
  "ash",
  "calloop",
+ "cc",
  "gstreamer",
  "gstreamer-allocators",
  "gstreamer-video",

--- a/ci/README.md
+++ b/ci/README.md
@@ -43,6 +43,7 @@ wherever `vulkanh264enc` registers (an nvidia render node, or Intel with
 
 - rust toolchain (`rustup`), `gst-launch-1.0` + gst-plugins-{base,bad,vaapi}
 - build deps: `libwayland-dev libinput-dev libxkbcommon-dev libgbm-dev libegl1-mesa-dev libudev-dev libclang-dev pkg-config`
+- a C compiler (`gcc`/`clang`) and the Vulkan loader headers (`libvulkan-dev`, or `vulkan-loader-devel` on Fedora) — `build.rs` compiles `vulkan_bridge.c` against the gst Vulkan headers
 - a Vulkan driver (`mesa-vulkan-drivers` for AMD/Intel, the proprietary driver for Nvidia) — the converter queries Vulkan for NV12 export modifiers; without it the source advertises nothing and negotiation fails
 - `hwdata` (for `/usr/share/hwdata/pci.ids`) so the GPU-name lookup test passes
 - Nvidia only: the `cuda` feature links `libgstcuda-1.0`; if your distro ships it without a `.pc`, add a `gstreamer-cuda-1.0.pc` (`Libs: -lgstcuda-1.0`) and a `libgstcuda-1.0.so` dev symlink

--- a/wayland-display-core/Cargo.toml
+++ b/wayland-display-core/Cargo.toml
@@ -45,6 +45,7 @@ libc = "0.2"
 
 [build-dependencies]
 pkg-config = "0.3"
+cc = "1"
 
 [dev-dependencies]
 tracing-subscriber = "0.3.18"

--- a/wayland-display-core/build.rs
+++ b/wayland-display-core/build.rs
@@ -1,6 +1,20 @@
-use pkg_config;
-
 fn main() {
+    // Compile a tiny, header-checked bridge for Vulkan handle/barrier fields that bindgen
+    // intentionally truncates because Vulkan handles are platform-dependent typedefs.
+    // This avoids guessing private struct offsets in Rust and makes any GStreamer ABI drift
+    // a compile-time failure against the exact headers used by the plugin.
+    let vulkan = pkg_config::Config::new()
+        .atleast_version("1.28")
+        .probe("gstreamer-vulkan-1.0")
+        .expect("gstreamer-vulkan-1.0 >= 1.28 is required");
+    let mut bridge = cc::Build::new();
+    bridge.file("src/utils/vulkan_bridge.c");
+    for include in vulkan.include_paths {
+        bridge.include(include);
+    }
+    bridge.compile("wayland_display_vulkan_bridge");
+    println!("cargo:rustc-link-lib=vulkan");
+
     // Check if the cuda feature is enabled
     #[cfg(feature = "cuda")]
     {
@@ -18,4 +32,5 @@ fn main() {
 
     // Rerun if build script changes
     println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=src/utils/vulkan_bridge.c");
 }

--- a/wayland-display-core/build.rs
+++ b/wayland-display-core/build.rs
@@ -13,7 +13,6 @@ fn main() {
         bridge.include(include);
     }
     bridge.compile("wayland_display_vulkan_bridge");
-    println!("cargo:rustc-link-lib=vulkan");
 
     // Check if the cuda feature is enabled
     #[cfg(feature = "cuda")]

--- a/wayland-display-core/src/utils/vulkan_bridge.c
+++ b/wayland-display-core/src/utils/vulkan_bridge.c
@@ -18,12 +18,6 @@ wayland_display_vk_device (GstVulkanDevice *device)
   return device->device;
 }
 
-VkQueue
-wayland_display_vk_queue (GstVulkanQueue *queue)
-{
-  return queue->queue;
-}
-
 guint32
 wayland_display_vk_queue_family (GstVulkanQueue *queue)
 {
@@ -47,9 +41,22 @@ wayland_display_vk_prepare_encode_image (GstMemory *memory)
   /* Preserve PR #37's fan-out contract, but make it header-checked rather than
    * writing guessed Rust byte offsets. The producer CPU-waits its write fence and
    * vulkanh26x synchronously waits encode completion before dropping the buffer. */
-  if (image->barrier.parent.semaphore != VK_NULL_HANDLE)
-    vkDestroySemaphore (image->device->device,
-        image->barrier.parent.semaphore, NULL);
+  if (image->barrier.parent.semaphore != VK_NULL_HANDLE) {
+    /* Resolve through gst instead of calling vkDestroySemaphore directly. A direct call
+     * puts libvulkan in DT_NEEDED, and ash is declared features = ["loaded"] so a missing
+     * loader must stay a runtime error -- hard-linking it would break the CUDA and VA
+     * builds, which never wanted Vulkan. */
+    PFN_vkDestroySemaphore destroy_semaphore =
+        (PFN_vkDestroySemaphore) gst_vulkan_device_get_proc_address (image->device,
+        "vkDestroySemaphore");
+    if (destroy_semaphore)
+      destroy_semaphore (image->device->device, image->barrier.parent.semaphore, NULL);
+    else
+      GST_WARNING ("vkDestroySemaphore unavailable; encode-src semaphore not freed");
+  }
+  /* Deliberate defensive no-op: barrier.parent.queue is NULL at alloc (g_new0, never set
+   * in _init), so this cannot fire from the sole call site. Kept because it states the
+   * function's postcondition and matches gst's own _vk_image_mem_free. NOT a leak fix. */
   gst_clear_object (&image->barrier.parent.queue);
   image->barrier.parent.semaphore = VK_NULL_HANDLE;
   image->barrier.parent.semaphore_value = 0;

--- a/wayland-display-core/src/utils/vulkan_bridge.c
+++ b/wayland-display-core/src/utils/vulkan_bridge.c
@@ -50,7 +50,7 @@ wayland_display_vk_prepare_encode_image (GstMemory *memory)
   if (image->barrier.parent.semaphore != VK_NULL_HANDLE)
     vkDestroySemaphore (image->device->device,
         image->barrier.parent.semaphore, NULL);
-  image->barrier.parent.queue = NULL;
+  gst_clear_object (&image->barrier.parent.queue);
   image->barrier.parent.semaphore = VK_NULL_HANDLE;
   image->barrier.parent.semaphore_value = 0;
   image->barrier.image_layout = VK_IMAGE_LAYOUT_VIDEO_ENCODE_SRC_KHR;

--- a/wayland-display-core/src/utils/vulkan_bridge.c
+++ b/wayland-display-core/src/utils/vulkan_bridge.c
@@ -1,0 +1,57 @@
+#include <gst/vulkan/vulkan.h>
+
+VkInstance
+wayland_display_vk_instance (GstVulkanDevice *device)
+{
+  return device->instance->instance;
+}
+
+VkInstance
+wayland_display_vk_instance_handle (GstVulkanInstance *instance)
+{
+  return instance->instance;
+}
+
+VkDevice
+wayland_display_vk_device (GstVulkanDevice *device)
+{
+  return device->device;
+}
+
+VkQueue
+wayland_display_vk_queue (GstVulkanQueue *queue)
+{
+  return queue->queue;
+}
+
+guint32
+wayland_display_vk_queue_family (GstVulkanQueue *queue)
+{
+  return queue->family;
+}
+
+VkImage
+wayland_display_vk_image (GstMemory *memory)
+{
+  g_return_val_if_fail (gst_is_vulkan_image_memory (memory), VK_NULL_HANDLE);
+  return ((GstVulkanImageMemory *) memory)->image;
+}
+
+void
+wayland_display_vk_prepare_encode_image (GstMemory *memory)
+{
+  GstVulkanImageMemory *image;
+
+  g_return_if_fail (gst_is_vulkan_image_memory (memory));
+  image = (GstVulkanImageMemory *) memory;
+  /* Preserve PR #37's fan-out contract, but make it header-checked rather than
+   * writing guessed Rust byte offsets. The producer CPU-waits its write fence and
+   * vulkanh26x synchronously waits encode completion before dropping the buffer. */
+  if (image->barrier.parent.semaphore != VK_NULL_HANDLE)
+    vkDestroySemaphore (image->device->device,
+        image->barrier.parent.semaphore, NULL);
+  image->barrier.parent.queue = NULL;
+  image->barrier.parent.semaphore = VK_NULL_HANDLE;
+  image->barrier.parent.semaphore_value = 0;
+  image->barrier.image_layout = VK_IMAGE_LAYOUT_VIDEO_ENCODE_SRC_KHR;
+}

--- a/wayland-display-core/src/utils/vulkan_nv12.rs
+++ b/wayland-display-core/src/utils/vulkan_nv12.rs
@@ -459,8 +459,6 @@ pub struct VulkanNv12 {
     /// Keeps the shared `GstVulkanDevice` alive for the converter's lifetime (the encode-src
     /// images are allocated on it).
     _shared_device: Option<gstreamer_vulkan::VulkanDevice>,
-    /// The exact GStreamer graphics queue used by `queue`; retained so every custom
-    /// `vkQueueSubmit` participates in GStreamer's external-submit lock.
     outputs: Vec<Nv12Out>,
     next: usize, // next ring slot to write
     cur: usize,  // last slot written (the one to_gst_buffer returns)
@@ -905,11 +903,17 @@ impl VulkanNv12 {
             self.outputs[idx].in_flight = false;
         }
 
-        // vulkanh26x waits its GstVulkanOperation before returning from encode, and retains
-        // the input buffer until then. Writability is therefore the PR #37 completion gate.
+        // Fan-out safety (encode-src path): one produced buffer can be referenced by several
+        // downstream encoders at once (interpipe delivers it to every consumer). Our own
+        // graphics fence above only proves *our* last write to this slot finished -- it says
+        // nothing about the consumers' encode *reads*, which run on the encode queue with no
+        // shared sync to us. Overwriting the slot's image while an encode still reads it is a
+        // GPU data hazard that wedges the encoder. Block until every consumer has dropped its
+        // ref (the buffer is writable again, refcount back to 1) before reusing the slot.
         if self.encode_src {
             let mut waited = 0u32;
             while self.outputs[idx].buffer.get_mut().is_none() {
+                // ~1s cap so a paused/stalled consumer can't deadlock the producer forever.
                 if waited >= 10_000 {
                     tracing::warn!(
                         "VulkanNv12: encode-src slot {idx} still referenced after 1s; reusing anyway"

--- a/wayland-display-core/src/utils/vulkan_nv12.rs
+++ b/wayland-display-core/src/utils/vulkan_nv12.rs
@@ -459,6 +459,8 @@ pub struct VulkanNv12 {
     /// Keeps the shared `GstVulkanDevice` alive for the converter's lifetime (the encode-src
     /// images are allocated on it).
     _shared_device: Option<gstreamer_vulkan::VulkanDevice>,
+    /// The exact GStreamer graphics queue used by `queue`; retained so every custom
+    /// `vkQueueSubmit` participates in GStreamer's external-submit lock.
     outputs: Vec<Nv12Out>,
     next: usize, // next ring slot to write
     cur: usize,  // last slot written (the one to_gst_buffer returns)
@@ -903,17 +905,11 @@ impl VulkanNv12 {
             self.outputs[idx].in_flight = false;
         }
 
-        // Fan-out safety (encode-src path): one produced buffer can be referenced by several
-        // downstream encoders at once (interpipe delivers it to every consumer). Our own
-        // graphics fence above only proves *our* last write to this slot finished -- it says
-        // nothing about the consumers' encode *reads*, which run on the encode queue with no
-        // shared sync to us. Overwriting the slot's image while an encode still reads it is a
-        // GPU data hazard that wedges the encoder. Block until every consumer has dropped its
-        // ref (the buffer is writable again, refcount back to 1) before reusing the slot.
+        // vulkanh26x waits its GstVulkanOperation before returning from encode, and retains
+        // the input buffer until then. Writability is therefore the PR #37 completion gate.
         if self.encode_src {
             let mut waited = 0u32;
             while self.outputs[idx].buffer.get_mut().is_none() {
-                // ~1s cap so a paused/stalled consumer can't deadlock the producer forever.
                 if waited >= 10_000 {
                     tracing::warn!(
                         "VulkanNv12: encode-src slot {idx} still referenced after 1s; reusing anyway"

--- a/wayland-display-core/src/utils/vulkan_share.rs
+++ b/wayland-display-core/src/utils/vulkan_share.rs
@@ -16,8 +16,10 @@
 //!
 //! `gstreamer-vulkan` (safe) leaves the Vulkan-typed calls unbound (gir skips vk types), so
 //! we call them through `gstreamer-vulkan-sys` (whose `vulkan::*` are ash `vk::*`
-//! re-exports) and read the two public struct fields we need (`VkDevice`, `VkImage`) via
-//! `repr(C)` overlays anchored on `gst::ffi::{GstObject, GstMemory}` (correct ABI prefix).
+//! re-exports), and read the handles we need (`VkInstance`, `VkDevice`, `VkImage`, the
+//! queue family) through `utils/vulkan_bridge.c`, a small C shim compiled by `build.rs`
+//! against the target's own GStreamer Vulkan headers. Field access is therefore checked by
+//! the C compiler and tracks the headers, instead of being guessed at hand-computed offsets.
 
 #![allow(unsafe_op_in_unsafe_fn)]
 

--- a/wayland-display-core/src/utils/vulkan_share.rs
+++ b/wayland-display-core/src/utils/vulkan_share.rs
@@ -26,9 +26,8 @@ use ash::vk;
 use gst::glib::translate::{ToGlibPtr, from_glib_full};
 use gst::prelude::*;
 use gstreamer_vulkan::prelude::*;
-use gstreamer_vulkan::{VulkanDevice, VulkanInstance, VulkanPhysicalDevice};
+use gstreamer_vulkan::{VulkanDevice, VulkanInstance, VulkanPhysicalDevice, VulkanQueue};
 use gstreamer_vulkan_sys as gstvk;
-use std::os::raw::c_void;
 use std::sync::{Mutex, OnceLock};
 
 // VK_IMAGE_USAGE_VIDEO_ENCODE_SRC_BIT_KHR / VK_IMAGE_LAYOUT_VIDEO_ENCODE_SRC_KHR via raw
@@ -36,43 +35,13 @@ use std::sync::{Mutex, OnceLock};
 const VK_IMAGE_USAGE_VIDEO_ENCODE_SRC_KHR: u32 = 0x0000_2000;
 const VK_IMAGE_LAYOUT_VIDEO_ENCODE_SRC_KHR: i32 = 1_000_299_001;
 
-// --- repr(C) overlays of the public gst-vulkan structs (fields the -sys crate omits). ---
-
-/// `struct _GstVulkanDevice { GstObject parent; GstVulkanInstance *instance;
-/// GstVulkanPhysicalDevice *physical_device; VkDevice device; ... }`
-#[repr(C)]
-struct GstVulkanDeviceOverlay {
-    parent: gst::ffi::GstObject,
-    instance: *mut c_void,        // GstVulkanInstance*
-    physical_device: *mut c_void, // GstVulkanPhysicalDevice*
-    device: vk::Device,           // ABI: a dispatchable handle (pointer)
-}
-
-/// `struct _GstVulkanInstance { GstObject parent; VkInstance instance; ... }`
-#[repr(C)]
-struct GstVulkanInstanceOverlay {
-    parent: gst::ffi::GstObject,
-    instance: vk::Instance,
-}
-
-/// `struct _GstVulkanQueue { GstObject parent; GstVulkanDevice *device; VkQueue queue;
-/// guint32 family; guint32 index; }`
-#[repr(C)]
-struct GstVulkanQueueOverlay {
-    parent: gst::ffi::GstObject,
-    device: *mut c_void,
-    queue: vk::Queue,
-    family: u32,
-    index: u32,
-}
-
-/// `struct _GstVulkanImageMemory { GstMemory parent; GstVulkanDevice *device;
-/// VkImage image; ... }`
-#[repr(C)]
-struct GstVulkanImageMemoryOverlay {
-    parent: gst::ffi::GstMemory,
-    device: *mut c_void,
-    image: vk::Image,
+unsafe extern "C" {
+    fn wayland_display_vk_instance(device: *mut gstvk::GstVulkanDevice) -> vk::Instance;
+    fn wayland_display_vk_instance_handle(instance: *mut gstvk::GstVulkanInstance) -> vk::Instance;
+    fn wayland_display_vk_device(device: *mut gstvk::GstVulkanDevice) -> vk::Device;
+    fn wayland_display_vk_queue_family(queue: *mut gstvk::GstVulkanQueue) -> u32;
+    fn wayland_display_vk_image(memory: *mut gst::ffi::GstMemory) -> vk::Image;
+    fn wayland_display_vk_prepare_encode_image(memory: *mut gst::ffi::GstMemory);
 }
 
 /// Raw Vulkan handles + queue family pulled out of the shared `GstVulkanDevice`, ready to
@@ -212,7 +181,7 @@ pub fn ensure_owned_device(target_minor: Option<u32>) -> Option<VulkanDevice> {
         tracing::error!("vulkan_share: GstVulkanInstance open failed: {e}");
         return None;
     }
-    let vk_instance = unsafe { (*(instance.as_ptr() as *const GstVulkanInstanceOverlay)).instance };
+    let vk_instance = unsafe { wayland_display_vk_instance_handle(instance.as_ptr()) };
     let index = unsafe {
         let entry = match ash::Entry::load() {
             Ok(e) => e,
@@ -297,27 +266,28 @@ pub fn raw_handles(device: &VulkanDevice) -> Option<RawVk> {
         return None;
     }
     unsafe {
-        let overlay = &*(dev_ptr as *const GstVulkanDeviceOverlay);
-        if overlay.device == vk::Device::null() || overlay.instance.is_null() {
+        let vk_device = wayland_display_vk_device(dev_ptr);
+        let vk_instance = wayland_display_vk_instance(dev_ptr);
+        if vk_device == vk::Device::null() || vk_instance == vk::Instance::null() {
             return None;
         }
-        let vk_instance = (*(overlay.instance as *const GstVulkanInstanceOverlay)).instance;
         let vk_physical = gstvk::gst_vulkan_device_get_physical_device(dev_ptr);
         if vk_physical == vk::PhysicalDevice::null() {
             return None;
         }
-        // A queue that can run our compute + copy (the encoder owns its own encode queue).
-        let queue =
+        // `gst_vulkan_device_select_queue()` is transfer-full: take ownership of the
+        // returned GstVulkanQueue so it is not leaked once the family index is read.
+        let gfx_ptr =
             gstvk::gst_vulkan_device_select_queue(dev_ptr, vk::QueueFlags::GRAPHICS.as_raw());
-        let gfx_queue_family = if queue.is_null() {
-            0
-        } else {
-            (*(queue as *const GstVulkanQueueOverlay)).family
-        };
+        if gfx_ptr.is_null() {
+            return None;
+        }
+        let gfx_queue_family = wayland_display_vk_queue_family(gfx_ptr);
+        drop(from_glib_full::<_, VulkanQueue>(gfx_ptr));
         Some(RawVk {
             instance: vk_instance,
             physical: vk_physical,
-            device: overlay.device,
+            device: vk_device,
             gfx_queue_family,
         })
     }
@@ -442,42 +412,19 @@ pub fn alloc_encode_src_buffer(
             );
         }
 
-        // Our converter always leaves this image in VIDEO_ENCODE_SRC layout (it CPU-waits the
-        // copy fence before handing the buffer downstream). Seed gst's *tracked* layout to match.
-        // Otherwise `gst_vulkan_operation_add_frame_barrier` reads the stale alloc-time layout
-        // (UNDEFINED) and records an UNDEFINED->VIDEO_ENCODE_SRC layout *write* transition for the
-        // input image on every encode. With one encoder that's merely wasteful; with the interpipe
-        // fan-out (one buffer -> N encoders) two such concurrent layout writes on the shared image,
-        // on the video-encode queue with no semaphore between them, deadlock the GPU at frame 2.
-        // With the tracked layout already SRC, each encoder's barrier is old==new == a pure read
-        // barrier (VIDEO_ENCODE_READ), which is safe to issue concurrently from multiple encoders.
-        //
-        // `barrier.image_layout` offset in GstVulkanImageMemory (public struct, ABI-stable since
-        // 1.18); verified against the running gst headers (sizeof=472, image@120, barrier@288,
-        // barrier.image_layout@368).
-        // GstVulkanImageMemory.barrier field offsets, verified against the running gst headers
-        // (sizeof=472, image@120, barrier@288) and cross-checked against the gst 1.28.4 tag
-        // (deploy target): _GstVulkanImageMemory and _GstVulkanBarrierMemoryInfo have identical
-        // field order in 1.28.4 and 1.29.1, so these offsets hold for both. The struct is public
-        // and ABI-stable since 1.18; re-run the /tmp/off.c offsetof probe if targeting a newer gst.
-        const BARRIER_QUEUE_OFFSET: usize = 296; // barrier.parent.queue (GstVulkanQueue*)
-        const BARRIER_SEMAPHORE_OFFSET: usize = 320; // barrier.parent.semaphore (VkSemaphore)
-        const BARRIER_SEMAPHORE_VALUE_OFFSET: usize = 328; // barrier.parent.semaphore_value
-        const BARRIER_IMAGE_LAYOUT_OFFSET: usize = 368; // barrier.image_layout (VkImageLayout)
-        let base = mem_ptr as *mut u8;
-        *(base.add(BARRIER_IMAGE_LAYOUT_OFFSET) as *mut i32) = VK_IMAGE_LAYOUT_VIDEO_ENCODE_SRC_KHR;
-        // Null the per-memory cross-queue dependency so gst's encoder adds no timeline-semaphore
-        // wait/signal nor queue-ownership transfer against our image. gst's normal flow uses this
-        // per-memory timeline semaphore to order one consumer after the previous producer op; but
-        // (a) our converter already CPU-waits its write fence before handing the buffer downstream,
-        // so the write is GPU-complete, and (b) the encoders only READ the image. With the interpipe
-        // fan-out, leaving the semaphore set makes two encoders race the shared timeline value
-        // (each does add_dependency=read-value, encode=signal value+1, end=increment) -> two
-        // submissions signal the same value -> timeline corruption -> GPU hang. Read-only access by
-        // N encoders needs no cross-dependency, so clear it.
-        *(base.add(BARRIER_QUEUE_OFFSET) as *mut usize) = 0;
-        *(base.add(BARRIER_SEMAPHORE_OFFSET) as *mut u64) = 0;
-        *(base.add(BARRIER_SEMAPHORE_VALUE_OFFSET) as *mut u64) = 0;
+        // Seed gst's tracked layout to VIDEO_ENCODE_SRC and clear the per-memory timeline,
+        // as PR #37 intends -- but through the target's own headers instead of hand-computed
+        // ABI offsets. Both halves matter under the interpipe fan-out (one buffer -> N
+        // encoders):
+        //   * layout: our converter always leaves the image in VIDEO_ENCODE_SRC, so without
+        //     the seed every encoder records an UNDEFINED->VIDEO_ENCODE_SRC layout *write*.
+        //     Two concurrent layout writes on the shared image, on the video-encode queue with
+        //     no semaphore between them, deadlock the GPU at frame 2. Seeded, each encoder's
+        //     barrier is old==new, a pure VIDEO_ENCODE_READ barrier, safe to issue N-way.
+        //   * timeline: the encoders only READ, and the converter already CPU-waits its write
+        //     fence, so no cross-queue dependency is needed. Left set, two encoders race the
+        //     shared timeline value (each reads it, signals value+1) and corrupt it.
+        wayland_display_vk_prepare_encode_image(mem_ptr);
 
         let mem: gst::Memory = from_glib_full(mem_ptr);
         let mut buffer = gst::Buffer::new();
@@ -510,6 +457,7 @@ pub fn recover_vk_image(buffer: &gst::Buffer) -> Option<vk::Image> {
         if gstvk::gst_is_vulkan_image_memory(mem_ptr) == gst::glib::ffi::GFALSE {
             return None;
         }
-        Some((*(mem_ptr as *const GstVulkanImageMemoryOverlay)).image)
+        let image = wayland_display_vk_image(mem_ptr);
+        (image != vk::Image::null()).then_some(image)
     }
 }


### PR DESCRIPTION
The encode-src path reaches into GStreamer Vulkan structs by writing hardcoded byte offsets from Rust:

```rust
const BARRIER_QUEUE_OFFSET: usize = 296;      // barrier.parent.queue
const BARRIER_SEMAPHORE_OFFSET: usize = 320;  // barrier.parent.semaphore
const BARRIER_IMAGE_LAYOUT_OFFSET: usize = 368;
```

plus `#[repr(C)]` overlay structs mirroring `GstVulkanInstance`, `GstVulkanDevice`, `GstVulkanQueue` and `GstVulkanImageMemory`.

The comments record that the offsets were verified with an `offsetof` probe against the running headers, and they are correct today. The concern is the failure mode: if any of those structs gains or reorders a field, the result is a silent write to the wrong memory rather than a build error, and each overlay has to be re-verified by hand against every GStreamer version.

This replaces both mechanisms with a small C bridge (`vulkan_bridge.c`) compiled against the actual GStreamer Vulkan headers via `build.rs`, so field access is checked by the compiler and tracks the headers automatically. Two behavior changes ride along, both replacing guesses with failure:

* `raw_handles()` no longer falls back to queue family 0 when `select_queue(GRAPHICS)` returns null. It returns `None`, and `GsVulkanBuf::new` turns that into Vulkan output failure instead of submitting on a guessed family.
* `recover_vk_image()` returns `None` on a null image instead of handing back a garbage handle.

Both are intended. The layout and fan-out handling is unchanged.

### Two leaks surfaced while moving the barrier reset into the bridge

1. **Per-image `VkSemaphore` handle leak.** Clearing `barrier.parent.semaphore` by writing the field left the timeline semaphore the allocator created undestroyed — one leaked handle per encode-src image. The bridge now calls `vkDestroySemaphore` before clearing.

2. **Per-call `GstVulkanQueue` leak.** `gst_vulkan_device_select_queue()` is transfer-full, but `raw_handles()` only read the queue family off the returned object and dropped the pointer, leaking one queue object per call. It is now taken with `from_glib_full` and released once the family index has been read.

### Scope

Deliberately limited to the ABI-safety change and those two leaks. I also carry a separate change that makes the producer participate in `GstVulkanQueue`'s submission lock, which I have **not** included here: it was written for a `VK_ERROR_DEVICE_LOST` / Xid theory on my hardware that later turned out to have a different, proven cause (a buffer-reuse gate blinded by a header copy), so I have no evidence it fixes anything and did not want to present it as a fix. Happy to open it separately if you think it is correct on principle.

Build-verified on this branch's head (`43d4c25`).

