### PR TITLE
fix(vulkan): preserve image flags during allocation

### DIFF
--- a/docker/vulkan.Dockerfile
+++ b/docker/vulkan.Dockerfile
@@ -55,11 +55,13 @@ RUN dnf install -y \
 # --- Patched GStreamer 1.28.4 -> /opt/gst -----------------------------------
 COPY patches/vkh264enc-dpb-pool-in-new-sequence.patch /tmp/dpb.patch
 COPY patches/vulkanh265enc.patch /tmp/h265.patch
+COPY patches/gstvulkan-preserve-image-create-flags.patch /tmp/image-flags.patch
 RUN git clone --depth 1 --branch ${GST_VERSION} \
       https://gitlab.freedesktop.org/gstreamer/gstreamer.git /tmp/gstreamer && \
     cd /tmp/gstreamer && \
     git apply /tmp/dpb.patch && \
     git apply /tmp/h265.patch && \
+    git apply /tmp/image-flags.patch && \
     # auto_features=disabled leaves several subprojects' docs/meson.build referring
     # to an undefined plugins_cache_generator; short-circuit each when doc is off.
     for d in subprojects/*/docs/meson.build docs/meson.build; do \
@@ -86,7 +88,7 @@ RUN git clone --depth 1 --branch ${GST_VERSION} \
       -Dnls=disabled -Dgst-examples=disabled -Drs=disabled && \
     meson compile -C build && \
     meson install -C build && \
-    rm -rf /tmp/gstreamer /tmp/dpb.patch /tmp/h265.patch
+    rm -rf /tmp/gstreamer /tmp/dpb.patch /tmp/h265.patch /tmp/image-flags.patch
 
 ENV PKG_CONFIG_PATH=/opt/gst/lib64/pkgconfig \
     LD_LIBRARY_PATH=/opt/gst/lib64 \

--- a/patches/README.md
+++ b/patches/README.md
@@ -6,6 +6,7 @@ Apply against a gstreamer monorepo checkout before building:
 ```
 git apply patches/vkh264enc-dpb-pool-in-new-sequence.patch
 git apply patches/vulkanh265enc.patch
+git apply patches/gstvulkan-preserve-image-create-flags.patch
 ```
 
 ## vkh264enc-dpb-pool-in-new-sequence.patch
@@ -42,6 +43,20 @@ to import the compositor's RGBA dmabuf. Rather than fork gstreamer for that, the
 plugin **creates its own `GstVulkanInstance`/`GstVulkanDevice`** with those
 extensions enabled and hands it to the encoder via a context-query answer, so no
 gstreamer patch is required. See `wayland-display-core/src/utils/vulkan_share.rs`.)
+
+## gstvulkan-preserve-image-create-flags.patch
+
+Preserves the caller's `VkImageCreateInfo::flags` when
+`gst_vulkan_image_memory_alloc_with_image_info()` validates the created image
+with `vkGetPhysicalDeviceImageFormatProperties()`. Dropping
+`VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT` and
+`VK_IMAGE_CREATE_EXTENDED_USAGE_BIT` can reject a successfully created
+multiplanar NV12/P010 image whose compatible plane views provide storage-image
+support.
+
+Tested with NV12/H.264 and P010/H.265 Vulkan Video allocation on RADV. The fix
+is also prepared against GStreamer `main`; this local patch can be removed once
+the fix is available in the pinned GStreamer release.
 
 ## Building the patched gstreamer
 

--- a/patches/gstvulkan-preserve-image-create-flags.patch
+++ b/patches/gstvulkan-preserve-image-create-flags.patch
@@ -1,0 +1,34 @@
+From 1b44b7eb790ae88bbda25f8766cd8df795adcc82 Mon Sep 17 00:00:00 2001
+From: Eli Bosley <eli@bosley.dev>
+Date: Mon, 27 Jul 2026 09:27:21 -0400
+Subject: [PATCH] vulkan: preserve image flags in format query
+
+The allocator creates an image with the caller-supplied flags but then
+validates its format properties with flags set to zero. This can reject an
+image after vkCreateImage succeeds, including multiplanar images using
+MUTABLE_FORMAT and EXTENDED_USAGE where storage support is supplied by
+compatible plane views.
+
+Pass the original image flags to the format query, matching the wrapped-image
+allocation path.
+---
+ .../gst-plugins-bad/gst-libs/gst/vulkan/gstvkimagememory.c     | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/subprojects/gst-plugins-bad/gst-libs/gst/vulkan/gstvkimagememory.c b/subprojects/gst-plugins-bad/gst-libs/gst/vulkan/gstvkimagememory.c
+index 9714d65..dbe4c2c 100644
+--- a/subprojects/gst-plugins-bad/gst-libs/gst/vulkan/gstvkimagememory.c
++++ b/subprojects/gst-plugins-bad/gst-libs/gst/vulkan/gstvkimagememory.c
+@@ -189,7 +189,8 @@ _vk_image_mem_new_alloc_with_image_info (GstAllocator * allocator,
+ 
+ 
+   err = vkGetPhysicalDeviceImageFormatProperties (gpu, image_info->format,
+-      VK_IMAGE_TYPE_2D, image_info->tiling, image_info->usage, 0,
++      VK_IMAGE_TYPE_2D, image_info->tiling, image_info->usage,
++      image_info->flags,
+       &mem->format_properties);
+   if (gst_vulkan_error_to_g_error (err, &error,
+           "vkGetPhysicalDeviceImageFormatProperties") < 0)
+-- 
+2.50.1 (Apple Git-155)
+


### PR DESCRIPTION
## What changed

- add a GStreamer patch that forwards `VkImageCreateInfo::flags` to
  `vkGetPhysicalDeviceImageFormatProperties()`
- apply the patch in the Vulkan runtime image
- document why the patch is required and when it can be removed

## Root cause

`gst_vulkan_image_memory_alloc_with_image_info()` creates the image with the
caller's flags, but its post-create format query currently passes `0`. On RADV,
that makes an otherwise valid multiplanar NV12/P010 allocation fail when
`MUTABLE_FORMAT` and `EXTENDED_USAGE` authorize storage-capable plane views.
The wrapped-image allocation path already preserves these flags.

## Impact

Compatible Vulkan Video implementations can write conversion output directly
into the encoder-owned NV12/P010 image instead of falling back to a separate
storage scratch image and copy. Implementations that do not advertise the
required format/usage combination retain the existing fallback.

## Validation

- patch applies cleanly to GStreamer 1.28.4 and current GStreamer `main`
- the patched GStreamer/Wolf images built successfully with the protected
  Vulkan, HDR, shared-frame ownership, and input-idempotency tests
- live RADV probes on an AMD Radeon 780M at 3840×2160 selected
  `direct_storage=true`, optimal tiling, for both NV12/H.264 and P010/H.265
- local 3840×2160/60 DMA-BUF presentation remained zero-copy

The same minimal source change is prepared against GStreamer `main`; this
repository patch can be removed once an upstream release contains it.
