### PR TITLE
fix(egl): drop the vestigial wl_display bind and its misleading log

### DIFF
--- a/wayland-display-core/src/comp/mod.rs
+++ b/wayland-display-core/src/comp/mod.rs
@@ -4,7 +4,6 @@ use smithay::backend::SwapBuffersError;
 use smithay::backend::allocator::format::FormatSet;
 use smithay::backend::input::AxisSource;
 use smithay::backend::input::TouchSlot;
-use smithay::backend::renderer::ImportEgl;
 use smithay::backend::renderer::gles::GlesRenderer;
 use smithay::reexports::gbm::BufferObjectFlags;
 use smithay::wayland::dmabuf::DmabufFeedbackBuilder;
@@ -295,7 +294,9 @@ impl State {
 
         let render_node: Option<DrmNode> = render_target.clone().into();
 
-        let mut renderer = setup_renderer(render_node);
+        // No `mut`: with the `bind_wl_display` call gone, nothing in this scope takes
+        // `renderer` mutably before it moves into `State`.
+        let renderer = setup_renderer(render_node);
 
         let shm_state = ShmState::new::<State>(&dh, vec![]);
         let dmabuf_global = if let RenderTarget::Hardware(node) = render_target {
@@ -322,10 +323,16 @@ impl State {
                 dmabuf_state.create_global::<State>(&dh, formats.clone())
             };
 
-            match renderer.bind_wl_display(&dh) {
-                Ok(_) => tracing::info!("EGL hardware-acceleration enabled"),
-                Err(err) => tracing::info!(?err, "Failed to initialize EGL hardware-acceleration"),
-            }
+            // No `bind_wl_display` here. Its only product is the `EGLBufferReader` behind
+            // `BufferType::Egl`, and nothing in this compositor can produce such a buffer:
+            // every buffer-carrying global we advertise resolves earlier in smithay's
+            // `buffer_type()` dispatch. `ShmState` gives `Shm`, `DmabufState` gives `Dma`,
+            // `SinglePixelBufferState` gives `SinglePixel`, and our own `wl_drm` below hands
+            // the `WlBuffer` a `Dmabuf` as user data, so it resolves as `Dma` too. The bind
+            // therefore enabled an import path with no possible client, while logging
+            // "Failed to initialize EGL hardware-acceleration" on every start where the
+            // extension is missing -- which reads as a fallback to software rendering that
+            // never happened.
 
             // wl_drm (mesa protocol, so we don't need EGL_WL_bind_display)
             let wl_drm_global = create_drm_global::<State>(


### PR DESCRIPTION
`bind_wl_display`'s only product is the `EGLBufferReader` behind `BufferType::Egl`, and nothing reads it. `EGLBufferReader` and `import_egl_buffer` appear nowhere in the crate; the only client-buffer import routes are `import_dmabuf` at `handlers/dmabuf.rs:20` and `handlers/wl_drm.rs:18`.

No client can reach that path either. smithay's `buffer_type()` resolves `Dma`, `Shm` and `SinglePixel` before `Egl`, and every buffer-carrying global this compositor advertises lands in one of the first three. Its own `wl_drm` initialises the `WlBuffer` with a `Dmabuf` as user data, so mesa's wl_drm buffers resolve as `Dma`, which is why the comment below already notes wl_drm does not need the bind. That is a reading of the dispatch order rather than an observation of a client: `tests/fixture.rs:38` runs `RenderTarget::Software`, so no test reaches this branch at all.

The bind therefore enabled an import path with no possible client, and its only observable effect was the log. On render nodes lacking `EGL_WL_bind_wayland_display` it printed "Failed to initialize EGL hardware-acceleration" on every start, reading as a fallback to software rendering that never happened. The success arm claimed acceleration had been enabled by a call that enables nothing used. Removing both removes the confusion at its source instead of rewording it.

Dropping the call also makes the `mut` on `renderer` redundant, since nothing else in that scope takes it mutably before it moves into `State`.