### PR TITLE
fix(egl): stop reporting a failed wl_display bind as lost hardware acceleration

### DIFF
--- a/wayland-display-core/src/comp/mod.rs
+++ b/wayland-display-core/src/comp/mod.rs
@@ -322,9 +322,19 @@ impl State {
                 dmabuf_state.create_global::<State>(&dh, formats.clone())
             };
 
+            // The only product of this bind is the `EGLBufferReader` used by the legacy
+            // wl_drm / EGL-image import path. Both client-buffer routes here go through
+            // `import_dmabuf` (`handlers/dmabuf.rs`, and `handlers/wl_drm.rs` -- mesa's wl_drm
+            // is implemented over dmabuf), so a failed bind does not disable hardware
+            // acceleration and does not affect dmabuf import. Logging it as
+            // "Failed to initialize EGL hardware-acceleration" is misleading: on render nodes
+            // where the bind always fails it reads as a fallback to software rendering.
             match renderer.bind_wl_display(&dh) {
                 Ok(_) => tracing::info!("EGL hardware-acceleration enabled"),
-                Err(err) => tracing::info!(?err, "Failed to initialize EGL hardware-acceleration"),
+                Err(err) => tracing::debug!(
+                    ?err,
+                    "EGL wl_display bind unavailable (legacy wl_drm/EGL-image import disabled; dmabuf import unaffected)"
+                ),
             }
 
             // wl_drm (mesa protocol, so we don't need EGL_WL_bind_display)


### PR DESCRIPTION
One small logging fix around the EGL `wl_display` bind.

`renderer.bind_wl_display()` failing is logged as `info!("Failed to initialize EGL hardware-acceleration")`. That reads as a fallback to software rendering, but the only product of this bind is the `EGLBufferReader` used by the legacy wl_drm / EGL-image import path. Both client-buffer routes here go through `import_dmabuf` (`handlers/dmabuf.rs`, and `handlers/wl_drm.rs`, since mesa's wl_drm is implemented over dmabuf), so a failed bind disables neither hardware acceleration nor dmabuf import.

On render nodes where the bind always fails, that line appears on every startup. It cost me a long detour chasing a software-rendering fallback that was never happening. Demoted to `debug!` and reworded to say what is actually unavailable.

The earlier revision of this PR also added an explicit `unbind_wl_display()` at teardown. Review showed the mechanism I proposed for it was wrong, and a live reproduction confirmed the real cause is overlapping compositor lifetimes, which prompt unbinding does not address. Dropped; details in the comments.

`cargo build` and `cargo fmt --check` clean on `43d4c25`.
