### PR TITLE
fix(compositor): close the seat keymap memfd at session teardown

### DIFF
--- a/wayland-display-core/src/comp/mod.rs
+++ b/wayland-display-core/src/comp/mod.rs
@@ -45,7 +45,10 @@ use smithay::{
             backend::{ClientData, ClientId, DisconnectReason, GlobalId},
         },
     },
-    utils::{Clock, DeviceFd, Logical, Monotonic, Physical, Point, Rectangle, Size, Transform},
+    utils::{
+        Clock, DeviceFd, Logical, Monotonic, Physical, Point, Rectangle, SERIAL_COUNTER, Size,
+        Transform,
+    },
     wayland::{
         compositor::{CompositorClientState, CompositorState, with_states},
         dmabuf::{DmabufGlobal, DmabufState},
@@ -299,6 +302,39 @@ impl State {
             viewporter_state,
             single_pixel_buffer_state,
         }
+    }
+
+    /// Release the seat's keyboard before the compositor state is dropped.
+    ///
+    /// smithay mints one sealed `memfd:smithay-keymap` per [`Seat::add_keyboard`]
+    /// (`KeymapFile::new`) and keeps it in the `Arc<KbdRc>` behind the seat's
+    /// `KeyboardHandle`. Dropping `State` is NOT guaranteed to close it, because the
+    /// keyboard's *own* grab slot lives inside that same `KbdRc`
+    /// (`input/keyboard/mod.rs`: `KbdInternal::grab`) while every grab smithay hands us
+    /// carries a clone of the handle it is installed on -- `PopupKeyboardGrab` wraps a
+    /// `PopupGrab`, whose `keyboard_handle` field is exactly that clone
+    /// (`desktop/wayland/popup/grab.rs`), and one is installed for every `xdg_popup.grab`
+    /// (`wayland/handlers/xdg.rs`). A grab still active when the session ends is therefore
+    /// an `Arc` pointing at itself: no drop of ours can reach it, and the keymap memfd
+    /// stays open for the lifetime of the *process*, not the session.
+    ///
+    /// So end the session by hand instead of relying on the object graph unwinding: unset
+    /// any surviving grab (this is what breaks the cycle), clear focus, and drop the seat's
+    /// own handle. Whatever the client left behind, the fd is closed here.
+    ///
+    /// Upstream candidate for smithay itself: unset the grab when the last non-grab
+    /// reference to a `KeyboardHandle` goes away, or hold the grab's handle weakly.
+    pub(crate) fn release_seat(&mut self) {
+        let Some(keyboard) = self.seat.get_keyboard() else {
+            return;
+        };
+        if keyboard.is_grabbed() {
+            tracing::debug!("Unsetting a keyboard grab still active at shutdown.");
+            keyboard.unset_grab(self);
+        }
+        keyboard.set_focus(self, None, SERIAL_COUNTER.next_serial());
+        drop(keyboard);
+        self.seat.remove_keyboard();
     }
 }
 
@@ -784,4 +820,9 @@ pub(crate) fn init(
     }) {
         tracing::error!(?err, "Event loop broke.");
     }
+
+    // Close the seat's keymap memfd before `state` drops. A grab left active by the client
+    // makes the keyboard's Arc self-referential, so dropping `state` alone leaks one
+    // `memfd:smithay-keymap` per session -- see [`State::release_seat`].
+    state.release_seat();
 }

--- a/wayland-display-core/src/tests/mod.rs
+++ b/wayland-display-core/src/tests/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod client;
 mod device;
 mod fixture;
+mod test_keymap_fd;
 mod test_pointer;
 mod test_resolution;

