### PR TITLE
feat(vulkan): write directly into compatible encode images

### DIFF
--- a/docker/vulkan.Dockerfile
+++ b/docker/vulkan.Dockerfile
@@ -55,11 +55,13 @@ RUN dnf install -y \
 # --- Patched GStreamer 1.28.4 -> /opt/gst -----------------------------------
 COPY patches/vkh264enc-dpb-pool-in-new-sequence.patch /tmp/dpb.patch
 COPY patches/vulkanh265enc.patch /tmp/h265.patch
+COPY patches/vulkan-image-create-flags-1.28.patch /tmp/image-create-flags.patch
 RUN git clone --depth 1 --branch ${GST_VERSION} \
       https://gitlab.freedesktop.org/gstreamer/gstreamer.git /tmp/gstreamer && \
     cd /tmp/gstreamer && \
     git apply /tmp/dpb.patch && \
     git apply /tmp/h265.patch && \
+    git apply /tmp/image-create-flags.patch && \
     # auto_features=disabled leaves several subprojects' docs/meson.build referring
     # to an undefined plugins_cache_generator; short-circuit each when doc is off.
     for d in subprojects/*/docs/meson.build docs/meson.build; do \
@@ -86,7 +88,7 @@ RUN git clone --depth 1 --branch ${GST_VERSION} \
       -Dnls=disabled -Dgst-examples=disabled -Drs=disabled && \
     meson compile -C build && \
     meson install -C build && \
-    rm -rf /tmp/gstreamer /tmp/dpb.patch /tmp/h265.patch
+    rm -rf /tmp/gstreamer /tmp/dpb.patch /tmp/h265.patch /tmp/image-create-flags.patch
 
 ENV PKG_CONFIG_PATH=/opt/gst/lib64/pkgconfig \
     LD_LIBRARY_PATH=/opt/gst/lib64 \

--- a/docker/vulkan.Dockerfile
+++ b/docker/vulkan.Dockerfile
@@ -126,7 +126,8 @@ COPY . /src
 WORKDIR /src
 # Install the plugin .so into /opt/gst's plugin dir (so anything FROM this image,
 # e.g. wolf:vulkan, inherits it on GST_PLUGIN_PATH) plus its pkg-config/header.
-RUN cargo cinstall --release \
+RUN cargo test --release -p wayland-display-core direct_encode && \
+    cargo cinstall --release \
       --prefix=/opt/gst \
       --libdir=/opt/gst/lib64/gstreamer-1.0 \
       --pkgconfigdir=/opt/gst/lib64/pkgconfig

--- a/docker/vulkan.Dockerfile
+++ b/docker/vulkan.Dockerfile
@@ -119,7 +119,7 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
 # Cache-bust the plugin source COPY + compile. The registry build cache (cache-from/
 # cache-to mode=max) can serve a STALE `cargo cinstall` layer even when src/ changed,
 # leaving an outdated plugin .so in the image. Bump this to force a clean recompile.
-ARG PLUGIN_CACHEBUST=2026-06-30-fmt-fix2
+ARG PLUGIN_CACHEBUST=2026-07-30-direct-encode-storage
 RUN echo "plugin rebuild: ${PLUGIN_CACHEBUST}"
 
 COPY . /src

--- a/patches/README.md
+++ b/patches/README.md
@@ -6,6 +6,7 @@ Apply against a gstreamer monorepo checkout before building:
 ```
 git apply patches/vkh264enc-dpb-pool-in-new-sequence.patch
 git apply patches/vulkanh265enc.patch
+git apply patches/vulkan-image-create-flags-1.28.patch
 ```
 
 ## vkh264enc-dpb-pool-in-new-sequence.patch
@@ -35,6 +36,17 @@ the H.264 patch (independent files; no conflict).
 Status: compiles + links + loads clean on 1.28.4; HEVC bitstream design
 roundtable-approved. Pending hardware validation on AMD (RADV
 `RADV_PERFTEST=video_encode`) before any upstream MR.
+
+## vulkan-image-create-flags-1.28.patch
+
+Keeps Vulkan image-format capability validation aligned with the flags used to
+create an image from `GstVulkanImageMemoryCreateInfo`. This is required when
+the direct encode path requests `MUTABLE_FORMAT` and `EXTENDED_USAGE` for an
+image that is both storage-writable and `VIDEO_ENCODE_SRC`.
+
+The patch intentionally covers the 1.28 allocation-with-image-info path used
+by this plugin. It does not alter the legacy wrapped-image helper, which also
+uses zero flags on this GStreamer branch.
 
 (The Vulkan-encode path also needs the device to enable the external-memory
 extensions that `GstVulkanDevice` does not — `VK_KHR_external_memory_fd` etc. —

--- a/patches/vulkan-image-create-flags-1.28.patch
+++ b/patches/vulkan-image-create-flags-1.28.patch
@@ -1,0 +1,13 @@
+diff --git a/subprojects/gst-plugins-bad/gst-libs/gst/vulkan/gstvkimagememory.c b/subprojects/gst-plugins-bad/gst-libs/gst/vulkan/gstvkimagememory.c
+index 2a78935..5888d4b 100644
+--- a/subprojects/gst-plugins-bad/gst-libs/gst/vulkan/gstvkimagememory.c
++++ b/subprojects/gst-plugins-bad/gst-libs/gst/vulkan/gstvkimagememory.c
+@@ -191,5 +191,7 @@ _vk_image_mem_new_alloc_with_image_info (GstAllocator * allocator,
++  /* Validate the exact create contract. In particular EXTENDED_USAGE permits
++   * multiplanar images whose storage capability is exposed through plane views. */
+   err = vkGetPhysicalDeviceImageFormatProperties (gpu, image_info->format,
+-      VK_IMAGE_TYPE_2D, image_info->tiling, image_info->usage, 0,
++      VK_IMAGE_TYPE_2D, image_info->tiling, image_info->usage, image_info->flags,
+       &mem->format_properties);
+   if (gst_vulkan_error_to_g_error (err, &error,
+           "vkGetPhysicalDeviceImageFormatProperties") < 0)

