### PR TITLE
fix(cuda): stop clearing a pool the query still owns

### DIFF
--- a/gst-plugin-wayland-display/src/waylandsrc/imp.rs
+++ b/gst-plugin-wayland-display/src/waylandsrc/imp.rs
@@ -657,7 +657,9 @@ impl BaseSrcImpl for WaylandDisplaySrc {
                             "Failed to get CUDA buffer pool from allocation pool: {}",
                             err
                         );
-                        unsafe { gst::ffi::gst_clear_object(pool.as_ptr() as *mut _) };
+                        // Nothing to release here. `query.allocation_pools()` parses with
+                        // `gst_query_parse_nth_allocation_pool`, which is (transfer full), so
+                        // `pools` owns this `BufferPool` and drops it at the end of the scope.
                         CUDABufferPool::new(&cuda_ctx)
                     }
                 },


### PR DESCRIPTION
`decide_allocation()` released a downstream pool it does not own, through a call whose type is wrong in a way the compiler cannot see:

    gst_clear_object(pool.as_ptr() as *mut _)

`gst_clear_object` takes a `GstObject **`. `pool.as_ptr()` is a `GstBufferPool *`. The `as *mut _` lets inference supply `*mut *mut GstObject` from the parameter type, so the cast is legal and it compiles without a warning. At runtime the call dereferences one level too far and treats the pool's first field, `GTypeInstance.g_class`, as the pointer to clear.

Measured on GStreamer 1.26.2 against a plain `gst_buffer_pool_new()` with the same cast:

  - `g_object_unref: assertion 'G_IS_OBJECT (object)' failed`, as the call tries to unref the class vtable. GLib's check refuses it, so the vtable itself survives.
  - The pool's class pointer is then overwritten with NULL.
  - Every later call on the pool fails its type check: `gst_buffer_pool_set_active: assertion 'GST_IS_BUFFER_POOL (pool)' failed`.
  - The owner's own unref fails the same assertion, so the pool can never be freed.

That is the outcome with GLib checks compiled in, which is the Debian and Ubuntu default. Under `G_DISABLE_CHECKS` the first unref is not refused and the class vtable's refcount is decremented instead. I have not built that configuration.

The release was never needed, which is the part worth keeping. `query.allocation_pools()` parses with `gst_query_parse_nth_allocation_pool`, which is (transfer full), so the returned `Vec` owns the `BufferPool` and drops it at the end of the scope. Deleting the line is the whole fix.

Reachable only when the CUDA path is live and downstream offers a pool that is not a CUDA buffer pool, so it has stayed quiet.

The same line is on feat/vulkan-encode at imp.rs:1100 and needs the same removal there.