--- a/wayland-display-core/src/tests/test_keymap_fd.rs
+++ b/wayland-display-core/src/tests/test_keymap_fd.rs
@@ -1,0 +1,162 @@
+//! Regression guard for the per-session `memfd:smithay-keymap` fd leak.
+//!
+//! smithay mints one sealed memfd named `smithay-keymap` per `Seat::add_keyboard`
+//! (`KeymapFile::new`), i.e. one per compositor instance, and keeps it in the
+//! `Arc<KbdRc>` behind the seat's `KeyboardHandle`. A grab that is still installed
+//! when the session ends lives *inside* that same `KbdRc` while holding a clone of
+//! the handle, so the `Arc` references itself and dropping the compositor cannot
+//! close the fd. [`State::release_seat`] unsets the grab at shutdown; these tests
+//! pin both halves: a plain teardown stays clean, and a teardown with a grab still
+//! active stays clean too.
+
+use crate::comp::{FocusTarget, State};
+use crate::tests::fixture::Fixture;
+use smithay::backend::input::{KeyState, Keycode};
+use smithay::input::keyboard::{
+    GrabStartData, KeyboardGrab, KeyboardHandle, KeyboardInnerHandle, ModifiersState,
+};
+use smithay::utils::{SERIAL_COUNTER, Serial};
+use test_log::test;
+
+/// Open fds in this process whose target names the smithay keymap memfd.
+fn keymap_fd_count() -> usize {
+    let Ok(entries) = std::fs::read_dir("/proc/self/fd") else {
+        // Not Linux / no procfs: the count is meaningless, keep it at 0 so the
+        // assertions below trivially hold.
+        return 0;
+    };
+    entries
+        .flatten()
+        .filter(|entry| {
+            std::fs::read_link(entry.path())
+                .map(|target| target.to_string_lossy().contains("smithay-keymap"))
+                .unwrap_or(false)
+        })
+        .count()
+}
+
+/// One compositor lifecycle, round-tripped far enough that the client has bound a
+/// `wl_keyboard`, a window is mapped, and the keyboard has focus and key history.
+fn cycle() -> Fixture {
+    let mut f = Fixture::new();
+    f.round_trip();
+    f.create_window(320, 240);
+    f.round_trip();
+    let keycode = f.server.scancode_to_keycode(30);
+    f.server.keyboard_input(0, keycode, KeyState::Pressed);
+    f.round_trip();
+    f.server.keyboard_input(10, keycode, KeyState::Released);
+    f.round_trip();
+    f
+}
+
+/// A grab with the retaining shape of smithay's `PopupKeyboardGrab`: it holds a
+/// clone of the `KeyboardHandle` whose internal state stores the grab
+/// (`PopupGrab::keyboard_handle`). Installing one and never unsetting it is what a
+/// client leaves behind when it dies with a popup grab open.
+struct StaleGrab {
+    _handle: KeyboardHandle<State>,
+    start_data: GrabStartData<State>,
+}
+
+impl KeyboardGrab<State> for StaleGrab {
+    fn input(
+        &mut self,
+        data: &mut State,
+        handle: &mut KeyboardInnerHandle<'_, State>,
+        keycode: Keycode,
+        state: KeyState,
+        modifiers: Option<ModifiersState>,
+        serial: Serial,
+        time: u32,
+    ) {
+        handle.input(data, keycode, state, modifiers, serial, time);
+    }
+
+    fn set_focus(
+        &mut self,
+        data: &mut State,
+        handle: &mut KeyboardInnerHandle<'_, State>,
+        focus: Option<FocusTarget>,
+        serial: Serial,
+    ) {
+        handle.set_focus(data, focus, serial);
+    }
+
+    fn start_data(&self) -> &GrabStartData<State> {
+        &self.start_data
+    }
+
+    fn unset(&mut self, _data: &mut State) {}
+}
+
+/// Growth tolerance: other tests in this binary may hold a fixture (and so a
+/// keymap) alive while this one samples. It is well under `CYCLES`, which is what
+/// the one-per-session leak produces.
+const TOLERANCE: usize = 2;
+const CYCLES: usize = 8;
+
+/// `keymap_fd_count` reads a PROCESS-global number while cargo runs the rest of this
+/// binary's tests in parallel threads, each holding its own fixture (and so its own
+/// keymap fd) for the duration. A single sample can therefore read another test's
+/// fixtures as growth. Re-sample a few times and keep the lowest reading: the leak
+/// under test is permanent, so it survives every sample, while a neighbouring
+/// fixture's fd disappears as soon as that test finishes.
+fn settled_keymap_fd_count() -> usize {
+    let mut lowest = keymap_fd_count();
+    for _ in 0..5 {
+        std::thread::sleep(std::time::Duration::from_millis(100));
+        lowest = lowest.min(keymap_fd_count());
+    }
+    lowest
+}
+
+#[test]
+fn keymap_memfd_is_released_on_compositor_teardown() {
+    // Warm-up cycle: the first compositor pulls in process-lifetime singletons
+    // (GStreamer, the EGL display cache) whose fds must not count as growth.
+    drop(cycle());
+
+    let baseline = keymap_fd_count();
+    for _ in 0..CYCLES {
+        let mut f = cycle();
+        f.server.release_seat();
+        drop(f);
+    }
+    let after = settled_keymap_fd_count();
+
+    assert!(
+        after <= baseline + TOLERANCE,
+        "smithay-keymap memfds grew across {CYCLES} compositor teardowns: \
+         {baseline} -> {after}"
+    );
+}
+
+#[test]
+fn keymap_memfd_is_released_when_a_grab_is_still_active() {
+    drop(cycle());
+
+    let baseline = keymap_fd_count();
+    for _ in 0..CYCLES {
+        let mut f = cycle();
+        let keyboard = f.server.seat.get_keyboard().unwrap();
+        let grab = StaleGrab {
+            _handle: keyboard.clone(),
+            start_data: GrabStartData { focus: None },
+        };
+        keyboard.set_grab(&mut f.server, grab, SERIAL_COUNTER.next_serial());
+        drop(keyboard);
+
+        // The session ends with the grab still installed -- without
+        // `release_seat` this is the self-referential Arc that leaks the keymap.
+        f.server.release_seat();
+        drop(f);
+    }
+    let after = settled_keymap_fd_count();
+
+    assert!(
+        after <= baseline + TOLERANCE,
+        "smithay-keymap memfds grew across {CYCLES} teardowns with an active grab: \
+         {baseline} -> {after}"
+    );
+}