--- a/wayland-display-core/src/utils/vulkan_nv12.rs
+++ b/wayland-display-core/src/utils/vulkan_nv12.rs
@@ -178,7 +178,7 @@ pub enum PixFmt {
 
 impl PixFmt {
     /// The multiplanar Vulkan format of the output/scratch image.
-    fn image_format(self) -> vk::Format {
+    pub(crate) fn image_format(self) -> vk::Format {
         match self {
             PixFmt::Nv12 => vk::Format::G8_B8R8_2PLANE_420_UNORM,
             PixFmt::P010 => vk::Format::G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16,
@@ -188,7 +188,7 @@ impl PixFmt {
     /// the plane is `R10X6_UNORM_PACK16`; we view it as `R16_UNORM` -- both are in Vulkan's
     /// 16-bit format-compatibility class, so the view is size/class-compatible -- and a
     /// normalized store lands across all 16 bits (the P010 reader takes the top 10).
-    fn y_view_format(self) -> vk::Format {
+    pub(crate) fn y_view_format(self) -> vk::Format {
         match self {
             PixFmt::Nv12 => vk::Format::R8_UNORM,
             PixFmt::P010 => vk::Format::R16_UNORM,
@@ -196,7 +196,7 @@ impl PixFmt {
     }
     /// Per-plane storage-view format for the interleaved Cb/Cr plane (`R10X6G10X6` <-> R16G16,
     /// 32-bit class, compatible).
-    fn uv_view_format(self) -> vk::Format {
+    pub(crate) fn uv_view_format(self) -> vk::Format {
         match self {
             PixFmt::Nv12 => vk::Format::R8G8_UNORM,
             PixFmt::P010 => vk::Format::R16G16_UNORM,
@@ -430,6 +430,7 @@ struct Nv12Out {
 pub struct VulkanNv12 {
     _entry: ash::Entry,
     instance: ash::Instance,
+    physical: vk::PhysicalDevice,
     device: ash::Device,
     queue: vk::Queue,
     cmd_pool: vk::CommandPool,
@@ -449,12 +450,8 @@ pub struct VulkanNv12 {
     sem_fd: Option<ash::khr::external_semaphore_fd::Device>,
     /// AMD/Intel: hand downstream a dmabuf write-fence and don't stall. Nvidia: block.
     implicit_sync: bool,
-    /// LINEAR direct path (compute writes the export image; no scratch/copy).
-    direct: bool,
-    /// Shared-device encode path: outputs are NV12 `GstVulkanImageMemory` from the encoder's
-    /// own pool (single multiplanar `VIDEO_ENCODE_SRC` images); compute writes a storage
-    /// scratch then copies into the pool image, which is left in `VIDEO_ENCODE_SRC` layout
-    /// for the encoder to view zero-copy. No dmabuf export, no implicit-sync fence.
+    /// Shared-device encode path: outputs are encoder-owned NV12/P010 images. Each record
+    /// either exposes storage plane views directly or retains a storage scratch fallback.
     encode_src: bool,
     /// Keeps the shared `GstVulkanDevice` alive for the converter's lifetime (the encode-src
     /// images are allocated on it).
@@ -670,13 +667,13 @@ impl VulkanNv12 {
             }
             Ok(outputs)
         };
-        let (outputs, direct) = match (want_direct, build(want_direct)) {
-            (_, Ok(o)) => (o, want_direct),
+        let outputs = match (want_direct, build(want_direct)) {
+            (_, Ok(o)) => o,
             (true, Err(e)) => {
                 tracing::warn!(
                     "VulkanNv12: LINEAR direct path unavailable ({e}); using scratch+copy"
                 );
-                (build(false)?, false)
+                build(false)?
             }
             (false, Err(e)) => return Err(e),
         };
@@ -698,6 +695,7 @@ impl VulkanNv12 {
         Ok(VulkanNv12 {
             _entry: entry,
             instance,
+            physical: pd,
             device,
             queue,
             cmd_pool,
@@ -711,7 +709,6 @@ impl VulkanNv12 {
             sync_sem,
             sem_fd,
             implicit_sync,
-            direct,
             encode_src: false,
             _shared_device: None,
             outputs,
@@ -725,10 +722,8 @@ impl VulkanNv12 {
 
     /// Shared-device encode path: wrap the downstream encoder's `GstVulkanDevice` and build
     /// an output ring of NV12 `GstVulkanImageMemory` buffers from its encode-src pool. The
-    /// compositor's RGBA dmabuf is imported + converted (compute -> storage scratch) and
-    /// `vkCmdCopyImage`'d into the pool's encode-src image, left in `VIDEO_ENCODE_SRC`
-    /// layout for `vulkanh264enc` to view zero-copy. Same device as the encoder, so ordering
-    /// is a plain fence wait (the encoder does its own input acquire).
+    /// compositor's RGBA dmabuf is converted directly into the encoder image when supported,
+    /// otherwise through the existing storage scratch and image-copy fallback.
     #[allow(clippy::too_many_arguments)]
     pub fn new_on_shared(
         device_gst: gstreamer_vulkan::VulkanDevice,
@@ -836,6 +831,9 @@ impl VulkanNv12 {
         let mut outputs = Vec::with_capacity(RING);
         for _ in 0..RING {
             outputs.push(create_encode_output(
+                &entry,
+                &instance,
+                raw.physical,
                 &device,
                 &memp,
                 &device_gst,
@@ -852,6 +850,7 @@ impl VulkanNv12 {
         Ok(VulkanNv12 {
             _entry: entry,
             instance,
+            physical: raw.physical,
             device,
             queue,
             cmd_pool,
@@ -865,7 +864,6 @@ impl VulkanNv12 {
             sync_sem: vk::Semaphore::null(),
             sem_fd: None,
             implicit_sync: false,
-            direct: false,
             encode_src: true,
             _shared_device: Some(device_gst),
             outputs,
@@ -943,7 +941,7 @@ impl VulkanNv12 {
         let desc_set = slot.desc_set;
         let cmd = slot.cmd;
         let fence = slot.fence;
-        let direct = self.direct;
+        let direct = slot.scratch.is_none();
         // Per-frame shader: the PQ-passthrough pipeline when this frame is already-PQ 10-bit
         // content and that pipeline exists, else the normal (tone-mapping / BT.601) pipeline.
         let pipeline = match (pq_passthrough, self.pipeline_pq) {
@@ -1034,14 +1032,18 @@ impl VulkanNv12 {
             .cmd_dispatch(cmd, (self.width / 2 + 7) / 8, (self.height / 2 + 7) / 8, 1);
 
         if direct {
-            // LINEAR direct: the compute output *is* the export image. Flush the shader
-            // writes so the dmabuf consumer sees them (ordering to the consumer is the
-            // implicit dma-buf write-fence / the CPU wait below).
+            // Direct path: the compute output is the consumer image. The encoder path must
+            // publish it in VIDEO_ENCODE_SRC rather than leaving it in GENERAL.
+            let final_layout = if self.encode_src {
+                vk::ImageLayout::from_raw(VK_IMAGE_LAYOUT_VIDEO_ENCODE_SRC_KHR)
+            } else {
+                vk::ImageLayout::GENERAL
+            };
             let f_y = img_barrier(
                 out_img,
                 vk::ImageAspectFlags::PLANE_0,
                 vk::ImageLayout::GENERAL,
-                vk::ImageLayout::GENERAL,
+                final_layout,
                 vk::AccessFlags::SHADER_WRITE,
                 vk::AccessFlags::empty(),
             );
@@ -1049,7 +1051,7 @@ impl VulkanNv12 {
                 out_img,
                 vk::ImageAspectFlags::PLANE_1,
                 vk::ImageLayout::GENERAL,
-                vk::ImageLayout::GENERAL,
+                final_layout,
                 vk::AccessFlags::SHADER_WRITE,
                 vk::AccessFlags::empty(),
             );
@@ -1898,12 +1900,13 @@ unsafe fn create_output(
     })
 }
 
-/// Build one encode-src ring slot: a buffer from the encoder's `GstVulkanImageBufferPool`
-/// (a single multiplanar NV12 `VIDEO_ENCODE_SRC` image), a LINEAR storage scratch the
-/// compute shader writes, and the per-slot cmd/fence/descriptor set. No dmabuf export --
-/// the pool owns the output image's memory.
+/// Build one encode-src record. A compatible encoder image receives storage writes directly;
+/// all other drivers retain the portable scratch-and-copy path.
 #[allow(clippy::too_many_arguments)]
 unsafe fn create_encode_output(
+    entry: &ash::Entry,
+    instance: &ash::Instance,
+    physical: vk::PhysicalDevice,
     device: &ash::Device,
     memp: &vk::PhysicalDeviceMemoryProperties,
     gst_device: &gstreamer_vulkan::VulkanDevice,
@@ -1915,32 +1918,56 @@ unsafe fn create_encode_output(
     height: u32,
     fmt: PixFmt,
 ) -> Result<Nv12Out, Err> {
-    let buffer = crate::utils::vulkan_share::alloc_encode_src_buffer(
-        gst_device, width, height, profile, fmt,
+    let allocation = crate::utils::vulkan_share::alloc_encode_src_buffer(
+        entry, instance, physical, gst_device, width, height, profile, fmt,
     )
     .ok_or("encode-src image allocation failed")?;
+    let buffer = allocation.buffer;
     let out_img = crate::utils::vulkan_share::recover_vk_image(&buffer)
         .ok_or("encode-src buffer is not a single GstVulkanImageMemory")?;
 
-    // LINEAR storage scratch (compute writes here; copied into the encode-src image).
-    let (s_img, s_mem, y_view, uv_view) = create_storage(
-        device,
-        memp,
-        width,
-        height,
-        vk::ImageUsageFlags::STORAGE | vk::ImageUsageFlags::TRANSFER_SRC,
-        false,
-        fmt,
-    )?;
+    let (scratch, y_view, uv_view) = if allocation.direct_storage {
+        (
+            None,
+            plane_view(
+                device,
+                out_img,
+                fmt.y_view_format(),
+                vk::ImageAspectFlags::PLANE_0,
+            )?,
+            plane_view(
+                device,
+                out_img,
+                fmt.uv_view_format(),
+                vk::ImageAspectFlags::PLANE_1,
+            )?,
+        )
+    } else {
+        let (scratch_image, scratch_memory, y_view, uv_view) = create_storage(
+            device,
+            memp,
+            width,
+            height,
+            vk::ImageUsageFlags::STORAGE | vk::ImageUsageFlags::TRANSFER_SRC,
+            false,
+            fmt,
+        )?;
+        (Some((scratch_image, scratch_memory)), y_view, uv_view)
+    };
 
     // Diagnostic for the RX 9070 green-bar/jump report: if the encoder's pool gives us an
     // encode-src image padded beyond width*height*3/2 (e.g. RDNA4 row-alignment), our copy
     // fills only `height` rows and the padding stays zeroed -> green at the bottom.
-    let tight_nv12 = width as u64 * height as u64 * 3 / 2;
+    let tight_nv12 = width as u64 * height as u64 * fmt.y_bytes() * 3 / 2;
+    let scratch_size = scratch
+        .map(|(image, _)| device.get_image_memory_requirements(image).size)
+        .unwrap_or(0);
     tracing::debug!(
-        "encode-src slot: req={width}x{height} NV12; out_img mem={} scratch mem={} tight={tight_nv12}",
+        "encode-src slot: req={width}x{height} {:?}; out_img mem={} scratch mem={} tight={tight_nv12} direct_storage={}",
+        fmt,
         device.get_image_memory_requirements(out_img).size,
-        device.get_image_memory_requirements(s_img).size,
+        scratch_size,
+        allocation.direct_storage,
     );
 
     let cmd = device.allocate_command_buffers(
@@ -1970,7 +1997,7 @@ unsafe fn create_encode_output(
         mem: vk::DeviceMemory::null(), // the pool owns the encode-src image memory
         buffer,
         export_fd: -1,
-        scratch: Some((s_img, s_mem)),
+        scratch,
         y_view,
         uv_view,
         cmd,

--- a/wayland-display-core/src/utils/vulkan_share.rs
+++ b/wayland-display-core/src/utils/vulkan_share.rs
@@ -36,6 +36,24 @@ use std::sync::{Mutex, OnceLock};
 const VK_IMAGE_USAGE_VIDEO_ENCODE_SRC_KHR: u32 = 0x0000_2000;
 const VK_IMAGE_LAYOUT_VIDEO_ENCODE_SRC_KHR: i32 = 1_000_299_001;
 
+fn encode_image_usage(direct_storage: bool) -> vk::ImageUsageFlags {
+    vk::ImageUsageFlags::TRANSFER_DST
+        | vk::ImageUsageFlags::from_raw(VK_IMAGE_USAGE_VIDEO_ENCODE_SRC_KHR)
+        | if direct_storage {
+            vk::ImageUsageFlags::STORAGE
+        } else {
+            vk::ImageUsageFlags::empty()
+        }
+}
+
+fn encode_image_flags(direct_storage: bool) -> vk::ImageCreateFlags {
+    if direct_storage {
+        vk::ImageCreateFlags::MUTABLE_FORMAT | vk::ImageCreateFlags::EXTENDED_USAGE
+    } else {
+        vk::ImageCreateFlags::empty()
+    }
+}
+
 // --- repr(C) overlays of the public gst-vulkan structs (fields the -sys crate omits). ---
 
 /// `struct _GstVulkanDevice { GstObject parent; GstVulkanInstance *instance;
@@ -395,19 +413,41 @@ pub fn encode_src_pool(
     }
 }
 
-/// Allocate ONE encode-src NV12 image as a `GstVulkanImageMemory`, built directly via
-/// `gst_vulkan_image_memory_alloc_with_image_info` so we control the `VkImageCreateInfo`
-/// (usage `TRANSFER_DST | VIDEO_ENCODE_SRC` + the H.264 `VkVideoProfileListInfoKHR` chained
-/// in). This bypasses `GstVulkanImageBufferPool`'s generic-format-feature check, which
-/// rejects NV12 on NVIDIA because the encode-input feature is only reported via the
-/// profile-specific query. Returns a `GstBuffer` holding the single image memory + VideoMeta.
-pub fn alloc_encode_src_buffer(
-    device: &VulkanDevice,
-    width: u32,
-    height: u32,
+pub struct EncodeSrcAllocation {
+    pub buffer: gst::Buffer,
+    pub direct_storage: bool,
+}
+
+fn plane_storage_supported(
+    instance: &ash::Instance,
+    physical: vk::PhysicalDevice,
+    format: vk::Format,
+    tiling: vk::ImageTiling,
+) -> bool {
+    let properties = unsafe { instance.get_physical_device_format_properties(physical, format) };
+    let features = match tiling {
+        vk::ImageTiling::LINEAR => properties.linear_tiling_features,
+        vk::ImageTiling::OPTIMAL => properties.optimal_tiling_features,
+        _ => return false,
+    };
+    features.contains(vk::FormatFeatureFlags::STORAGE_IMAGE)
+}
+
+/// Ask Vulkan whether an encode-profile-compatible image may also expose storage views.
+unsafe fn direct_encode_storage_supported(
+    entry: &ash::Entry,
+    instance: &ash::Instance,
+    physical: vk::PhysicalDevice,
     profile: &str,
     fmt: PixFmt,
-) -> Option<gst::Buffer> {
+    tiling: vk::ImageTiling,
+) -> bool {
+    if !plane_storage_supported(instance, physical, fmt.y_view_format(), tiling)
+        || !plane_storage_supported(instance, physical, fmt.uv_view_format(), tiling)
+    {
+        return false;
+    }
+
     let std_h264_idc = match profile {
         "high" | "constrained-high" | "progressive-high" => {
             vk::native::StdVideoH264ProfileIdc_STD_VIDEO_H264_PROFILE_IDC_HIGH
@@ -415,32 +455,92 @@ pub fn alloc_encode_src_buffer(
         "main" => vk::native::StdVideoH264ProfileIdc_STD_VIDEO_H264_PROFILE_IDC_MAIN,
         _ => vk::native::StdVideoH264ProfileIdc_STD_VIDEO_H264_PROFILE_IDC_BASELINE,
     };
-    unsafe {
-        // Profile chain (matches what the encoder's pool builds from caps): the codec struct
-        // chained off the VkVideoProfileInfoKHR; usage info omitted. P010 -> H.265 Main-10
-        // 10-bit (for vulkanh265enc); NV12 -> H.264 8-bit (the default Vulkan-encode path).
-        let mut h264 = vk::VideoEncodeH264ProfileInfoKHR::default().std_profile_idc(std_h264_idc);
-        let mut h265 = vk::VideoEncodeH265ProfileInfoKHR::default()
-            .std_profile_idc(vk::native::StdVideoH265ProfileIdc_STD_VIDEO_H265_PROFILE_IDC_MAIN_10);
-        let bit_depth = match fmt {
-            PixFmt::P010 => vk::VideoComponentBitDepthFlagsKHR::TYPE_10,
-            PixFmt::Nv12 => vk::VideoComponentBitDepthFlagsKHR::TYPE_8,
-        };
-        let mut profile_info = vk::VideoProfileInfoKHR::default()
-            .chroma_subsampling(vk::VideoChromaSubsamplingFlagsKHR::TYPE_420)
-            .luma_bit_depth(bit_depth)
-            .chroma_bit_depth(bit_depth);
-        profile_info = match fmt {
-            PixFmt::P010 => profile_info
-                .video_codec_operation(vk::VideoCodecOperationFlagsKHR::ENCODE_H265)
-                .push_next(&mut h265),
-            PixFmt::Nv12 => profile_info
-                .video_codec_operation(vk::VideoCodecOperationFlagsKHR::ENCODE_H264)
-                .push_next(&mut h264),
-        };
-        let profiles = [profile_info];
-        let mut profile_list = vk::VideoProfileListInfoKHR::default().profiles(&profiles);
+    let mut h264 = vk::VideoEncodeH264ProfileInfoKHR::default().std_profile_idc(std_h264_idc);
+    let mut h265 = vk::VideoEncodeH265ProfileInfoKHR::default()
+        .std_profile_idc(vk::native::StdVideoH265ProfileIdc_STD_VIDEO_H265_PROFILE_IDC_MAIN_10);
+    let bit_depth = match fmt {
+        PixFmt::P010 => vk::VideoComponentBitDepthFlagsKHR::TYPE_10,
+        PixFmt::Nv12 => vk::VideoComponentBitDepthFlagsKHR::TYPE_8,
+    };
+    let mut profile_info = vk::VideoProfileInfoKHR::default()
+        .chroma_subsampling(vk::VideoChromaSubsamplingFlagsKHR::TYPE_420)
+        .luma_bit_depth(bit_depth)
+        .chroma_bit_depth(bit_depth);
+    profile_info = match fmt {
+        PixFmt::P010 => profile_info
+            .video_codec_operation(vk::VideoCodecOperationFlagsKHR::ENCODE_H265)
+            .push_next(&mut h265),
+        PixFmt::Nv12 => profile_info
+            .video_codec_operation(vk::VideoCodecOperationFlagsKHR::ENCODE_H264)
+            .push_next(&mut h264),
+    };
+    let profiles = [profile_info];
+    let mut profile_list = vk::VideoProfileListInfoKHR::default().profiles(&profiles);
+    let requested_usage = encode_image_usage(true);
+    let video_queue = ash::khr::video_queue::Instance::new(entry, instance);
+    let video_info = vk::PhysicalDeviceVideoFormatInfoKHR::default()
+        .image_usage(requested_usage)
+        .push_next(&mut profile_list);
+    let mut count = 0;
+    let query = video_queue
+        .fp()
+        .get_physical_device_video_format_properties_khr;
+    let first = query(physical, &video_info, &mut count, std::ptr::null_mut());
+    if first != vk::Result::SUCCESS || count == 0 {
+        return false;
+    }
+    let mut video_formats = vec![vk::VideoFormatPropertiesKHR::default(); count as usize];
+    let second = query(
+        physical,
+        &video_info,
+        &mut count,
+        video_formats.as_mut_ptr(),
+    );
+    if second != vk::Result::SUCCESS {
+        return false;
+    }
+    if !video_formats[..count as usize].iter().any(|properties| {
+        properties.format == fmt.image_format()
+            && properties.image_tiling == tiling
+            && properties.image_type == vk::ImageType::TYPE_2D
+            && properties.image_usage_flags.contains(requested_usage)
+    }) {
+        return false;
+    }
 
+    let view_formats = [
+        fmt.image_format(),
+        fmt.y_view_format(),
+        fmt.uv_view_format(),
+    ];
+    let mut format_list = vk::ImageFormatListCreateInfo::default().view_formats(&view_formats);
+    let info = vk::PhysicalDeviceImageFormatInfo2::default()
+        .format(fmt.image_format())
+        .ty(vk::ImageType::TYPE_2D)
+        .tiling(tiling)
+        .usage(requested_usage)
+        .flags(encode_image_flags(true))
+        .push_next(&mut profile_list)
+        .push_next(&mut format_list);
+    let mut properties = vk::ImageFormatProperties2::default();
+    instance
+        .get_physical_device_image_format_properties2(physical, &info, &mut properties)
+        .is_ok()
+}
+
+/// Allocate an encode-src image directly on the encoder device. Unsupported storage/video
+/// combinations retain the existing scratch-and-copy allocation contract.
+pub fn alloc_encode_src_buffer(
+    entry: &ash::Entry,
+    instance: &ash::Instance,
+    physical: vk::PhysicalDevice,
+    device: &VulkanDevice,
+    width: u32,
+    height: u32,
+    profile: &str,
+    fmt: PixFmt,
+) -> Option<EncodeSrcAllocation> {
+    unsafe {
         // RX 9070 / GFX12 (RDNA4) workaround: radv mishandles a LINEAR->tiled (different
         // swizzle mode) vkCmdCopyImage on GFX12 (cf. Mesa 26.0.2 "radv: fix copying images
         // with different swizzle modes on SDMA7"), corrupting the encoder's tiled NV12 input
@@ -464,30 +564,74 @@ pub fn alloc_encode_src_buffer(
             PixFmt::Nv12 => vk::Format::G8_B8R8_2PLANE_420_UNORM,
             PixFmt::P010 => vk::Format::G10X6_B10X6R10X6_2PLANE_420_UNORM_3PACK16,
         };
-        let image_info = vk::ImageCreateInfo::default()
-            .image_type(vk::ImageType::TYPE_2D)
-            .format(image_format)
-            .extent(vk::Extent3D {
-                width,
-                height,
-                depth: 1,
-            })
-            .mip_levels(1)
-            .array_layers(1)
-            .samples(vk::SampleCountFlags::TYPE_1)
-            .tiling(tiling)
-            .usage(
-                vk::ImageUsageFlags::TRANSFER_DST
-                    | vk::ImageUsageFlags::from_raw(VK_IMAGE_USAGE_VIDEO_ENCODE_SRC_KHR),
+        let requested_direct =
+            direct_encode_storage_supported(entry, instance, physical, profile, fmt, tiling);
+        let allocate = |direct_storage: bool| {
+            let mut h264 =
+                vk::VideoEncodeH264ProfileInfoKHR::default().std_profile_idc(std_h264_idc);
+            let mut h265 = vk::VideoEncodeH265ProfileInfoKHR::default().std_profile_idc(
+                vk::native::StdVideoH265ProfileIdc_STD_VIDEO_H265_PROFILE_IDC_MAIN_10,
+            );
+            let bit_depth = match fmt {
+                PixFmt::P010 => vk::VideoComponentBitDepthFlagsKHR::TYPE_10,
+                PixFmt::Nv12 => vk::VideoComponentBitDepthFlagsKHR::TYPE_8,
+            };
+            let mut profile_info = vk::VideoProfileInfoKHR::default()
+                .chroma_subsampling(vk::VideoChromaSubsamplingFlagsKHR::TYPE_420)
+                .luma_bit_depth(bit_depth)
+                .chroma_bit_depth(bit_depth);
+            profile_info = match fmt {
+                PixFmt::P010 => profile_info
+                    .video_codec_operation(vk::VideoCodecOperationFlagsKHR::ENCODE_H265)
+                    .push_next(&mut h265),
+                PixFmt::Nv12 => profile_info
+                    .video_codec_operation(vk::VideoCodecOperationFlagsKHR::ENCODE_H264)
+                    .push_next(&mut h264),
+            };
+            let profiles = [profile_info];
+            let mut profile_list = vk::VideoProfileListInfoKHR::default().profiles(&profiles);
+            let view_formats = [
+                fmt.image_format(),
+                fmt.y_view_format(),
+                fmt.uv_view_format(),
+            ];
+            let mut format_list =
+                vk::ImageFormatListCreateInfo::default().view_formats(&view_formats);
+            let mut image_info = vk::ImageCreateInfo::default()
+                .image_type(vk::ImageType::TYPE_2D)
+                .format(image_format)
+                .extent(vk::Extent3D {
+                    width,
+                    height,
+                    depth: 1,
+                })
+                .mip_levels(1)
+                .array_layers(1)
+                .samples(vk::SampleCountFlags::TYPE_1)
+                .tiling(tiling)
+                .usage(encode_image_usage(direct_storage))
+                .initial_layout(vk::ImageLayout::UNDEFINED)
+                .push_next(&mut profile_list);
+            if direct_storage {
+                image_info = image_info
+                    .flags(encode_image_flags(true))
+                    .push_next(&mut format_list);
+            }
+            gstvk::gst_vulkan_image_memory_alloc_with_image_info(
+                device.to_glib_none().0,
+                &image_info as *const vk::ImageCreateInfo as *mut _,
+                vk::MemoryPropertyFlags::DEVICE_LOCAL,
             )
-            .initial_layout(vk::ImageLayout::UNDEFINED)
-            .push_next(&mut profile_list);
-
-        let mem_ptr = gstvk::gst_vulkan_image_memory_alloc_with_image_info(
-            device.to_glib_none().0,
-            &image_info as *const vk::ImageCreateInfo as *mut _,
-            vk::MemoryPropertyFlags::DEVICE_LOCAL,
-        );
+        };
+        let mut direct_storage = requested_direct;
+        let mut mem_ptr = allocate(direct_storage);
+        if mem_ptr.is_null() && direct_storage {
+            tracing::warn!(
+                "vulkan_share: direct encode storage allocation was rejected; using scratch+copy"
+            );
+            direct_storage = false;
+            mem_ptr = allocate(false);
+        }
         if mem_ptr.is_null() {
             tracing::warn!("vulkan_share: gst_vulkan_image_memory_alloc_with_image_info failed");
             return None;
@@ -546,7 +690,33 @@ pub fn alloc_encode_src_buffer(
                 height,
             );
         }
-        Some(buffer)
+        Some(EncodeSrcAllocation {
+            buffer,
+            direct_storage,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn direct_encode_images_request_storage_and_video_encode_usage() {
+        let usage = encode_image_usage(true);
+        assert!(usage.contains(vk::ImageUsageFlags::STORAGE));
+        assert!(usage.contains(vk::ImageUsageFlags::TRANSFER_DST));
+        assert!(usage.contains(vk::ImageUsageFlags::from_raw(
+            VK_IMAGE_USAGE_VIDEO_ENCODE_SRC_KHR
+        )));
+        assert!(encode_image_flags(true).contains(vk::ImageCreateFlags::MUTABLE_FORMAT));
+        assert!(encode_image_flags(true).contains(vk::ImageCreateFlags::EXTENDED_USAGE));
+    }
+
+    #[test]
+    fn portable_encode_images_do_not_claim_storage_views() {
+        assert!(!encode_image_usage(false).contains(vk::ImageUsageFlags::STORAGE));
+        assert!(encode_image_flags(false).is_empty());
     }
 }
 


### PR DESCRIPTION
## Summary
The shared Vulkan encoder path can now write NV12 directly into a compatible encode image, eliminating the scratch image and copy on drivers that support the required storage and video-encode combination.

## Why This Exists
The shared encoder image was already created with `VIDEO_ENCODE_SRC`, but compute conversion still wrote to a separate storage image and copied the result into that encoder image. This added an allocation, synchronization, and full-frame transfer to every compatible frame.

## Resolution
Probe `STORAGE | VIDEO_ENCODE_SRC` support with the active video profile, image-format list, tiling, and creation flags. When supported, allocate the encoder image with storage usage and create plane views directly on it. When unsupported or allocation fails, retain the existing scratch-image-and-copy path.

## Reviewer Considerations
- The direct capability probe deliberately includes the same video profile, format list, usage, and create flags as allocation so it does not assume storage support from the video-encode capability alone.
- The bundled GStreamer 1.28.4 patch is required because its allocator validated image format properties with zero flags even when the actual image used non-zero flags. It covers only the allocation-with-image-info path used here; the legacy wrapped-image helper remains unchanged.
- Hardware coverage is important: drivers may reject the requested flag/usage/profile combination, in which case the code must stay on the existing fallback path.

## Behavior Changes
- Supported Vulkan video-encode configurations convert directly into the encode source image.
- Unsupported configurations and allocation failures keep the portable scratch-and-copy behavior.

## Implementation Summary
- Add a GStreamer 1.28.4 allocator backport that preserves image creation flags during format validation.
- Query and allocate direct storage-capable encode images with `MUTABLE_FORMAT` and `EXTENDED_USAGE`.
- Use plane storage views of the encode image for direct conversion, with the existing scratch image retained as fallback.
- Add static usage/flag tests, document the GStreamer patch, and force a fresh Docker plugin build.

## Verification
- `cargo fmt --check` — passed.
- `git diff --check origin/feat/vulkan-encode...HEAD` — passed.
- `cargo test -p wayland-display-core direct_encode --lib` — blocked before compilation in this macOS checkout because `wayland-server.pc` is unavailable; the container image runs `cargo test --release -p wayland-display-core direct_encode`.

## Risk
Moderate, hardware-specific: a driver can decline the combined image capabilities. The capability probe and allocation-failure fallback preserve the prior scratch-and-copy path; NVIDIA and RADV encode smoke tests are still needed.
