### PR TITLE
ci(vulkan-image): pin cargo-c so it stops drifting past the pinned to…

### DIFF
--- a/docker/vulkan.Dockerfile
+++ b/docker/vulkan.Dockerfile
@@ -110,9 +110,16 @@ RUN git clone --depth 1 https://github.com/games-on-whales/gst-interpipe.git /tm
 
 # --- Rust toolchain (gstreamer-rs 0.25 + cargo-c need >= 1.94) + the plugin ---
 ENV CARGO_HOME=/root/.cargo RUSTUP_HOME=/root/.rustup
+# cargo-c is pinned because it is installed from crates.io at build time, so an
+# unpinned `cargo install` picks up whatever is newest and drifts away from the
+# toolchain pinned above. cargo-c 0.10.24 raised its MSRV to rustc 1.95 and broke
+# this layer against RUST_VERSION=1.94.0; 0.10.23 is the last release supporting
+# 1.94. `--locked` uses cargo-c's own Cargo.lock so a transitive dependency
+# raising ITS MSRV cannot break the build again without a deliberate bump here.
+# Raise both this pin and RUST_VERSION together.
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
       sh -s -- -y --default-toolchain ${RUST_VERSION} --profile minimal && \
-    cargo install cargo-c
+    cargo install cargo-c --version 0.10.23 --locked
 
 # Cache-bust the plugin source COPY + compile. The registry build cache (cache-from/
 # cache-to mode=max) can serve a STALE `cargo cinstall` layer even when src/ changed,


### PR DESCRIPTION
…olchain

`cargo install cargo-c` was unpinned while the toolchain beside it is pinned to `RUST_VERSION=1.94.0`, so the layer resolved whatever crates.io served that day. cargo-c 0.10.24 raised its MSRV to rustc 1.95, which turns that layer into a hard failure:

    error: cannot install package `cargo-c 0.10.24+cargo-0.98.0`, it requires
    rustc 1.95 or newer, while the currently active rustc version is 1.94.0

Pushes to feat/vulkan-encode kept passing because they authenticate to GHCR and reuse the cached layer. Pull-request builds skip the GHCR login, so they rebuild it from scratch and hit the wall. That is why the :vulkan job fails only on PRs, and it has now taken out #51, #52 and #55.

Reproduced and fixed on rustc 1.94.0: the unpinned command exits 101 with the error above, and `--version 0.10.23 --locked` exits 0 and installs cargo-cinstall, which is the binary this image actually uses.

`--locked` matters as much as the version: without it a transitive dependency raising its own MSRV breaks the build again even with cargo-c pinned.