### PR TITLE
feat(vulkan): own the GstVulkanInstance/Device per element instead of process-globals

### DIFF
--- a/gst-plugin-wayland-display/src/waylandsrc/imp.rs
+++ b/gst-plugin-wayland-display/src/waylandsrc/imp.rs
@@ -47,6 +47,14 @@ pub struct WaylandDisplaySrc {
     /// `caps()` falls back to the hardcoded `HDR_MASTERING` / `HDR_CLL` defaults. Driven in
     /// `create()`, read in `caps()`. Never consulted when WOLF_HDR_CM is unset.
     hdr_meta: Mutex<(Option<String>, Option<String>)>,
+    /// This element's OWN Vulkan-encode device share, replacing the process-global
+    /// `vulkan_share` slots so N concurrent Vulkan sessions in one process each mint, own and
+    /// destroy their own `VkDevice` (an isolated failure domain). Lives for the element's whole
+    /// lifetime (created in `Default`) so `set_context`, the context query and `set_caps` can
+    /// reach it regardless of start/stop ordering; a clone goes to this element's compositor
+    /// thread in `start()`. The device is retired by ownership: when the element is finalized
+    /// its `Arc` drops, so N sessions do not leak N devices.
+    vulkan_share: Arc<waylanddisplaycore::utils::vulkan_share::VulkanShare>,
 }
 
 impl Default for WaylandDisplaySrc {
@@ -59,6 +67,7 @@ impl Default for WaylandDisplaySrc {
             command_rx: Mutex::new(Some(command_rx)),
             hdr_active: AtomicBool::new(false),
             hdr_meta: Mutex::new((None, None)),
+            vulkan_share: waylanddisplaycore::utils::vulkan_share::VulkanShare::new(),
         }
     }
 }
@@ -569,9 +578,9 @@ impl ElementImpl for WaylandDisplaySrc {
     fn set_context(&self, context: &Context) {
         // Absorb a downstream encoder's shared GstVulkanDevice so the Vulkan-encode path can
         // mint encode-src images on the same device (best-effort; no-op for other contexts).
-        if waylanddisplaycore::utils::vulkan_share::handle_set_context(context) {
-            tracing::info!("waylandsrc: absorbed shared GstVulkanDevice for Vulkan encode path");
-        }
+        // Returns true whenever a device is shared afterwards, including when the guard kept
+        // the one this element already had; vulkan_share logs which of the two happened.
+        self.vulkan_share.handle_set_context(context);
 
         // Absorb a downstream VA encoder's GstVaDisplay context so our NV12 buffers can
         // attach VA surfaces on the same display (best-effort).
@@ -705,11 +714,8 @@ impl WaylandDisplaySrc {
         }
         let node = render_node.unwrap_or_else(|| "/dev/dri/renderD128".into());
         let minor = waylanddisplaycore::utils::vulkan_nv12::render_node_minor(&node);
-        waylanddisplaycore::utils::vulkan_share::provide_context(
-            self.obj().upcast_ref::<gst::Element>(),
-            query,
-            minor,
-        )
+        self.vulkan_share
+            .provide_context(self.obj().upcast_ref::<gst::Element>(), query, minor)
     }
 }
 
