### PR TITLE
fix(vulkan): complete the GLES render fence before the Vulkan conversion reads it

### DIFF
--- a/wayland-display-core/src/comp/mod.rs
+++ b/wayland-display-core/src/comp/mod.rs
@@ -836,10 +836,6 @@ pub(crate) fn init(
                         }
                         if let Err(_) = match state.create_frame() {
                             Ok((buf, render_result)) => {
-                                render_result
-                                    .sync
-                                    .wait()
-                                    .expect("Error during render_result.sync"); // we need to wait before giving a hardware buffer to gstreamer or we might not be done writing to it
                                 let res = buffer_sender.send(Ok(buf));
                                 let rendered_states = &render_result.states;
                                 let rendered_damage = render_result.damage.is_some();

--- a/wayland-display-core/src/comp/rendering.rs
+++ b/wayland-display-core/src/comp/rendering.rs
@@ -221,6 +221,17 @@ impl State {
             [0.0, 0.0, 0.0, 1.0],
         )?;
 
+        // The NV12/VulkanImage paths import this GLES render target as external Vulkan
+        // memory and sample it during `to_gs_buffer`. Waiting in the caller after
+        // `create_frame` returns is too late: the converter has already submitted its
+        // Vulkan read by then, so the GLES write and the Vulkan read are only ordered if
+        // the driver happens to serialize the two APIs -- which nothing guarantees.
+        // Complete the GLES render here, before any hardware conversion or hand-off
+        // consumes the target.
+        render_output_result
+            .sync
+            .wait()
+            .expect("Error during render_result.sync");
         // HDR render-path spike ISOLATION probe: read the fp16 RGBA dmabuf straight off the GLES
         // framebuffer (after render_output, before the Vulkan converter in to_gs_buffer) and log
         // the bar-center float values -- proving whether GLES kept >1.0 or clamped. Gated behind


### PR DESCRIPTION
The NV12 / VulkanImage output paths render the scene into a GLES RGBA dmabuf and then import that same allocation into Vulkan for the RGBA→NV12 conversion.

The render fence is waited in the caller, **after** `State::create_frame()` returns — but `create_frame()` has already called `to_gs_buffer()`, which submits the Vulkan read. So the wait only orders the later GStreamer hand-off, not the GLES→Vulkan ownership seam: the GLES write and the Vulkan read end up ordered only if the driver happens to serialize the two APIs, which nothing guarantees.

This moves the existing wait to immediately after `render_output()`, before any readback or `to_gs_buffer()` conversion, and drops the now-redundant late wait from the caller.

**No new synchronization is introduced** — the same fence is waited, just at the point where it actually protects the consumer. Net diff is 2 files, +11/−4.

Independent of the encoder and of any downstream element: it concerns only the GLES-producer / Vulkan-consumer seam inside the compositor.

### On attribution

I found this while chasing NVIDIA device-loss reports (Xid 13/32 → `VK_ERROR_DEVICE_LOST`) on an RTX 5090. To be straight with you: **that symptom turned out to have a different, separately proven cause**, so I am not claiming this fixes device loss. It is offered as a correctness/ordering fix on its own merits — the current code depends on undocumented driver behaviour for the seam to be safe.

### Verification

`cargo build --release` clean and `cargo test -p wayland-display-core` green (18 passed, 0 failed) on this branch's head; `cargo fmt --check` clean. This fix has been running in my deployment on both NVIDIA and AMD hosts.