### PR DESCRIPTION
## Problem

smithay mints one sealed `memfd:smithay-keymap` per `Seat::add_keyboard` and keeps it in the `Arc<KbdRc>` behind the seat's `KeyboardHandle`. Dropping `State` closes it only when no grab is left installed.

The cycle:

- The keyboard's own grab slot lives inside that same `KbdRc` (`input/keyboard/mod.rs`, `KbdInternal::grab`).
- Every grab smithay hands out carries a clone of the handle it is installed on. `PopupKeyboardGrab` wraps a `PopupGrab` whose `keyboard_handle` is exactly that clone.
- We install one for every `xdg_popup.grab` (`wayland/handlers/xdg.rs`).

So a grab still active when the session ends is an `Arc` pointing at itself, and the fd stays open for the life of the process. The escape hatches do not save it: the stale-grab discard in `with_grab` and `PopupKeyboardGrab`'s `has_ended()` unset both run on the *next* grab access, which never comes once the session is over.

Measured on a workload whose clients routinely end a session with a popup grab open: 136 back-to-back sessions, exactly one leaked fd each, slope 1.00/cycle with no plateau. Everything else the compositor owns was released on schedule, including the sibling `smithay-dmabuffeedback-format-table` memfd in the same `Display`, which is what rules out a leaked `State` or `Display`. At ~50 sessions a day a host crosses the 1024 fd soft limit in under a month and new sessions fail with `EMFILE`.

## Fix

`State::release_seat`, called once the event loop stops: unset any surviving grab (this is what breaks the cycle), clear keyboard focus, drop the seat's handle. The fd closes deterministically rather than depending on the client having torn its popups down politely.

## Tests

Count the process's open `smithay-keymap` memfds across 8 teardowns, once plainly and once with a grab of `PopupGrab`'s retaining shape installed. Neutering `release_seat` fails the grab test and leaves the plain one passing, which is the expected split since the plain case has no cycle to leak.

The count is process-global while cargo runs this binary's tests in parallel, so the post-cycle sample is the lowest of several readings. A leak is permanent and survives every sample; a neighbouring test's fixture is not. Without that, the two tests contaminate each other's baseline.

## Known gap

Neither test goes through `comp::init`, so the production call site is wired but not covered. Deleting the call would leave the suite green.

## Upstream candidate

The deeper fix belongs in smithay: hold the grab's `KeyboardHandle` weakly, or unset the grab when the last non-grab reference goes away. This is the compositor-side workaround.

## Verified

`cargo fmt` clean, `cargo check` clean, 25 tests pass.