@@ -1175,7 +1181,7 @@ impl BaseSrcImpl for WaylandDisplaySrc {
                 .clone()
                 .unwrap_or_else(|| "/dev/dri/renderD128".into());
             let minor = waylanddisplaycore::utils::vulkan_nv12::render_node_minor(&node);
-            waylanddisplaycore::utils::vulkan_share::ensure_owned_device(minor);
+            self.vulkan_share.ensure_owned_device(minor);
             let base_video_info =
                 gst_video::VideoInfo::from_caps(caps).expect("failed to get vulkan video info");
             // P010 ⇒ the Vulkan HEVC encoder (vulkanh265enc) Main-10; NV12 ⇒ vulkanh264enc.
@@ -1278,6 +1284,9 @@ impl BaseSrcImpl for WaylandDisplaySrc {
                 render_node.clone(),
                 self.command_tx.clone(),
                 command_rx.deref_mut().take().unwrap(),
+                // Hand this element's compositor thread a clone of OUR share, so producer +
+                // compositor + encoder resolve THIS element's device.
+                Arc::clone(&self.vulkan_share),
             )
         }) else {
             return Err(gst::error_msg!(

--- a/wayland-display-core/src/comp/mod.rs
+++ b/wayland-display-core/src/comp/mod.rs
@@ -88,6 +88,7 @@ use crate::utils::allocator::{
 };
 use crate::utils::device::gpu::GPUDevice;
 use crate::utils::renderer::setup_renderer;
+use crate::utils::vulkan_share::VulkanShare;
 use crate::{
     utils::RenderTarget,
     wayland::protocols::{
@@ -175,6 +176,12 @@ pub struct State {
     /// committed (TV switched) once it has held for [`HDR_DEBOUNCE`]. `None` = no pending
     /// flip. See [`State::update_hdr_state`].
     hdr_candidate_since: Option<Instant>,
+    /// This element's Vulkan-encode device share. A clone of the gst element's own
+    /// `Arc<VulkanShare>`, so the compositor thread reads the SAME per-element device the
+    /// element mints -- not a process-global singleton. Read in `apply_video_info` when
+    /// building the `memory:VulkanImage` output ring. Replaced by the real share in [`init`];
+    /// the `State::new` default is an empty placeholder.
+    pub(crate) vulkan_share: Arc<VulkanShare>,
 }
 
 /// HDR-capable dmabuf fourccs advertised to clients under WOLF_HDR_CM (when the GLES
@@ -444,6 +451,7 @@ impl State {
             frog_color_mgmt_global,
             hdr_state_tx: None,
             last_hdr_state: false,
+            vulkan_share: VulkanShare::new(),
             hdr_candidate_since: None,
         }
     }
@@ -669,7 +677,11 @@ pub(crate) fn apply_video_info(
                     // of panicking when it merely hasn't been shared yet. If it never comes,
                     // leave output_buffer unset -- the render loop turns that into a clean
                     // FlowError rather than aborting the process.
-                    if crate::utils::vulkan_share::wait_for_shared_device(Duration::from_secs(5))
+                    // Clone the Arc so it can be passed to GsVulkanBuf::new while
+                    // `state.renderer` is borrowed mutably below.
+                    let vulkan_share = Arc::clone(&state.vulkan_share);
+                    if vulkan_share
+                        .wait_for_shared_device(Duration::from_secs(5))
                         .is_some()
                     {
                         match GsVulkanBuf::new(
@@ -677,6 +689,7 @@ pub(crate) fn apply_video_info(
                             node,
                             params.video_info,
                             params.profile,
+                            &vulkan_share,
                         ) {
                             Some(allocator) => {
                                 state.output_buffer = Some(GsBufferType::VULKAN(allocator))
@@ -759,6 +772,7 @@ pub(crate) fn init(
     devices_tx: Sender<Vec<CString>>,
     envs_tx: Sender<Vec<CString>>,
     hdr_state_tx: Sender<Command>,
+    vulkan_share: Arc<VulkanShare>,
 ) {
     let render_target = render.into();
     let _ = devices_tx.send(render_target.clone().as_devices());
@@ -775,6 +789,7 @@ pub(crate) fn init(
     let libinput_backend = LibinputInputBackend::new(libinput_context);
 
     let mut state = State::new(&render_target, &dh, &input_context, event_loop.handle());
+    state.vulkan_share = vulkan_share;
 
     // Wire the compositor -> element HDR-state reverse channel only under WOLF_HDR_CM;
     // unset leaves `hdr_state_tx` as `None`, making the per-frame HDR check a no-op.

--- a/wayland-display-core/src/lib.rs
+++ b/wayland-display-core/src/lib.rs
@@ -5,6 +5,7 @@ pub use smithay::reexports::calloop::channel::{Channel, Sender, channel};
 #[cfg(feature = "cuda")]
 use crate::utils::allocator::cuda::CUDABufferPool;
 use crate::utils::device::gpu::GPUDevice;
+use crate::utils::vulkan_share::VulkanShare;
 pub use smithay::backend::allocator::{
     Format as DrmFormat, Fourcc, Modifier as DrmModifier, Vendor as DrmVendor, format::FormatSet,
 };
@@ -140,6 +141,11 @@ impl WaylandDisplay {
         let (envs_tx, envs_rx) = std::sync::mpsc::channel();
         // Reverse channel (compositor -> element) for HDR-state notifications.
         let (hdr_state_tx, hdr_state_rx) = std::sync::mpsc::channel();
+        // This constructor has no gst element to answer context queries, so nothing outside
+        // the compositor thread mints on it -- but comp::init needs one, and making it
+        // per-instance keeps the process-global slots gone on this path too.
+        let vulkan_share = VulkanShare::new();
+        let compositor_vulkan_share = Arc::clone(&vulkan_share);
         let render_target = RenderTarget::from_str(
             &render_node.unwrap_or_else(|| String::from("/dev/dri/renderD128")),
         )?;
@@ -155,6 +161,7 @@ impl WaylandDisplay {
                     devices_tx,
                     envs_tx,
                     hdr_state_tx,
+                    compositor_vulkan_share,
                 );
             }) {
                 tracing::error!(?err, "Compositor thread panic'ed!");
@@ -176,11 +183,16 @@ impl WaylandDisplay {
         render_node: Option<String>,
         command_tx: Sender<Command>,
         commands_rx: Channel<Command>,
+        vulkan_share: Arc<VulkanShare>,
     ) -> Result<WaylandDisplay, CreateDrmNodeError> {
         let (devices_tx, devices_rx) = std::sync::mpsc::channel();
         let (envs_tx, envs_rx) = std::sync::mpsc::channel();
         // Reverse channel (compositor -> element) for HDR-state notifications.
         let (hdr_state_tx, hdr_state_rx) = std::sync::mpsc::channel();
+        // Per-element Vulkan share: the gst element owns one for its whole lifetime and hands
+        // the compositor thread a clone, so producer + compositor + encoder all resolve THIS
+        // element's device instead of a process-global singleton.
+        let compositor_vulkan_share = Arc::clone(&vulkan_share);
         let render_target = RenderTarget::from_str(
             &render_node.unwrap_or_else(|| String::from("/dev/dri/renderD128")),
         )?;
@@ -192,6 +204,7 @@ impl WaylandDisplay {
                 devices_tx,
                 envs_tx,
                 hdr_state_tx,
+                compositor_vulkan_share,
             );
         });
 

--- a/wayland-display-core/src/utils/allocator/mod.rs
+++ b/wayland-display-core/src/utils/allocator/mod.rs
@@ -285,6 +285,7 @@ impl GsVulkanBuf {
         render_node: DrmNode,
         video_info: VideoInfo,
         profile: String,
+        vulkan_share: &crate::utils::vulkan_share::VulkanShare,
     ) -> Option<Self> {
         let (w, h) = (video_info.width(), video_info.height());
 
@@ -318,8 +319,9 @@ impl GsVulkanBuf {
             rgba.format().modifier
         );
 
-        // The shared device must already have been absorbed from a GstContext.
-        let dev = crate::utils::vulkan_share::shared_device()?;
+        // This element's shared device must already have been absorbed from a GstContext
+        // (read THIS element's per-element share, not a process-global slot).
+        let dev = vulkan_share.shared_device()?;
         let raw = crate::utils::vulkan_share::raw_handles(&dev)?;
         // NV12 (8-bit, vulkanh264enc) or P010 (10-bit, vulkanh265enc Main-10) per the
         // negotiated memory:VulkanImage format.

--- a/wayland-display-core/src/utils/vulkan_share.rs
+++ b/wayland-display-core/src/utils/vulkan_share.rs
@@ -30,7 +30,7 @@ use gst::prelude::*;
 use gstreamer_vulkan::prelude::*;
 use gstreamer_vulkan::{VulkanDevice, VulkanInstance, VulkanPhysicalDevice, VulkanQueue};
 use gstreamer_vulkan_sys as gstvk;
-use std::sync::{Mutex, OnceLock};
+use std::sync::{Arc, Mutex};
 
 // VK_IMAGE_USAGE_VIDEO_ENCODE_SRC_BIT_KHR / VK_IMAGE_LAYOUT_VIDEO_ENCODE_SRC_KHR via raw
 // values (stable, and avoids depending on the named ash constants existing).
@@ -56,39 +56,85 @@ pub struct RawVk {
     pub gfx_queue_family: u32,
 }
 
-/// Process-wide slot for the shared device, filled from `set_context` and read by the
-/// converter when it builds its output ring (mirrors `va_share`'s display slot).
-fn device_slot() -> &'static Mutex<Option<VulkanDevice>> {
-    static SLOT: OnceLock<Mutex<Option<VulkanDevice>>> = OnceLock::new();
-    SLOT.get_or_init(|| Mutex::new(None))
+/// Per-`waylanddisplaysrc`-element owner of the Vulkan objects the encode path shares.
+///
+/// Historically the
+/// owned `GstVulkanInstance` + `GstVulkanDevice` lived in *process-global* `OnceLock` slots,
+/// so every session in one process reused the first session's `VkDevice` (a single failure
+/// domain — one session's `DEVICE_LOST` corrupts all N; session 2..N's `target_minor`
+/// ignored; a deliberate per-process device leak). One `VulkanShare` is now created per
+/// element and cloned **once** into that element's compositor thread (mirroring the existing
+/// `app_surface_commits` / `renderer_degraded` `Arc`s threaded through
+/// `WaylandDisplay::new_with_channel` -> `comp::init`), so each `waylanddisplaysrc` mints,
+/// answers `gst.vulkan.{instance,device}` context queries with, and owns its **own** device,
+/// released when the element is finalized and this `Arc` drops. N concurrent Vulkan-encode
+/// sessions on one host therefore get N isolated devices — a `DEVICE_LOST` on one retires
+/// only that element's device, leaving the other N-1 untouched.
+///
+/// This is a **storage-location** change only: device creation
+/// ([`ensure_owned_device`](VulkanShare::ensure_owned_device)) is byte-identical to the
+/// previous global path, with no vendor branch, so the RADV path sees no behavioral change.
+/// The `wayland_display_vk_*` C bridge is untouched.
+pub struct VulkanShare {
+    /// The `GstVulkanInstance` we own (keeps it alive + lets us answer `gst.vulkan.instance`
+    /// context queries). Replaces the process-global `instance_slot()`.
+    instance: Mutex<Option<VulkanInstance>>,
+    /// The shared device, filled from `set_context`
+    /// ([`handle_set_context`](VulkanShare::handle_set_context)) or minted by
+    /// [`ensure_owned_device`](VulkanShare::ensure_owned_device), and read by the converter
+    /// when it builds its output ring. Replaces the process-global `device_slot()`.
+    device: Mutex<Option<VulkanDevice>>,
 }
 
-/// Pull the shared `GstVulkanDevice` out of a received `GstContext` and stash it. Call from
-/// `ElementImpl::set_context` for the `gst.vulkan.device` context type. Returns true if a
-/// device is now shared.
-pub fn handle_set_context(context: &gst::Context) -> bool {
-    let ctx_ptr = context.to_glib_none().0;
-    let mut dev_ptr: *mut gstvk::GstVulkanDevice = std::ptr::null_mut();
-    let got = unsafe { gstvk::gst_context_get_vulkan_device(ctx_ptr, &mut dev_ptr) };
-    if got == gst::glib::ffi::GFALSE || dev_ptr.is_null() {
-        return false;
+impl VulkanShare {
+    /// A fresh, empty per-element share. Cheap; holds no Vulkan objects until first use. Kept
+    /// behind an `Arc` so one clone can be handed to the compositor thread while the element
+    /// keeps the other (exactly like `app_surface_commits` / `renderer_degraded`).
+    pub fn new() -> Arc<VulkanShare> {
+        Arc::new(VulkanShare {
+            instance: Mutex::new(None),
+            device: Mutex::new(None),
+        })
     }
-    let device: VulkanDevice = unsafe { from_glib_full(dev_ptr) };
-    tracing::debug!("vulkan_share: absorbed shared GstVulkanDevice {dev_ptr:?}");
-    *device_slot().lock().unwrap() = Some(device);
-    true
-}
 
-/// The shared device, if one has been created (or absorbed).
-pub fn shared_device() -> Option<VulkanDevice> {
-    device_slot().lock().unwrap().clone()
-}
+    /// Pull the shared `GstVulkanDevice` out of a received `GstContext` and stash it in **this
+    /// element's** slot. Call from `ElementImpl::set_context` for the `gst.vulkan.device`
+    /// context type. Returns true if a device is now shared.
+    pub fn handle_set_context(&self, context: &gst::Context) -> bool {
+        let ctx_ptr = context.to_glib_none().0;
+        let mut dev_ptr: *mut gstvk::GstVulkanDevice = std::ptr::null_mut();
+        let got = unsafe { gstvk::gst_context_get_vulkan_device(ctx_ptr, &mut dev_ptr) };
+        if got == gst::glib::ffi::GFALSE || dev_ptr.is_null() {
+            return false;
+        }
+        let device: VulkanDevice = unsafe { from_glib_full(dev_ptr) };
+        let mut slot = self.device.lock().unwrap();
+        // Keep the device this element already has. GstBin fans a have-context message to
+        // EVERY child, so with two waylanddisplaysrc in one bin the second element's encoder
+        // would otherwise overwrite the first element's device while that element's own
+        // encoder stays on the original -- producing buffers on one VkDevice and encoding
+        // them on another. Under the old process-global slot everyone shared one device and
+        // the overwrite was free; per element it is a cross-device hazard, so refuse it here
+        // rather than relying on the embedder to check.
+        if let Some(existing) = slot.as_ref() {
+            if existing.as_ptr() != device.as_ptr() {
+                tracing::warn!(
+                    "vulkan_share: ignoring a different GstVulkanDevice {dev_ptr:?} offered to an \
+                     element already on {:?}",
+                    existing.as_ptr()
+                );
+            }
+            return true;
+        }
+        tracing::debug!("vulkan_share: absorbed shared GstVulkanDevice {dev_ptr:?}");
+        *slot = Some(device);
+        true
+    }
 
-/// Process-wide slot for the `GstVulkanInstance` we own (keeps it alive + lets us answer
-/// `gst.vulkan.instance` context queries).
-fn instance_slot() -> &'static Mutex<Option<VulkanInstance>> {
-    static SLOT: OnceLock<Mutex<Option<VulkanInstance>>> = OnceLock::new();
-    SLOT.get_or_init(|| Mutex::new(None))
+    /// This element's shared device, if one has been created (or absorbed).
+    pub fn shared_device(&self) -> Option<VulkanDevice> {
+        self.device.lock().unwrap().clone()
+    }
 }
 
 // VK_QUEUE_VIDEO_ENCODE_BIT_KHR — the encoder (gst_vulkan_encoder_create_from_queue) requires a
@@ -168,95 +214,117 @@ unsafe fn physical_index_for_minor(
     Some(0)
 }
 
-/// Create (once) the `GstVulkanInstance` + `GstVulkanDevice` that *we* own, on the GPU
-/// backing `target_minor`, with the external-memory extensions the RGBA-dmabuf import needs
-/// (`VK_KHR_external_memory_fd` etc.) enabled — which gst-vulkan's own device does not. This
-/// is the device we hand the encoder (see [`provide_context`]) so producer and encoder share
-/// one device with no zero-copy gap *and* no gstreamer fork. Idempotent.
-pub fn ensure_owned_device(target_minor: Option<u32>) -> Option<VulkanDevice> {
-    let mut slot = device_slot().lock().unwrap();
-    if let Some(d) = slot.clone() {
-        return Some(d);
-    }
-    let instance = VulkanInstance::new();
-    if let Err(e) = instance.open() {
-        tracing::error!("vulkan_share: GstVulkanInstance open failed: {e}");
-        return None;
-    }
-    let vk_instance = unsafe { wayland_display_vk_instance_handle(instance.as_ptr()) };
-    let index = unsafe {
-        let entry = match ash::Entry::load() {
-            Ok(e) => e,
-            Err(e) => {
-                tracing::error!("vulkan_share: ash entry load failed: {e}");
-                return None;
-            }
-        };
-        let ash_inst = ash::Instance::load(entry.static_fn(), vk_instance);
-        physical_index_for_minor(&ash_inst, target_minor)?
-    };
-    let physical = VulkanPhysicalDevice::new(&instance, index);
-    let device = VulkanDevice::new(&physical);
-    for ext in [
-        "VK_KHR_external_memory_fd",
-        "VK_EXT_external_memory_dma_buf",
-        "VK_EXT_image_drm_format_modifier",
-        "VK_KHR_external_semaphore_fd",
-    ] {
-        device.enable_extension(ext);
-    }
-    if let Err(e) = device.open() {
-        tracing::error!("vulkan_share: GstVulkanDevice open failed: {e}");
-        return None;
-    }
-    *instance_slot().lock().unwrap() = Some(instance);
-    *slot = Some(device.clone());
-    tracing::info!(
-        "vulkan_share: created shared GstVulkanDevice (phys idx {index}) with external-memory extensions"
-    );
-    Some(device)
-}
-
-/// Answer a `gst.vulkan.{instance,device}` context query on `element` with the device we own,
-/// creating it on `target_minor`'s GPU on first ask. The downstream encoder's
-/// `gst_vulkan_ensure_element_data` then adopts *our* device instead of minting its own.
-pub fn provide_context(
-    element: &gst::Element,
-    query: &mut gst::QueryRef,
-    target_minor: Option<u32>,
-) -> bool {
-    if ensure_owned_device(target_minor).is_none() {
-        return false;
-    }
-    let inst = instance_slot().lock().unwrap().clone();
-    let dev = device_slot().lock().unwrap().clone();
-    unsafe {
-        gstvk::gst_vulkan_handle_context_query(
-            element.as_ptr() as *mut _,
-            query.as_mut_ptr() as *mut _,
-            std::ptr::null_mut(),
-            inst.as_ref().map_or(std::ptr::null_mut(), |i| i.as_ptr()) as *mut _,
-            dev.as_ref().map_or(std::ptr::null_mut(), |d| d.as_ptr()) as *mut _,
-        ) != gst::glib::ffi::GFALSE
-    }
-}
-
-/// Wait up to `timeout` for our shared `GstVulkanDevice` to be available.
-///
-/// The encoder shares its device via a `GstContext` delivered to `set_context` on the
-/// streaming thread, which races the compositor thread that allocates our Vulkan output
-/// buffer. Polling here lets the allocation wait for the device to arrive instead of
-/// failing when it merely hasn't been shared *yet*. Returns `None` if it never arrives.
-pub fn wait_for_shared_device(timeout: std::time::Duration) -> Option<VulkanDevice> {
-    let start = std::time::Instant::now();
-    loop {
-        if let Some(dev) = shared_device() {
-            return Some(dev);
+impl VulkanShare {
+    /// Create (once, on **this element**) the `GstVulkanInstance` + `GstVulkanDevice` that *we*
+    /// own, on the GPU backing `target_minor`, with the external-memory extensions the
+    /// RGBA-dmabuf import needs (`VK_KHR_external_memory_fd` etc.) enabled — which gst-vulkan's
+    /// own device does not. This is the device we hand the encoder (see
+    /// [`provide_context`](VulkanShare::provide_context)) so producer and encoder share one
+    /// device with no zero-copy gap *and* no gstreamer fork. Idempotent **per element** (not
+    /// per process): the first call on *this* share mints on *this* element's `target_minor`.
+    ///
+    /// Device creation below is unchanged from the pre-patch process-global path — no vendor
+    /// branch — so RADV behaves byte-identically; only where the result is stored moved from a
+    /// `static` slot to `self`.
+    /// LOCK ORDER: `device` then `instance`, and this is the only method that holds both.
+    /// The `device` guard is deliberately held across the instance open, `Entry::load` and
+    /// device enumeration below -- it is the mutual exclusion that stops two threads each
+    /// minting a `VkDevice` for this element. Every other accessor takes a single lock as a
+    /// temporary (`provide_context` clones instance and device in separate statements, so it
+    /// never holds both), which is why the inverse order cannot arise.
+    pub fn ensure_owned_device(&self, target_minor: Option<u32>) -> Option<VulkanDevice> {
+        let mut slot = self.device.lock().unwrap();
+        if let Some(d) = slot.clone() {
+            // Whatever this element already has wins over target_minor. Usually that is the
+            // device minted below on that very node, so the two agree; the slot records no
+            // provenance, so this branch cannot tell the two apart. When they disagree the
+            // device was injected by an embedder and the encoder is already bound to it, and
+            // minting a second device on the requested node would put producer and encoder on
+            // different VkDevices, which is worse than honouring the wrong node.
+            return Some(d);
         }
-        if start.elapsed() >= timeout {
+        let instance = VulkanInstance::new();
+        if let Err(e) = instance.open() {
+            tracing::error!("vulkan_share: GstVulkanInstance open failed: {e}");
             return None;
         }
-        std::thread::sleep(std::time::Duration::from_millis(10));
+        let vk_instance = unsafe { wayland_display_vk_instance_handle(instance.as_ptr()) };
+        let index = unsafe {
+            let entry = match ash::Entry::load() {
+                Ok(e) => e,
+                Err(e) => {
+                    tracing::error!("vulkan_share: ash entry load failed: {e}");
+                    return None;
+                }
+            };
+            let ash_inst = ash::Instance::load(entry.static_fn(), vk_instance);
+            physical_index_for_minor(&ash_inst, target_minor)?
+        };
+        let physical = VulkanPhysicalDevice::new(&instance, index);
+        let device = VulkanDevice::new(&physical);
+        for ext in [
+            "VK_KHR_external_memory_fd",
+            "VK_EXT_external_memory_dma_buf",
+            "VK_EXT_image_drm_format_modifier",
+            "VK_KHR_external_semaphore_fd",
+        ] {
+            device.enable_extension(ext);
+        }
+        if let Err(e) = device.open() {
+            tracing::error!("vulkan_share: GstVulkanDevice open failed: {e}");
+            return None;
+        }
+        *self.instance.lock().unwrap() = Some(instance);
+        *slot = Some(device.clone());
+        tracing::info!(
+            "vulkan_share: created per-element shared GstVulkanDevice (phys idx {index}) with external-memory extensions"
+        );
+        Some(device)
+    }
+
+    /// Answer a `gst.vulkan.{instance,device}` context query on `element` with the device we
+    /// own, creating it on `target_minor`'s GPU on first ask. The downstream encoder's
+    /// `gst_vulkan_ensure_element_data` then adopts *our* device instead of minting its own.
+    pub fn provide_context(
+        &self,
+        element: &gst::Element,
+        query: &mut gst::QueryRef,
+        target_minor: Option<u32>,
+    ) -> bool {
+        if self.ensure_owned_device(target_minor).is_none() {
+            return false;
+        }
+        let inst = self.instance.lock().unwrap().clone();
+        let dev = self.device.lock().unwrap().clone();
+        unsafe {
+            gstvk::gst_vulkan_handle_context_query(
+                element.as_ptr() as *mut _,
+                query.as_mut_ptr() as *mut _,
+                std::ptr::null_mut(),
+                inst.as_ref().map_or(std::ptr::null_mut(), |i| i.as_ptr()) as *mut _,
+                dev.as_ref().map_or(std::ptr::null_mut(), |d| d.as_ptr()) as *mut _,
+            ) != gst::glib::ffi::GFALSE
+        }
+    }
+
+    /// Wait up to `timeout` for **this element's** shared `GstVulkanDevice` to be available.
+    ///
+    /// The encoder shares its device via a `GstContext` delivered to `set_context` on the
+    /// streaming thread, which races the compositor thread that allocates this element's Vulkan
+    /// output buffer. Polling here lets the allocation wait for the device to arrive instead of
+    /// failing when it merely hasn't been shared *yet*. The race is **per element**, so the
+    /// poll is retained, scoped to this share. Returns `None` if it never arrives.
+    pub fn wait_for_shared_device(&self, timeout: std::time::Duration) -> Option<VulkanDevice> {
+        let start = std::time::Instant::now();
+        loop {
+            if let Some(dev) = self.shared_device() {
+                return Some(dev);
+            }
+            if start.elapsed() >= timeout {
+                return None;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
     }
 }
 


### PR DESCRIPTION
## Problem

The owned `GstVulkanInstance` + `GstVulkanDevice` live in two process-global `OnceLock` slots, so every `waylanddisplaysrc` in a process shares whichever one was minted first. That means:

- Session 2..N inherit session 1's `target_minor`, ignoring their own.
- One session's `DEVICE_LOST` corrupts all N.
- Nothing ever hands the device back. The slot leaks by design.

## Change

- One `VulkanShare` per element, cloned once into that element's compositor thread. Same pattern as the existing `app_surface_commits` / `renderer_degraded` `Arc`s.
- Each element mints its own device and answers `gst.vulkan.{instance,device}` with it. Ownership alone retires it: the `Arc` drops when the element is finalized, so N sessions no longer leak N devices.
- Storage location only. `ensure_owned_device` is byte-identical to the old global path, no vendor branch, RADV unchanged. C bridge untouched.

Rebased onto `b49f7c0` as a single commit now that #46 and #47 have landed.

## Your review points

**Fan-out topology.** Inside this crate, every buffer is minted on its own element's device (`set_caps` -> `ensure_owned_device`, ring built from the same share). Which device the *encoder* adopts is the embedder's context wiring, since the encoder is in a separate pipeline across interpipe.

`handle_set_context` now keeps the device this element already holds and warns if a different one is offered. Your bin-fanout path is what convinced me: GstBin fans a have-context to every child, so two sources in one bin is enough, no mis-wired embedder needed. The cross-device pairing is refused in the crate rather than left to the embedder to check.

Ordering contract worth stating: inject a device before caps negotiation or not at all. `set_caps` mints eagerly, so a later injection is refused.

**stop()/start().** `clear()` is gone. Per-element ownership plus the compositor thread join already retire everything that matters at `stop()`, so it only made release earlier, and it was the sole source of the desync caveat this PR previously pushed onto embedders. What remains after `stop()` is a bare `VkDevice`+`VkInstance` held until the element is finalized.

**Feature-gate.** I believe this is already true on base, so I've left it: `Cargo.toml` declares `gstreamer-vulkan` `features = ["v1_28"]` unconditionally, and `utils/mod.rs` declares `vulkan_share`/`vulkan_nv12` unconditionally. A CUDA-only gst-1.24 build fails before this PR. The only new requirement was headers + a C compiler, documented in `ci/README.md` by #47. Say the word if you still want a `vulkan` feature.

**target_minor after an absorbed device.** Left as-is, documented. The slot records no provenance, so the short-circuit cannot tell a self-minted device from an injected one. When they differ the encoder is already bound to the injected device, and re-minting on the requested node would split producer and encoder across two `VkDevice`s, which is worse than honouring the wrong node.

**Also done:** tautological test dropped · `repr(C)` overlay doc claim fixed · `comp/mod.rs` doc drift fixed · lock order documented on `ensure_owned_device` (only method holding both, so the inverse order can't arise) · `lib.rs` five-second comment deleted, that path cannot produce a VULKAN video info.

**Not needed:** `new_ret_no_self` doesn't fire (clippy exempts `new` returning `Arc<Self>`) · `raw_handles` is byte-identical to base, so the family-0 point is moot.

## Verified

`cargo fmt` clean · `check` and `check --features cuda` clean · rustdoc no broken links · 23 tests pass.
