### PR TITLE
patches: Vulkan AV1 encoder + encode-family fixes

### DIFF
--- a/docker/vulkan.Dockerfile
+++ b/docker/vulkan.Dockerfile
@@ -1,7 +1,8 @@
 # gst-wayland-display:vulkan
 #
 # A Fedora image carrying patched GStreamer 1.28.4 (Vulkan video encode enabled +
-# the vulkanh264enc DPB-pool patch + the vulkanh265enc element) with the
+# the vulkanh264enc DPB-pool/rate-control patches + the vulkanh265enc and
+# vulkanav1enc elements + the encoder-library retarget fix) with the
 # gst-wayland-display plugin installed.
 # It is the single source of the gst-1.28.4-Vulkan + plugin build and serves as the
 # base image for wolf:vulkan (which compiles Wolf on top and inherits the plugin).
@@ -55,11 +56,17 @@ RUN dnf install -y \
 # --- Patched GStreamer 1.28.4 -> /opt/gst -----------------------------------
 COPY patches/vkh264enc-dpb-pool-in-new-sequence.patch /tmp/dpb.patch
 COPY patches/vulkanh265enc.patch /tmp/h265.patch
+COPY patches/vkh264enc-rc-fix.patch /tmp/rc-fix.patch
+COPY patches/gstreamer-vulkan-rc-retarget-no-reset.patch /tmp/rc-retarget.patch
+COPY patches/vulkanav1enc.patch /tmp/av1.patch
 RUN git clone --depth 1 --branch ${GST_VERSION} \
       https://gitlab.freedesktop.org/gstreamer/gstreamer.git /tmp/gstreamer && \
     cd /tmp/gstreamer && \
     git apply /tmp/dpb.patch && \
     git apply /tmp/h265.patch && \
+    git apply /tmp/rc-fix.patch && \
+    git apply /tmp/rc-retarget.patch && \
+    git apply /tmp/av1.patch && \
     # auto_features=disabled leaves several subprojects' docs/meson.build referring
     # to an undefined plugins_cache_generator; short-circuit each when doc is off.
     for d in subprojects/*/docs/meson.build docs/meson.build; do \
@@ -86,7 +93,7 @@ RUN git clone --depth 1 --branch ${GST_VERSION} \
       -Dnls=disabled -Dgst-examples=disabled -Drs=disabled && \
     meson compile -C build && \
     meson install -C build && \
-    rm -rf /tmp/gstreamer /tmp/dpb.patch /tmp/h265.patch
+    rm -rf /tmp/gstreamer /tmp/dpb.patch /tmp/h265.patch /tmp/rc-fix.patch /tmp/rc-retarget.patch /tmp/av1.patch
 
 ENV PKG_CONFIG_PATH=/opt/gst/lib64/pkgconfig \
     LD_LIBRARY_PATH=/opt/gst/lib64 \

--- a/patches/gstreamer-vulkan-rc-retarget-no-reset.patch
+++ b/patches/gstreamer-vulkan-rc-retarget-no-reset.patch
@@ -1,0 +1,138 @@
+# gstreamer-vulkan-rc-retarget-no-reset.patch
+#
+# What: two independent, codec-neutral fixes to the shared Vulkan video-encode
+# library (gst-libs/gst/vulkan/gstvkencoder-private.{c,h}), no element files
+# touched:
+#
+#   A. gst_vulkan_encoder_request_rc_reset() no longer raises
+#      VK_VIDEO_CODING_CONTROL_RESET_BIT_KHR. It becomes a synonym of
+#      gst_vulkan_encoder_request_rc_update() (ENCODE_RATE_CONTROL_BIT only).
+#      A genuine session (re)start is unaffected: gst_vulkan_encoder_start()
+#      and gst_vulkan_encoder_set_rc_mode() (an actual rate-control *mode*
+#      change) both set priv->session_reset directly and never call through
+#      this function, so they still take the RESET_BIT path in
+#      gst_vulkan_encoder_encode()'s VkVideoCodingControlInfoKHR.flags.
+#
+#   B. gst_vulkan_encoder_picture_clear() never released DPB slot 0
+#      (`if (pic->dpb_slot.slotIndex > 0)`), so whichever picture claims slot
+#      0 -- typically the first frame encoded in a session -- is never marked
+#      free again. Over a long-running session this steadily shrinks the
+#      usable DPB by one slot for good. -1 is this codebase's established
+#      "no slot" sentinel (see gst_vulkan_encoder_encode()'s own
+#      `ref_slots[nb_refs].slotIndex = -1` for the setup slot, and this same
+#      function's `pic->dpb_slot.slotIndex = -1` two lines below the guard it
+#      fixes); slot indices returned by gst_vulkan_encoder_encode() range over
+#      [0, maxDpbSlots), so 0 is a legitimate, frequently-hit slot and the
+#      guard must be `>= 0`.
+#
+# Why: A live ABR bitrate retarget calls (or, for a codec ported from the
+# H.264 template without care, MAY call) gst_vulkan_encoder_request_rc_reset()
+# to push the new setpoint to the driver. As shipped, that function sets
+# priv->session_reset, and the encoder's next vkCmdControlVideoCoding call
+# ORs in RESET_BIT unconditionally alongside RATE_CONTROL_BIT and
+# QUALITY_LEVEL_BIT -- a full video-session reset. RESET_BIT invalidates the
+# DPB, so the very next frame has no usable reference and has to be an IDR.
+# Under a sustained ABR loop retargeting every ~1-2s, that is a forced key
+# frame on (close to) every retarget: a bandwidth spike exactly when the path
+# is already congested enough to trigger the retarget in the first place.
+# This is codec-neutral -- it lives in the shared encode library, so it hits
+# H.264, H.265 and AV1 identically; whichever Vulkan codec element reaches
+# for the "reset" entry point pays the same DPB-invalidation tax. B is the
+# same story: any codec's session eventually recycles slot 0 back to the
+# free pool it can never return to.
+#
+# Symptom (measured, AV1, driver 610.57.04, harness
+# deploy/experiments/vulkanav1enc/vkvideoencodeav1cbr.c "rcreset-*-midgop"
+# control cases -- see deploy/experiments/vulkanav1enc/README.md:96-106):
+# a mid-GOP retarget through the reset path takes ~3 frames to converge and
+# costs a key frame at the element level, versus the update path's one-frame
+# convergence and zero key frames. Fix A makes both entry points behave like
+# the update path, so a codec element cannot regress into the reset behavior
+# merely by calling the more obviously-named function.
+#
+# Provenance: the update/reset split (gst_vulkan_encoder_request_rc_update(),
+# the priv->rc_update flag, and the RESET_BIT flags triple this patch's Fix A
+# leaves untouched at genuine-restart call sites) was introduced by
+# deploy/patches/vulkan/vkh264enc-rc-fix.patch (Fix B2, 2026-07-26) for
+# vulkanh264enc's own live-bitrate path, which calls
+# gst_vulkan_encoder_request_rc_update() directly and was already unaffected
+# by request_rc_reset()'s old behavior. This patch closes the same hazard for
+# any *other* caller (H.265, or the vulkanav1enc element under development)
+# that reaches for request_rc_reset() instead. The reset-free control path
+# this patch relies on (ENCODE_RATE_CONTROL_BIT with no RESET_BIT, no
+# QUALITY_LEVEL_BIT) was prototyped and driver-validated in
+# deploy/experiments/vulkanav1enc/README.md ("Reset-free retarget",
+# 2026-07-26 and the 610.57.04 AV1 re-run): the driver accepts it and the new
+# setpoint takes effect the very next frame, with the DPB intact.
+#
+# Dependency: this patch's Fix A requires vkh264enc-rc-fix.patch to already
+# be applied -- gst_vulkan_encoder_request_rc_reset(), the sibling
+# gst_vulkan_encoder_request_rc_update(), and the priv->rc_update field do
+# not exist in stock GStreamer 1.28.4. Apply after (in order) the Quasar
+# vulkan patch chain's vkh264enc-rc-fix.patch. Fix B has no such dependency;
+# gst_vulkan_encoder_picture_clear() is unmodified by any of the other
+# patches in the chain and the fix applies equally to stock 1.28.4. See
+# libpatch-NOTES.md for the full GOW-baseline and six-patch overlap analysis.
+#
+# Scope: no QUASAR_* anything, no Quasar policy -- pure library bugfix,
+# upstreamable independently of vulkanav1enc.patch. License: LGPL, inherited
+# from gst-plugins-bad, same as the file it touches.
+#
+# Upstream status: not filed as of 2026-08-21 (companion to the existing
+# unreported vkh264enc-rc-fix.patch / vkh264enc-num-slices.patch filings
+# against gstreamer/gstreamer noted in deploy/patches/vulkan/README.md).
+diff --git a/subprojects/gst-plugins-bad/gst-libs/gst/vulkan/gstvkencoder-private.c b/subprojects/gst-plugins-bad/gst-libs/gst/vulkan/gstvkencoder-private.c
+index 0b92160..a1b2c3d 100644
+--- a/subprojects/gst-plugins-bad/gst-libs/gst/vulkan/gstvkencoder-private.c
++++ b/subprojects/gst-plugins-bad/gst-libs/gst/vulkan/gstvkencoder-private.c
+@@ -294,7 +294,11 @@ gst_vulkan_encoder_picture_clear (GstVulkanEncoderPicture * pic,
+
+   priv = gst_vulkan_encoder_get_instance_private (self);
+
+-  if (pic->dpb_slot.slotIndex > 0) {
++  /* PATCH (rc-retarget-no-reset): -1 is the "no slot" sentinel used
++   * throughout this file (see the setup slot below and the assignment two
++   * lines down); real slot indices from gst_vulkan_encoder_encode() start at
++   * 0, so a "> 0" guard here silently never released slot 0. */
++  if (pic->dpb_slot.slotIndex >= 0) {
+     priv->slots[pic->dpb_slot.slotIndex] = NULL;
+     pic->dpb_slot.slotIndex = -1;
+   }
+@@ -1580,17 +1584,28 @@ gst_vulkan_encoder_request_rc_update (GstVulkanEncoder * self)
+
+ /**
+  * gst_vulkan_encoder_request_rc_reset:
+  * @self: a #GstVulkanEncoder
+  *
+  * Request that the rate-control state be re-applied to the running video
+- * session on the next encode (via vkCmdControlVideoCoding). Use this after
+- * changing rate-control values (e.g. bitrate) that the encoder reads per-frame
+- * but only applies to the driver on a session reset.
++ * session on the next encode (via vkCmdControlVideoCoding).
++ *
++ * PATCH (rc-retarget-no-reset): despite the name, this raises
++ * %VK_VIDEO_CODING_CONTROL_ENCODE_RATE_CONTROL_BIT_KHR only -- it no longer
++ * raises %VK_VIDEO_CODING_CONTROL_RESET_BIT_KHR. It is now a synonym of
++ * gst_vulkan_encoder_request_rc_update(): both exist so a caller can use
++ * whichever name reads better at the call site. A rate-control *value*
++ * change (e.g. bitrate) never needs a real reset -- the DPB and reference
++ * state stay valid, so no key frame is forced. A genuine session (re)start
++ * still resets: gst_vulkan_encoder_start() and gst_vulkan_encoder_set_rc_mode()
++ * (an actual rate-control *mode* change) set priv->session_reset directly
++ * and do not go through this function, so they are unaffected and still
++ * raise RESET_BIT via the VkVideoCodingControlInfoKHR flags in
++ * gst_vulkan_encoder_encode().
+  */
+ void
+ gst_vulkan_encoder_request_rc_reset (GstVulkanEncoder * self)
+ {
+   GstVulkanEncoderPrivate *priv;
+
+   g_return_if_fail (GST_IS_VULKAN_ENCODER (self));
+
+   priv = gst_vulkan_encoder_get_instance_private (self);
+
+   if (priv->started)
+-    priv->session_reset = TRUE;
++    priv->rc_update = TRUE;
+ }

--- a/patches/vkh264enc-rc-fix.patch
+++ b/patches/vkh264enc-rc-fix.patch
@@ -1,0 +1,227 @@
+diff --git a/subprojects/gst-plugins-bad/ext/vulkan/vkh264enc.c b/subprojects/gst-plugins-bad/ext/vulkan/vkh264enc.c
+index 6841983..d3ddfdb 100644
+--- a/subprojects/gst-plugins-bad/ext/vulkan/vkh264enc.c
++++ b/subprojects/gst-plugins-bad/ext/vulkan/vkh264enc.c
+@@ -740,6 +740,13 @@ gst_vulkan_h264_encoder_new_sequence (GstH264Encoder * encoder,
+         && self->profile.profile.chromaBitDepth == bit_depth_chroma
+         && self->profile.profile.lumaBitDepth == bit_depth_luma
+         && self->profile.codec.h264enc.stdProfileIdc == vk_profile) {
++      /* Same profile: the session is not restarted, but a reconfigure may have
++       * changed the bitrate (or other rate-control values). Re-apply rate
++       * control to the driver via vkCmdControlVideoCoding; otherwise a live
++       * bitrate change is silently ignored. This is the *update* request, not
++       * a reset: a reset would raise VK_VIDEO_CODING_CONTROL_RESET_BIT_KHR,
++       * invalidate the DPB and force an IDR on every ABR retarget. */
++      gst_vulkan_encoder_request_rc_update (self->encoder);
+       return GST_FLOW_OK;
+     } else {
+       GST_DEBUG_OBJECT (self, "Restarting vulkan encoder");
+@@ -769,6 +776,7 @@ gst_vulkan_h264_encoder_new_sequence (GstH264Encoder * encoder,
+     self->rc.quality = gst_vulkan_encoder_quality_level (self->encoder);
+     update_property_uint (self, &self->prop.quality, self->rc.quality,
+         PROP_QUALITY);
++    gst_vulkan_encoder_set_rc_mode (self->encoder, self->prop.ratecontrol);
+     self->rc.ratecontrol = gst_vulkan_encoder_rc_mode (self->encoder);
+     update_property_uint (self, &self->prop.ratecontrol, self->rc.ratecontrol,
+         PROP_RATECONTROL);
+@@ -1993,6 +2001,38 @@ gst_vulkan_h264_encoder_get_property (GObject * object, guint property_id,
+   GST_OBJECT_UNLOCK (self);
+ }
+ 
++/* PATCH (rc-fix): apply a bitrate change to an already-STARTED encoder without
++ * a reconfigure. Mirrors the rate half of _configure_rate_control() (clamp to
++ * the driver maximum, then CBR: max == average / VBR: the 66% target
++ * percentage); cpb_size is deliberately left alone, being a ratio of the two and
++ * therefore independent of the setpoint magnitude. */
++static void
++_update_live_bitrate (GstVulkanH264Encoder * self)
++{
++  GstVulkanVideoCapabilities vk_caps;
++  guint max_kbps;
++
++  if (!gst_vulkan_encoder_caps (self->encoder, &vk_caps))
++    return;
++
++  max_kbps = vk_caps.encoder.caps.maxBitrate / 1024;
++
++  GST_OBJECT_LOCK (self);
++  self->rc.bitrate = MIN (self->prop.bitrate, max_kbps);
++  if (self->rc.ratecontrol == VK_VIDEO_ENCODE_RATE_CONTROL_MODE_VBR_BIT_KHR) {
++    self->rc.max_bitrate = MIN ((guint)
++        gst_util_uint64_scale_int (self->rc.bitrate, 100, 66), max_kbps);
++  } else {
++    self->rc.max_bitrate = self->rc.bitrate;
++  }
++  GST_OBJECT_UNLOCK (self);
++
++  GST_DEBUG_OBJECT (self, "live bitrate retarget to %u kbps (max %u): no "
++      "session reset, no reconfigure", self->rc.bitrate, self->rc.max_bitrate);
++
++  gst_vulkan_encoder_request_rc_update (self->encoder);
++}
++
+ static void
+ gst_vulkan_h264_encoder_set_property (GObject * object, guint property_id,
+     const GValue * value, GParamSpec * pspec)
+@@ -2000,12 +2040,13 @@ gst_vulkan_h264_encoder_set_property (GObject * object, guint property_id,
+   GstVulkanH264Encoder *self = GST_VULKAN_H264_ENCODER (object);
+   GstH264Encoder *h264enc = GST_H264_ENCODER (object);
+   gboolean reconfigure = FALSE;
++  gboolean bitrate_changed = FALSE;
+ 
+   GST_OBJECT_LOCK (self);
+   switch (property_id) {
+     case PROP_BITRATE:
+       self->prop.bitrate = g_value_get_uint (value);
+-      reconfigure = TRUE;
++      bitrate_changed = TRUE;
+       break;
+     case PROP_AUD:
+       self->prop.aud = g_value_get_boolean (value);
+@@ -2044,6 +2085,24 @@ gst_vulkan_h264_encoder_set_property (GObject * object, guint property_id,
+   }
+   GST_OBJECT_UNLOCK (self);
+ 
++  /* PATCH (rc-fix): a live bitrate change must NOT go through
++   * gst_h264_encoder_reconfigure(). The base class's configure() drains the
++   * encoder and calls gst_h264_encoder_reset(), which zeroes
++   * gop.cur_frame_index — so the very next frame is an IDR that restarts the
++   * GOP. Measured on Tower with deploy/diag/vulkan_rc_retarget_probe.c: with the
++   * reconfigure, a retarget emits a key frame 0-1 frames later and realigns
++   * idr-period to the retarget point, i.e. under sustained ABR the keyframe
++   * interval collapses to the retarget interval. Removing the video-session
++   * reset alone does not fix that; the reconfigure is the IDR's actual source.
++   * Before start() there is nothing live to update, so the normal reconfigure
++   * path still runs. */
++  if (bitrate_changed) {
++    if (self->encoder && gst_vulkan_encoder_is_started (self->encoder))
++      _update_live_bitrate (self);
++    else
++      reconfigure = TRUE;
++  }
++
+   if (reconfigure)
+     gst_h264_encoder_reconfigure (h264enc, FALSE);
+ }
+diff --git a/subprojects/gst-plugins-bad/gst-libs/gst/vulkan/gstvkencoder-private.c b/subprojects/gst-plugins-bad/gst-libs/gst/vulkan/gstvkencoder-private.c
+index fec23f3..0b92160 100644
+--- a/subprojects/gst-plugins-bad/gst-libs/gst/vulkan/gstvkencoder-private.c
++++ b/subprojects/gst-plugins-bad/gst-libs/gst/vulkan/gstvkencoder-private.c
+@@ -55,6 +55,12 @@ struct _GstVulkanEncoderPrivate
+   guint32 quality;
+   VkVideoEncodeRateControlModeFlagBitsKHR rc_mode;
+ 
++  /* PATCH (rc-fix): one-shot request to re-apply rate control to the
++   * running video session WITHOUT resetting it. Unlike session_reset this
++   * raises no VK_VIDEO_CODING_CONTROL_RESET_BIT_KHR, so the DPB survives
++   * and the next frame does not have to be an IDR. */
++  gboolean rc_update;
++
+   gboolean started;
+   gboolean session_reset;
+ 
+@@ -1148,7 +1154,7 @@ gst_vulkan_encoder_encode (GstVulkanEncoder * self, GstVideoInfo * info,
+   /* *INDENT-OFF* */
+   begin_coding = (VkVideoBeginCodingInfoKHR) {
+     .sType = VK_STRUCTURE_TYPE_VIDEO_BEGIN_CODING_INFO_KHR,
+-    .pNext = !priv->session_reset ? &rc_info : NULL,
++    .pNext = (priv->session_reset || priv->rc_update) ? NULL : &rc_info,
+     .videoSession = priv->session.session->handle,
+     .videoSessionParameters = priv->session_params->handle,
+     .referenceSlotCount = nb_refs + 1,
+@@ -1167,6 +1173,21 @@ gst_vulkan_encoder_encode (GstVulkanEncoder * self, GstVideoInfo * info,
+   if (priv->session_reset) {
+     priv->vk.CmdControlVideoCoding (cmd_buf->cmd, &coding_ctrl);
+     priv->session_reset = FALSE;
++    /* A reset re-applies rate control too, so a pending update is
++     * satisfied by it — clear it rather than issuing a second control. */
++    priv->rc_update = FALSE;
++  } else if (priv->rc_update) {
++    /* PATCH (rc-fix): re-apply rate control ONLY. No RESET_BIT, so the
++     * video session keeps its DPB and the next frame need not be an IDR.
++     * The quality level is not changing here, so QUALITY_LEVEL_BIT is left
++     * out and the pNext chain starts at the rate-control info
++     * (VUID-VkVideoCodingControlInfoKHR-flags-07018 requires the rate
++     * control info to be present; -08349 would require the quality level
++     * info only if that bit were set). */
++    coding_ctrl.pNext = &rc_info;
++    coding_ctrl.flags = VK_VIDEO_CODING_CONTROL_ENCODE_RATE_CONTROL_BIT_KHR;
++    priv->vk.CmdControlVideoCoding (cmd_buf->cmd, &coding_ctrl);
++    priv->rc_update = FALSE;
+   }
+ 
+   /* Peek the output memory to be used by VkVideoEncodeInfoKHR.dstBuffer */
+@@ -1411,6 +1432,56 @@ gst_vulkan_encoder_set_rc_mode (GstVulkanEncoder * self,
+   priv->rc_mode = rc_mode;
+ }
+ 
++/**
++ * gst_vulkan_encoder_request_rc_update:
++ * @self: a #GstVulkanEncoder
++ *
++ * Request that the rate-control state be re-applied to the running video
++ * session on the next encode via vkCmdControlVideoCoding with
++ * %VK_VIDEO_CODING_CONTROL_ENCODE_RATE_CONTROL_BIT_KHR **only**.
++ *
++ * This is the live-retarget path: unlike
++ * gst_vulkan_encoder_request_rc_reset() it does not raise
++ * %VK_VIDEO_CODING_CONTROL_RESET_BIT_KHR, so the decoded-picture buffer is
++ * not invalidated and the encoder is not forced to emit a key frame. Use
++ * request_rc_reset() only for a genuine session restart (start, or a
++ * rate-control *mode* change).
++ */
++void
++gst_vulkan_encoder_request_rc_update (GstVulkanEncoder * self)
++{
++  GstVulkanEncoderPrivate *priv;
++
++  g_return_if_fail (GST_IS_VULKAN_ENCODER (self));
++
++  priv = gst_vulkan_encoder_get_instance_private (self);
++
++  if (priv->started)
++    priv->rc_update = TRUE;
++}
++
++/**
++ * gst_vulkan_encoder_request_rc_reset:
++ * @self: a #GstVulkanEncoder
++ *
++ * Request that the rate-control state be re-applied to the running video
++ * session on the next encode (via vkCmdControlVideoCoding). Use this after
++ * changing rate-control values (e.g. bitrate) that the encoder reads per-frame
++ * but only applies to the driver on a session reset.
++ */
++void
++gst_vulkan_encoder_request_rc_reset (GstVulkanEncoder * self)
++{
++  GstVulkanEncoderPrivate *priv;
++
++  g_return_if_fail (GST_IS_VULKAN_ENCODER (self));
++
++  priv = gst_vulkan_encoder_get_instance_private (self);
++
++  if (priv->started)
++    priv->session_reset = TRUE;
++}
++
+ GType
+ gst_vulkan_encoder_rate_control_mode_get_type (void)
+ {
+diff --git a/subprojects/gst-plugins-bad/gst-libs/gst/vulkan/gstvkencoder-private.h b/subprojects/gst-plugins-bad/gst-libs/gst/vulkan/gstvkencoder-private.h
+index 9297736..033bd4c 100644
+--- a/subprojects/gst-plugins-bad/gst-libs/gst/vulkan/gstvkencoder-private.h
++++ b/subprojects/gst-plugins-bad/gst-libs/gst/vulkan/gstvkencoder-private.h
+@@ -174,6 +174,12 @@ GST_VULKAN_API
+ void                    gst_vulkan_encoder_set_rc_mode          (GstVulkanEncoder * self,
+                                                                  VkVideoEncodeRateControlModeFlagBitsKHR rc_mode);
+ 
++GST_VULKAN_API
++void                    gst_vulkan_encoder_request_rc_update    (GstVulkanEncoder * self);
++
++GST_VULKAN_API
++void                    gst_vulkan_encoder_request_rc_reset     (GstVulkanEncoder * self);
++
+ GST_VULKAN_API
+ gboolean                gst_vulkan_encoder_start                (GstVulkanEncoder * self,
+                                                                  GstVulkanVideoProfile * profile,

--- a/patches/vulkanav1enc.patch
+++ b/patches/vulkanav1enc.patch
@@ -1,0 +1,5371 @@
+# vulkanav1enc.patch
+#
+# What: a new Vulkan Video AV1 encoder element (`vulkanav1enc`), its AV1
+# base class — seven files, all additive except three registration touches:
+#
+#   ext/vulkan/base/gstav1encoder.{c,h}   AV1 base class: 8-slot VBI reference
+#     model (7-name ref_frame_idx map, refresh_frame_flags over VBI slots,
+#     order hints, forward-only golden-frame group). Forward-only by design
+#     (no B-frames / show_existing_frame): DTS==PTS, no reorder queue.
+#     Property writes never raise need_configure — a live bitrate retarget
+#     can NOT trigger the base-class GOP-reset IDR that bit vulkanh264enc.
+#   ext/vulkan/vkav1enc.{c,h}             the element. Driver-emitted sequence
+#     header adopted verbatim (no hand-written parameter sets — the H.265
+#     CTB/SPS round-trip failure class is structurally absent). Temporal unit
+#     assembled by concatenation: TD OBU + [seq hdr on key] + OBU_FRAME.
+#     CBR/VBR/CQP via VkVideoEncodeAV1RateControlInfoKHR (+ per-layer), 200 ms
+#     VBV default; colorimetry/chroma-site propagated to output caps.
+#   ext/vulkan/meson.build, gstvulkan.c   registration (rank NONE, like the
+#     vulkanh265enc sibling).
+#   ext/vulkan/gstvkvideocaps.c           av1_encode_caps(): stock 1.28.4
+#     returns FALSE /* unimplemented */ for ENCODE_AV1, which would veto
+#     registration on every device.
+#
+# Why: AV1 previously had no Vulkan encoder anywhere (gst 1.28 ships Vulkan
+# AV1 decode only), so a vulkan-encoder host resolved AV1 per session onto the
+# vendor HW encoder (NVENC/VA) — the one codec leaving the Vulkan zero-copy
+# path, and on NVIDIA the one codec still riding the crash-affected NVENC
+# teardown path (Quasar issue #489, an NVIDIA-driver UAF spanning the 595/610
+# branches)
+# library. Upstream (Igalia) has AV1 encode "in the pipeline" but nothing
+# published as of 2026-08.
+#
+# Depends on (apply order): vulkanh265enc.patch (shares meson.build/gstvulkan.c
+# context), vkh264enc-rc-fix.patch (gst_vulkan_encoder_request_rc_update),
+# gstreamer-vulkan-rc-retarget-no-reset.patch (reset-free live retarget).
+# Applies last in the chain.
+#
+# Live-pipeline fix folded in 2026-08-21: input VulkanImage buffers are
+# released at encode completion (references need only the DPB reconstruction,
+# never the source image). Without it the VBI pinned up to 8 compositor
+# encode-src ring slots against a 4-slot ring and the live zero-copy path
+# serialized to ~1.7 fps; with it, 59.5 fps live and NO ring-depth pin needed.
+#
+# Validated (2026-08-21, RTX 5090, driver 610.57.04, gst 1.28.4): compiles
+# clean; gst-inspect registers an NV12 memory:VulkanImage sink, video/x-av1
+# src; 120/120 and 600/600 frames decoded by vulkanav1dec; CBR 8 Mbps target
+# -> 9.55 Mbps measured over 600 frames; upstream libs_vkvideoencodeav1
+# conformance stays green; Khronos validation layer run clean.
+#
+# Upstream status: GStreamer has restricted submissions (no MR path for us);
+# offered to games-on-whales/gst-wayland-display patches/ alongside the
+# rc-fix + rc-retarget prerequisites. Regenerate on every GStreamer re-pin.
+diff --git a/subprojects/gst-plugins-bad/ext/vulkan/gstvkvideocaps.c b/subprojects/gst-plugins-bad/ext/vulkan/gstvkvideocaps.c
+index 8817839..e6cfa5f 100644
+--- a/subprojects/gst-plugins-bad/ext/vulkan/gstvkvideocaps.c
++++ b/subprojects/gst-plugins-bad/ext/vulkan/gstvkvideocaps.c
+@@ -483,6 +483,39 @@ av1_decode_caps (GstVulkanPhysicalDevice * device,
+   return TRUE;
+ }
+ 
++static gboolean
++av1_encode_caps (GstVulkanPhysicalDevice * device,
++    GstVulkanVideoProfile * profile, GstCaps ** codec_caps_ptr,
++    GstCaps ** raw_caps_ptr)
++{
++  GstCaps *codec_caps, *raw_caps;
++
++  profile->codec.av1enc.sType =
++      VK_STRUCTURE_TYPE_VIDEO_ENCODE_AV1_PROFILE_INFO_KHR;
++
++  codec_caps = gst_caps_new_empty ();
++  raw_caps = gst_caps_new_empty ();
++
++  /* the element only implements Main profile (8-bit 4:2:0) */
++  profile->codec.av1enc.stdProfile = STD_VIDEO_AV1_PROFILE_MAIN;
++
++  try_get_caps (device, profile, codec_caps, raw_caps);
++
++  if (!check_caps (&codec_caps, &raw_caps))
++    return FALSE;
++
++  gst_caps_set_simple (codec_caps, "alignment", G_TYPE_STRING, "tu",
++      "stream-format", G_TYPE_STRING, "obu-stream", NULL);
++
++  gst_caps_set_features_simple (raw_caps,
++      gst_caps_features_new (GST_CAPS_FEATURE_MEMORY_VULKAN_IMAGE, NULL));
++
++  *codec_caps_ptr = codec_caps;
++  *raw_caps_ptr = raw_caps;
++
++  return TRUE;
++}
++
+ static const StdVideoVP9Profile vp9_profile[] = {
+   STD_VIDEO_VP9_PROFILE_0, STD_VIDEO_VP9_PROFILE_1, STD_VIDEO_VP9_PROFILE_2,
+   STD_VIDEO_VP9_PROFILE_3,
+@@ -554,7 +587,7 @@ gst_vulkan_physical_device_codec_caps (GstVulkanPhysicalDevice * device,
+     case VK_VIDEO_CODEC_OPERATION_DECODE_AV1_BIT_KHR:
+       return av1_decode_caps (device, &profile, codec_caps, raw_caps);
+     case VK_VIDEO_CODEC_OPERATION_ENCODE_AV1_BIT_KHR:
+-      return FALSE;             /* unimplemented */
++      return av1_encode_caps (device, &profile, codec_caps, raw_caps);
+     case VK_VIDEO_CODEC_OPERATION_DECODE_VP9_BIT_KHR:
+       return vp9_decode_caps (device, &profile, codec_caps, raw_caps);
+     default:
+diff --git a/subprojects/gst-plugins-bad/ext/vulkan/gstvulkan.c b/subprojects/gst-plugins-bad/ext/vulkan/gstvulkan.c
+index 5f8a97f..9efaee3 100644
+--- a/subprojects/gst-plugins-bad/ext/vulkan/gstvulkan.c
++++ b/subprojects/gst-plugins-bad/ext/vulkan/gstvulkan.c
+@@ -50,6 +50,7 @@
+ #include "vkvp9dec.h"
+ #include "vkh264enc.h"
+ #include "vkh265enc.h"
++#include "vkav1enc.h"
+ #endif
+ 
+ GST_DEBUG_CATEGORY_EXTERN (gst_vulkan_debug);
+@@ -129,6 +130,10 @@ plugin_init (GstPlugin * plugin)
+               VK_KHR_VIDEO_ENCODE_H265_EXTENSION_NAME)) {
+         ret |= gst_vulkan_h265_encoder_register (plugin, device, GST_RANK_NONE);
+       }
++      if (gst_vulkan_device_is_extension_enabled (device,
++              VK_KHR_VIDEO_ENCODE_AV1_EXTENSION_NAME)) {
++        ret |= gst_vulkan_av1_encoder_register (plugin, device, GST_RANK_NONE);
++      }
+ #endif /* GST_VULKAN_HAVE_VIDEO_EXTENSIONS */
+       ret |= gst_vulkan_sink_register (plugin, device, GST_RANK_NONE);
+       gst_object_unref (device);
+diff --git a/subprojects/gst-plugins-bad/ext/vulkan/meson.build b/subprojects/gst-plugins-bad/ext/vulkan/meson.build
+index c01eb11..efeaa7b 100644
+--- a/subprojects/gst-plugins-bad/ext/vulkan/meson.build
++++ b/subprojects/gst-plugins-bad/ext/vulkan/meson.build
+@@ -35,8 +35,10 @@ glsc_sources = [
+ video_sources = [
+   'base/gsth264encoder.c',
+   'base/gsth265encoder.c',
++  'base/gstav1encoder.c',
+   'gstvkvideocaps.c',
+   'vkav1dec.c',
++  'vkav1enc.c',
+   'vkh264enc.c',
+   'vkh265enc.c',
+   'vkh264dec.c',
+diff --git a/subprojects/gst-plugins-bad/tests/check/meson.build b/subprojects/gst-plugins-bad/tests/check/meson.build
+index eddac3c..7b18df2 100644
+--- a/subprojects/gst-plugins-bad/tests/check/meson.build
++++ b/subprojects/gst-plugins-bad/tests/check/meson.build
+@@ -125,6 +125,7 @@ base_tests = [
+   [['libs/vkvideoencodeh264.c'], not gstvulkan_dep.found() or vulkan_conf.get('GST_VULKAN_HAVE_VIDEO_EXTENSIONS') != 1, [gstvulkan_dep, gstcodecparsers_dep]],
+   [['libs/vkvideoencodeh265.c'], not gstvulkan_dep.found() or vulkan_conf.get('GST_VULKAN_HAVE_VIDEO_EXTENSIONS') != 1, [gstvulkan_dep, gstcodecparsers_dep]],
+   [['libs/vkvideoencodeav1.c'], not gstvulkan_dep.found() or vulkan_conf.get('GST_VULKAN_HAVE_VIDEO_EXTENSIONS') != 1, [gstvulkan_dep, gstcodecparsers_dep]],
++  [['libs/vkvideoencodeav1refs.c'], false, [gstvideo_dep, gstcodecparsers_dep]],
+   [['libs/d3d11device.cpp'], not gstd3d11_dep.found(), [gstd3d11_dep]],
+   [['libs/d3d11memory.c'], not gstd3d11_dep.found(), [gstd3d11_dep]],
+   [['libs/cudamemory.c'], not gstcuda_dep.found(), [gstcuda_dep, gstcuda_stub_dep]],
+diff --git a/subprojects/gst-plugins-bad/ext/vulkan/base/gstav1encoder.c b/subprojects/gst-plugins-bad/ext/vulkan/base/gstav1encoder.c
+new file mode 100644
+index 00000000..4eb96397
+--- /dev/null
++++ b/subprojects/gst-plugins-bad/ext/vulkan/base/gstav1encoder.c
+@@ -0,0 +1,1339 @@
++/* GStreamer
++ * Copyright (C) 2026 Igalia, S.L.
++ *
++ * This library is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU Library General Public
++ * License as published by the Free Software Foundation; either
++ * version 2 of the License, or (at your option) any later version.
++ *
++ * This library is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++ * Library General Public License for more details.
++ *
++ * You should have received a copy of the GNU Library General Public
++ * License along with this library; if not, write to the
++ * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
++ * Boston, MA 02110-1301, USA.
++ */
++
++/**
++ * SECTION:gstav1encoder
++ * @title: GstAV1Encoder
++ * @short_description: Base class to implement stateless AV1 encoders
++ *
++ * This AV1 encoder base class manages the AV1 reference model: the 8-slot
++ * virtual buffer index (VBI), the 7-entry reference-name map, refresh
++ * bitmasks, order hints and a forward-only golden-frame group. The subclass
++ * is expected to implement the rate control algorithms and the specific
++ * accelerator logic.
++ *
++ * + Forward prediction only: no bidirectional compound (no ALTREF backward
++ *   references), so frames are encoded in display order and no reordering
++ *   is performed.
++ * + No show_existing_frame, no intra-only frames, no switch frames.
++ * + One tile per frame.
++ */
++
++#ifdef HAVE_CONFIG_H
++#include "config.h"
++#endif
++
++#include "gstav1encoder.h"
++
++GST_DEBUG_CATEGORY (gst_av1_encoder_debug);
++#define GST_CAT_DEFAULT gst_av1_encoder_debug
++
++#define AV1ENC_KEYFRAME_PERIOD_DEFAULT    0
++#define AV1ENC_NUM_REF_FRAMES_DEFAULT     3
++#define AV1ENC_GF_GROUP_SIZE_DEFAULT      8
++
++/* The AV1 order_hint field cannot exceed 8 bits (order_hint_bits_minus_1 is
++ * a 3-bit field capped at 7). The base class always operates with
++ * OrderHintBits == 8, so subclasses must write order_hint_bits_minus_1 = 7.
++ * (trap 5: order_hint_bits_minus_1 clamped to 7) */
++#define AV1ENC_ORDER_HINT_BITS            8
++
++typedef struct _GstAV1EncoderPrivate GstAV1EncoderPrivate;
++
++enum
++{
++  PROP_KEYFRAME_PERIOD = 1,     /* aka idr-period, mirroring the h26x siblings */
++  PROP_NUM_REF_FRAMES,
++  PROP_GF_GROUP_SIZE,
++  N_PROPERTIES
++};
++
++static GParamSpec *properties[N_PROPERTIES];
++
++struct _GstAV1EncoderPrivate
++{
++  GstVideoCodecState *input_state;
++
++  struct
++  {
++    guint max_num_references;
++    guint preferred_output_delay;
++  } config;
++
++  struct
++  {
++    guint32 keyframe_period;
++    guint num_ref_frames;
++    guint gf_group_size;
++  } prop;
++
++  struct
++  {
++    /* effective values, re-read from properties per frame so a live
++     * property write retargets the running GOP without a reset */
++    guint32 keyframe_period;
++    guint num_ref_frames;
++    guint gf_group_size;
++
++    /* frame number since the last key frame; 0 = key frame */
++    guint32 frame_num;
++    /* frames since the last golden-frame anchor */
++    guint32 frames_since_gf;
++
++    /* The AV1 virtual buffer index: 8 reference slots. Entries hold an
++     * owned reference on the #GstVideoCodecFrame. */
++    GstVideoCodecFrame *ref_list[GST_AV1_NUM_REF_FRAMES];
++  } gop;
++
++  guint fps_n;
++  guint fps_d;
++
++  GQueue output_list;
++
++  gboolean is_live;
++  gint need_configure;
++};
++
++/**
++ * GstAV1Encoder:
++ *
++ * Opaque #GstAV1Encoder data structure.
++ *
++ * Since: 1.28
++ */
++
++#define parent_class gst_av1_encoder_parent_class
++G_DEFINE_ABSTRACT_TYPE_WITH_CODE (GstAV1Encoder, gst_av1_encoder,
++    GST_TYPE_VIDEO_ENCODER,
++    G_ADD_PRIVATE (GstAV1Encoder);
++    GST_DEBUG_CATEGORY_INIT (gst_av1_encoder_debug, "av1encoder", 0,
++        "AV1 Video Encoder"));
++
++GST_DEFINE_MINI_OBJECT_TYPE (GstAV1EncoderFrame, gst_av1_encoder_frame);
++
++#define _GET_PRIV(obj) gst_av1_encoder_get_instance_private (obj)
++#define _GET_FRAME(codec_frame) GST_AV1_ENCODER_FRAME (gst_video_codec_frame_get_user_data (codec_frame))
++
++static void
++gst_av1_encoder_frame_free (GstMiniObject * mini_object)
++{
++  GstAV1EncoderFrame *frame = GST_AV1_ENCODER_FRAME (mini_object);
++
++  GST_TRACE ("Free frame %p", frame);
++  if (frame->user_data_destroy_notify)
++    frame->user_data_destroy_notify (frame->user_data);
++
++  g_free (frame);
++}
++
++/**
++ * gst_av1_encoder_frame_new:
++ *
++ * Create new #GstAV1EncoderFrame
++ *
++ * Returns: a new #GstAV1EncoderFrame
++ */
++GstAV1EncoderFrame *
++gst_av1_encoder_frame_new (void)
++{
++  GstAV1EncoderFrame *frame;
++  gint i;
++
++  frame = g_new0 (GstAV1EncoderFrame, 1);
++  frame->type = GST_AV1_INTER_FRAME;
++  frame->update_index = -1;
++  for (i = 0; i < GST_AV1_NUM_REF_FRAMES; i++) {
++    frame->ref_frame_idx[i] = -1;
++    /* the resolved view (bug A2) starts out empty too; g_new0 covers
++     * distinct_refs / num_distinct_refs / ref_order_hint */
++    frame->ref_distinct_idx[i] = -1;
++  }
++
++  gst_mini_object_init (GST_MINI_OBJECT_CAST (frame), 0,
++      GST_TYPE_AV1_ENCODER_FRAME, NULL, NULL, gst_av1_encoder_frame_free);
++
++  GST_TRACE ("New frame %p", frame);
++
++  return frame;
++}
++
++/**
++ * gst_av1_encoder_frame_set_user_data:
++ * @frame: a #GstAV1EncoderFrame
++ * @user_data: private data
++ * @notify: (closure user_data): a #GDestroyNotify
++ *
++ * Sets @user_data on the frame and the #GDestroyNotify that will be called
++ * when the frame is freed. Allows to attach private data by the subclass to
++ * frames.
++ *
++ * If a @user_data was previously set, then the previous set @notify will be
++ * called before the @user_data is replaced.
++ */
++void
++gst_av1_encoder_frame_set_user_data (GstAV1EncoderFrame * frame,
++    gpointer user_data, GDestroyNotify notify)
++{
++  if (frame->user_data_destroy_notify)
++    frame->user_data_destroy_notify (frame->user_data);
++
++  frame->user_data = user_data;
++  frame->user_data_destroy_notify = notify;
++}
++
++static void
++gst_av1_encoder_clear_ref_list (GstAV1Encoder * self)
++{
++  GstAV1EncoderPrivate *priv = _GET_PRIV (self);
++  gint i;
++
++  for (i = 0; i < GST_AV1_NUM_REF_FRAMES; i++) {
++    if (priv->gop.ref_list[i]) {
++      gst_video_codec_frame_unref (priv->gop.ref_list[i]);
++      priv->gop.ref_list[i] = NULL;
++    }
++  }
++}
++
++static inline void
++gst_av1_encoder_flush_lists (GstAV1Encoder * self)
++{
++  GstAV1EncoderPrivate *priv = _GET_PRIV (self);
++
++  g_queue_clear_full (&priv->output_list,
++      (GDestroyNotify) gst_video_codec_frame_unref);
++
++  gst_av1_encoder_clear_ref_list (self);
++}
++
++static gboolean
++gst_av1_encoder_start (GstVideoEncoder * encoder)
++{
++  /* No frame reordering, so PTS == DTS always; no min-pts offset needed. */
++  return TRUE;
++}
++
++static gboolean
++gst_av1_encoder_stop (GstVideoEncoder * encoder)
++{
++  GstAV1Encoder *self = GST_AV1_ENCODER (encoder);
++  GstAV1EncoderPrivate *priv = _GET_PRIV (self);
++
++  gst_av1_encoder_flush_lists (self);
++
++  g_clear_pointer (&priv->input_state, gst_video_codec_state_unref);
++
++  return TRUE;
++}
++
++static void
++gst_av1_encoder_reset (GstAV1Encoder * self)
++{
++  GstAV1EncoderPrivate *priv = _GET_PRIV (self);
++  GstAV1EncoderClass *klass = GST_AV1_ENCODER_GET_CLASS (self);
++
++  GST_OBJECT_LOCK (self);
++  priv->gop.keyframe_period = priv->prop.keyframe_period;
++  priv->gop.num_ref_frames = priv->prop.num_ref_frames;
++  priv->gop.gf_group_size = priv->prop.gf_group_size;
++  GST_OBJECT_UNLOCK (self);
++
++  priv->gop.frame_num = 0;
++  priv->gop.frames_since_gf = 0;
++
++  gst_av1_encoder_clear_ref_list (self);
++
++  g_atomic_int_set (&priv->need_configure, FALSE);
++
++  if (klass->reset)
++    klass->reset (self);
++}
++
++static gboolean
++gst_av1_encoder_set_format (GstVideoEncoder * encoder,
++    GstVideoCodecState * state)
++{
++  GstAV1Encoder *self = GST_AV1_ENCODER (encoder);
++  GstAV1EncoderPrivate *priv = _GET_PRIV (self);
++  GstQuery *query;
++
++  if (priv->input_state)
++    gst_video_codec_state_unref (priv->input_state);
++  priv->input_state = gst_video_codec_state_ref (state);
++
++  priv->fps_d = GST_VIDEO_INFO_FPS_D (&priv->input_state->info);
++  priv->fps_n = GST_VIDEO_INFO_FPS_N (&priv->input_state->info);
++
++  /* if still image */
++  if (priv->fps_d == 0 || priv->fps_n == 0) {
++    priv->fps_d = 1;
++    priv->fps_n = 30;
++  }
++
++  /* in case live streaming, we should run on low-latency mode */
++  priv->is_live = FALSE;
++  query = gst_query_new_latency ();
++  if (gst_pad_peer_query (GST_VIDEO_ENCODER_SINK_PAD (encoder), query))
++    gst_query_parse_latency (query, &priv->is_live, NULL, NULL);
++  gst_query_unref (query);
++
++  g_atomic_int_set (&priv->need_configure, TRUE);
++
++  return TRUE;
++}
++
++static GstFlowReturn
++gst_av1_encoder_finish_frame (GstAV1Encoder * self, GstVideoCodecFrame * frame)
++{
++  GstAV1EncoderClass *base_class = GST_AV1_ENCODER_GET_CLASS (self);
++  GstAV1EncoderFrame *av1_frame = _GET_FRAME (frame);
++  GstFlowReturn ret;
++
++  /* forward-only prediction, no reordering */
++  frame->dts = frame->pts;
++
++  if (base_class->prepare_output) {
++    ret = base_class->prepare_output (self, frame);
++    if (ret != GST_FLOW_OK)
++      goto prepare_error;
++  }
++
++  if (av1_frame->type == GST_AV1_KEY_FRAME) {
++    GST_VIDEO_CODEC_FRAME_SET_SYNC_POINT (frame);
++    GST_BUFFER_FLAG_UNSET (frame->output_buffer, GST_BUFFER_FLAG_DELTA_UNIT);
++    GST_BUFFER_FLAG_SET (frame->output_buffer, GST_BUFFER_FLAG_HEADER);
++  } else {
++    GST_VIDEO_CODEC_FRAME_UNSET_SYNC_POINT (frame);
++    GST_BUFFER_FLAG_SET (frame->output_buffer, GST_BUFFER_FLAG_DELTA_UNIT);
++  }
++
++  GST_LOG_OBJECT (self, "Push to downstream: frame system_frame_number: %d,"
++      " pts: %" GST_TIME_FORMAT ", dts: %" GST_TIME_FORMAT
++      " duration: %" GST_TIME_FORMAT ", buffer size: %" G_GSIZE_FORMAT,
++      frame->system_frame_number, GST_TIME_ARGS (frame->pts),
++      GST_TIME_ARGS (frame->dts), GST_TIME_ARGS (frame->duration),
++      frame->output_buffer ? gst_buffer_get_size (frame->output_buffer) : 0);
++
++  return gst_video_encoder_finish_frame (GST_VIDEO_ENCODER (self), frame);
++
++prepare_error:
++  {
++    GST_ERROR_OBJECT (self, "Failed to prepare output");
++    gst_clear_buffer (&frame->output_buffer);
++    ret = gst_video_encoder_finish_frame (GST_VIDEO_ENCODER (self), frame);
++    if (ret != GST_FLOW_OK)
++      GST_WARNING_OBJECT (self, "Failed to drop unprepared frame");
++
++    return GST_FLOW_ERROR;
++  }
++}
++
++static GstFlowReturn
++gst_av1_encoder_finish_last_frame (GstAV1Encoder * self)
++{
++  GstAV1EncoderPrivate *priv = _GET_PRIV (self);
++  GstVideoCodecFrame *frame;
++  GstFlowReturn ret;
++  guint32 system_frame_number;
++
++  if (g_queue_is_empty (&priv->output_list))
++    return GST_FLOW_OK;
++
++  frame = g_queue_pop_head (&priv->output_list);
++  system_frame_number = frame->system_frame_number;
++
++  ret = gst_av1_encoder_finish_frame (self, frame);
++
++  /* The reference list (VBI) may keep this codec frame alive for up to 8
++   * more frames, and the codec frame owns a ref on its input buffer.  The
++   * input image is no longer needed once the frame is finished (the encode
++   * op completed synchronously and downstream meta transformation happened
++   * inside gst_video_encoder_finish_frame() just above), so drop it here
++   * to let a fixed-ring upstream pool recycle the slot immediately. */
++  gst_buffer_replace (&frame->input_buffer, NULL);
++
++  gst_video_codec_frame_unref (frame);
++
++  if (ret != GST_FLOW_OK) {
++    GST_DEBUG_OBJECT (self, "fails to push one buffer, system_frame_number "
++        "%d: %s", system_frame_number, gst_flow_get_name (ret));
++  }
++
++  return ret;
++}
++
++/* Build the reference-model view of the VBI: the decision logic only ever
++ * needs the #GstAV1EncoderFrame attached to each held codec frame, never the
++ * codec frame itself. Taking that view explicitly is what lets the seam
++ * functions below run without a #GstAV1Encoder instance. */
++static void
++gst_av1_encoder_ref_frames_view (GstVideoCodecFrame ** ref_list,
++    GstAV1EncoderFrame ** ref_frames)
++{
++  gint i;
++
++  for (i = 0; i < GST_AV1_NUM_REF_FRAMES; i++)
++    ref_frames[i] = ref_list[i] ? _GET_FRAME (ref_list[i]) : NULL;
++}
++
++/* The effective reference budget: the number of DISTINCT reference pictures
++ * an inter frame may name, clamped by whatever the accelerator allows and
++ * floored at 1 (a forward-only inter frame always needs LAST).
++ *
++ * bug A3: this is shared on purpose. Reference-name assignment and VBI slot
++ * selection must agree on the budget -- when they did not, names were
++ * limited to num-ref-frames while slot selection happily filled all eight
++ * slots, so the VBI held (and pinned) far more pictures than the
++ * configuration asked for. One function, two callers, never two copies of
++ * the clamp. */
++guint
++gst_av1_encoder_effective_refs (guint num_ref_frames, guint max_num_references)
++{
++  return MAX (MIN (num_ref_frames, max_num_references), 1);
++}
++
++/* Reference-name assignment for forward-only prediction, following the
++ * gstvaav1enc model:
++ *
++ * 1. LAST is the most recent reference (the smallest temporal distance).
++ * 2. GOLDEN is the golden-frame-group anchor (a key frame or a designated
++ *    high-quality anchor), which usually has better quality.
++ * 3. LAST2/LAST3 take the next most recent distinct references while the
++ *    reference budget allows, otherwise they alias LAST.
++ * 4. There are no backward references, so BWDREF, ALTREF2 and ALTREF all
++ *    alias GOLDEN.
++ *
++ * @self is used for logging only and may be %NULL (see the test-seam note in
++ * gstav1encoder.h). @ref_frames is read, never written.
++ */
++gboolean
++gst_av1_encoder_assign_ref_index (GstAV1Encoder * self,
++    GstAV1EncoderFrame ** ref_frames, guint num_ref_frames,
++    guint max_num_references, GstAV1EncoderFrame * av1_frame)
++{
++  struct RefEntry
++  {
++    gint vbi_index;
++    guint32 frame_num;
++  } refs[GST_AV1_NUM_REF_FRAMES];
++  gint num_refs = 0, golden_idx = -1, budget;
++  gint i, j, n;
++
++  for (i = 0; i < GST_AV1_NUM_REF_FRAMES; i++)
++    av1_frame->ref_frame_idx[i] = -1;
++
++  if (av1_frame->type == GST_AV1_KEY_FRAME)
++    return TRUE;
++
++  for (i = 0; i < GST_AV1_NUM_REF_FRAMES; i++) {
++    GstAV1EncoderFrame *ref;
++
++    if (!ref_frames[i])
++      continue;
++
++    ref = ref_frames[i];
++    /* forward-only: every reference precedes the current frame */
++    g_assert (ref->frame_num < av1_frame->frame_num);
++
++    refs[num_refs].vbi_index = i;
++    refs[num_refs].frame_num = ref->frame_num;
++    num_refs++;
++
++    if (ref->is_golden)
++      golden_idx = i;
++  }
++
++  if (num_refs == 0) {
++    GST_ERROR_OBJECT (self, "No reference available for an inter frame");
++    return FALSE;
++  }
++
++  /* sort by frame_num descending (most recent first) */
++  for (i = 1; i < num_refs; i++) {
++    for (j = i; j > 0 && refs[j].frame_num > refs[j - 1].frame_num; j--) {
++      struct RefEntry tmp = refs[j];
++      refs[j] = refs[j - 1];
++      refs[j - 1] = tmp;
++    }
++  }
++
++  if (golden_idx < 0) {
++    GST_WARNING_OBJECT (self, "No golden frame in the reference list, "
++        "using the most recent reference");
++    golden_idx = refs[0].vbi_index;
++  }
++
++  budget = gst_av1_encoder_effective_refs (num_ref_frames,
++      max_num_references);
++
++  /* LAST: the most recent reference */
++  av1_frame->ref_frame_idx[GST_AV1_REF_LAST_FRAME] = refs[0].vbi_index;
++  budget--;
++
++  /* GOLDEN: the group anchor; consumes budget only when distinct */
++  av1_frame->ref_frame_idx[GST_AV1_REF_GOLDEN_FRAME] = golden_idx;
++  if (golden_idx != refs[0].vbi_index) {
++    if (budget > 0) {
++      budget--;
++    } else {
++      av1_frame->ref_frame_idx[GST_AV1_REF_GOLDEN_FRAME] =
++          av1_frame->ref_frame_idx[GST_AV1_REF_LAST_FRAME];
++    }
++  }
++
++  /* LAST2 / LAST3: the next most recent distinct references */
++  n = 1;
++  for (i = GST_AV1_REF_LAST2_FRAME; i <= GST_AV1_REF_LAST3_FRAME; i++) {
++    while (n < num_refs && refs[n].vbi_index == golden_idx)
++      n++;
++    if (n < num_refs && budget > 0) {
++      av1_frame->ref_frame_idx[i] = refs[n].vbi_index;
++      n++;
++      budget--;
++    } else {
++      av1_frame->ref_frame_idx[i] =
++          av1_frame->ref_frame_idx[GST_AV1_REF_LAST_FRAME];
++    }
++  }
++
++  /* No backward references: alias the golden frame */
++  av1_frame->ref_frame_idx[GST_AV1_REF_BWDREF_FRAME] =
++      av1_frame->ref_frame_idx[GST_AV1_REF_GOLDEN_FRAME];
++  av1_frame->ref_frame_idx[GST_AV1_REF_ALTREF2_FRAME] =
++      av1_frame->ref_frame_idx[GST_AV1_REF_GOLDEN_FRAME];
++  av1_frame->ref_frame_idx[GST_AV1_REF_ALTREF_FRAME] =
++      av1_frame->ref_frame_idx[GST_AV1_REF_GOLDEN_FRAME];
++
++  return TRUE;
++}
++
++/* Resolve the reference view a subclass actually binds (bug A2).
++ *
++ * The name map assign_ref_index() produces is a bitstream artefact: seven
++ * names, several of which routinely point at the same picture (LAST3 falls
++ * back on LAST when the budget runs out, the three backward names always
++ * alias GOLDEN, and after a key frame every VBI slot holds the same
++ * picture). An accelerator wants the opposite shape -- each reference
++ * picture bound exactly once -- so every subclass ended up writing the same
++ * deduplication loop plus the same walk of the VBI for the per-slot order
++ * hints. That derivation belongs here, once, next to the assignment it
++ * mirrors.
++ *
++ * Deliberately a separate function rather than a tail of
++ * assign_ref_index(): assign_ref_index() decides, this one only rewrites
++ * what it decided into another shape, and keeping them apart lets the
++ * decision be tested without the projection and vice versa.
++ *
++ * Fills @av1_frame's distinct_refs / num_distinct_refs / ref_distinct_idx /
++ * ref_order_hint. The distinct entries are borrowed pointers into
++ * @ref_frames: no reference is taken, and they are only valid while the VBI
++ * holds them, i.e. for the duration of the encode_frame() call.
++ * Deduplication is by PICTURE identity, not by VBI index -- two slots can
++ * legitimately hold the same picture.
++ *
++ * Must run after assign_ref_index(), over the same @ref_frames view.
++ * @ref_frames is read, never written. */
++void
++gst_av1_encoder_resolve_refs (GstAV1EncoderFrame ** ref_frames,
++    GstAV1EncoderFrame * av1_frame)
++{
++  gint i, j;
++
++  av1_frame->num_distinct_refs = 0;
++
++  for (i = 0; i < GST_AV1_NUM_REF_FRAMES; i++) {
++    av1_frame->distinct_refs[i] = NULL;
++    av1_frame->ref_distinct_idx[i] = -1;
++    /* Per-VBI-slot order hints, for all eight slots. An empty slot
++     * contributes 0: it cannot be named, and the bitstream field has to
++     * carry something deterministic. */
++    av1_frame->ref_order_hint[i] =
++        ref_frames[i] ? (guint8) ref_frames[i]->order_hint : 0;
++  }
++
++  /* order of first appearance scanning LAST..ALTREF, which is the order the
++   * names are laid out in the bitstream */
++  for (i = GST_AV1_REF_LAST_FRAME; i <= GST_AV1_REF_ALTREF_FRAME; i++) {
++    GstAV1EncoderFrame *ref;
++    gint vbi_idx = av1_frame->ref_frame_idx[i];
++
++    if (vbi_idx < 0 || vbi_idx >= GST_AV1_NUM_REF_FRAMES)
++      continue;
++
++    ref = ref_frames[vbi_idx];
++    if (!ref)
++      continue;
++
++    for (j = 0; j < (gint) av1_frame->num_distinct_refs; j++) {
++      if (av1_frame->distinct_refs[j] == ref)
++        break;
++    }
++
++    if (j == (gint) av1_frame->num_distinct_refs)
++      av1_frame->distinct_refs[av1_frame->num_distinct_refs++] = ref;
++
++    av1_frame->ref_distinct_idx[i] = j;
++  }
++}
++
++/* Choose the VBI slot this frame will refresh.
++ *
++ * A key frame takes slot 0 and refreshes the whole VBI (bug A9: the
++ * bitstream says refresh_frame_flags == 0xff, and
++ * gst_av1_encoder_update_ref_list() puts the picture in all eight slots to
++ * match). For an inter frame the choice is bounded by the SAME reference
++ * budget the name assignment uses (bug A3):
++ *
++ * 1. While fewer than (effective refs + 1) DISTINCT pictures are held --
++ *    the references a frame may name, plus the rolling slot the current
++ *    frame lands in -- an empty slot is the cheapest home.
++ * 2. Under the cap with no empty slot, recycle a redundant copy: a slot
++ *    whose picture is also held elsewhere, so evicting it loses nothing.
++ *    A key frame produces seven such copies at once.
++ * 3. At the cap, a picture must actually be retired, so evict the LAST
++ *    copy of the oldest non-golden picture -- the pre-existing recency
++ *    rule, restricted to pictures that a single-slot refresh can really
++ *    remove. The golden anchor is never the victim.
++ * 4. If no picture can be retired (every single-copy picture is the
++ *    anchor), fall back to a redundant copy: one more distinct picture is
++ *    better than losing the reference chain. This is the one case where
++ *    the model holds (cap + 1) pictures, and only key-frame copies can
++ *    cause it -- a picture spread over several slots cannot be retired by
++ *    a refresh that only ever clears one slot.
++ * 5. Otherwise the frame is not kept as a reference at all.
++ *
++ * @ref_frames is read, never written. */
++void
++gst_av1_encoder_find_ref_to_update (GstAV1EncoderFrame ** ref_frames,
++    guint num_ref_frames, guint max_num_references,
++    GstAV1EncoderFrame * av1_frame)
++{
++  GstAV1EncoderFrame *distinct[GST_AV1_NUM_REF_FRAMES] = { NULL, };
++  guint copies[GST_AV1_NUM_REF_FRAMES] = { 0, };
++  guint32 lowest_frame_num = G_MAXUINT32, lowest_dup_frame_num = G_MAXUINT32;
++  gint slot = -1, first_empty = -1, lowest_slot = -1, dup_slot = -1;
++  guint num_distinct = 0, cap;
++  gint i, j;
++
++  av1_frame->update_index = -1;
++
++  if (av1_frame->type == GST_AV1_KEY_FRAME) {
++    av1_frame->update_index = 0;
++    /* Key frames refresh the whole VBI. */
++    av1_frame->refresh_frame_flags = 0xff;
++    return;
++  }
++
++  cap = gst_av1_encoder_effective_refs (num_ref_frames,
++      max_num_references) + 1;
++
++  /* pass 1: occupancy, distinct pictures and their copy counts */
++  for (i = 0; i < GST_AV1_NUM_REF_FRAMES; i++) {
++    GstAV1EncoderFrame *ref = ref_frames[i];
++
++    if (!ref) {
++      if (first_empty < 0)
++        first_empty = i;
++      continue;
++    }
++
++    for (j = 0; j < (gint) num_distinct; j++) {
++      if (distinct[j] == ref)
++        break;
++    }
++
++    if (j == (gint) num_distinct) {
++      distinct[num_distinct] = ref;
++      copies[num_distinct] = 1;
++      num_distinct++;
++      continue;
++    }
++
++    /* a redundant copy of an already-counted picture */
++    copies[j]++;
++    if (ref->frame_num < lowest_dup_frame_num) {
++      lowest_dup_frame_num = ref->frame_num;
++      dup_slot = i;
++    }
++  }
++
++  /* pass 2: the oldest non-golden picture a single-slot refresh can retire,
++   * i.e. one this VBI holds exactly once */
++  for (i = 0; i < GST_AV1_NUM_REF_FRAMES; i++) {
++    GstAV1EncoderFrame *ref = ref_frames[i];
++
++    if (!ref || ref->is_golden)
++      continue;
++
++    for (j = 0; j < (gint) num_distinct; j++) {
++      if (distinct[j] == ref)
++        break;
++    }
++    if (copies[j] > 1)
++      continue;
++
++    if (ref->frame_num < lowest_frame_num) {
++      lowest_frame_num = ref->frame_num;
++      lowest_slot = i;
++    }
++  }
++
++  if (num_distinct < cap && first_empty >= 0)
++    slot = first_empty;
++  else if (num_distinct < cap && dup_slot >= 0)
++    slot = dup_slot;
++  else if (lowest_slot >= 0)
++    slot = lowest_slot;
++  else if (dup_slot >= 0)
++    slot = dup_slot;
++
++  av1_frame->update_index = slot;
++  /* refresh_frame_flags is a bitmask over VBI slots (the bitstream-level
++   * reference model), NOT over the accelerator's DPB slots. */
++  av1_frame->refresh_frame_flags = slot >= 0 ? (1 << slot) : 0;
++}
++
++/* A new golden anchor demotes the previous one. Call with @ref_frames
++ * reflecting the VBI *after* @av1_frame has been recorded in it: the frame
++ * being inserted keeps its own golden flag, every other held reference loses
++ * it. A non-golden @av1_frame leaves the list untouched.
++ *
++ * This is the only seam function that writes through @ref_frames. */
++void
++gst_av1_encoder_demote_golden (GstAV1EncoderFrame ** ref_frames,
++    GstAV1EncoderFrame * av1_frame)
++{
++  gint i;
++
++  if (!av1_frame->is_golden)
++    return;
++
++  for (i = 0; i < GST_AV1_NUM_REF_FRAMES; i++) {
++    GstAV1EncoderFrame *ref;
++
++    if (!ref_frames[i] || ref_frames[i] == av1_frame)
++      continue;
++
++    ref = ref_frames[i];
++    ref->is_golden = FALSE;
++  }
++}
++
++/* The AV1 order_hint field: frame_num masked to OrderHintBits. Wraps every
++ * 1 << AV1ENC_ORDER_HINT_BITS frames, which is why the reference model keys
++ * every temporal comparison on frame_num and never on order_hint. */
++guint32
++gst_av1_encoder_order_hint (guint32 frame_num)
++{
++  return frame_num & ((1 << AV1ENC_ORDER_HINT_BITS) - 1);
++}
++
++static void
++gst_av1_encoder_update_ref_list (GstAV1Encoder * self,
++    GstVideoCodecFrame * frame)
++{
++  GstAV1EncoderPrivate *priv = _GET_PRIV (self);
++  GstAV1EncoderFrame *av1_frame = _GET_FRAME (frame);
++  GstAV1EncoderFrame *ref_frames[GST_AV1_NUM_REF_FRAMES];
++
++  if (av1_frame->type == GST_AV1_KEY_FRAME) {
++    gint i;
++
++    gst_av1_encoder_clear_ref_list (self);
++
++    /* bug A9: a key frame carries refresh_frame_flags == 0xff, so a decoder
++     * puts it in ALL EIGHT reference slots. Model that literally instead of
++     * recording slot 0 alone: the two used to agree only by accident (an
++     * unmodelled slot was never named, and the subclass zero-filled the
++     * order hint of every slot it believed empty), and any change to name
++     * assignment or to the order-hint fill would have desynchronised the
++     * encoder's reference model from the decoder's.
++     *
++     * Refcounting: every slot owns its own reference, so this takes eight.
++     * That is exactly what the existing release paths expect -- both
++     * gst_av1_encoder_clear_ref_list() and the per-slot overwrite below
++     * unref one slot each -- so no shared-reference scheme is needed and
++     * the accounting stays one ref in, one ref out per slot. The eight
++     * slots are the same picture, so this costs one DPB image, not eight;
++     * the input buffer is already dropped in finish_last_frame(). */
++    for (i = 0; i < GST_AV1_NUM_REF_FRAMES; i++)
++      priv->gop.ref_list[i] = gst_video_codec_frame_ref (frame);
++
++    gst_av1_encoder_ref_frames_view (priv->gop.ref_list, ref_frames);
++    gst_av1_encoder_demote_golden (ref_frames, av1_frame);
++    return;
++  }
++
++  if (av1_frame->update_index < 0) {
++    GST_LOG_OBJECT (self, "Frame %d not kept as reference",
++        av1_frame->frame_num);
++    return;
++  }
++
++  if (priv->gop.ref_list[av1_frame->update_index])
++    gst_video_codec_frame_unref (priv->gop.ref_list[av1_frame->update_index]);
++
++  priv->gop.ref_list[av1_frame->update_index] =
++      gst_video_codec_frame_ref (frame);
++
++  gst_av1_encoder_ref_frames_view (priv->gop.ref_list, ref_frames);
++  gst_av1_encoder_demote_golden (ref_frames, av1_frame);
++}
++
++static GstFlowReturn
++gst_av1_encoder_encode_frame (GstAV1Encoder * self, GstVideoCodecFrame * frame,
++    gboolean is_last)
++{
++  GstAV1EncoderPrivate *priv = _GET_PRIV (self);
++  GstAV1EncoderClass *klass = GST_AV1_ENCODER_GET_CLASS (self);
++  GstAV1EncoderFrame *av1_frame = _GET_FRAME (frame);
++  GstAV1EncoderFrame *ref_frames[GST_AV1_NUM_REF_FRAMES];
++  GstFlowReturn ret;
++
++  av1_frame->last_frame = is_last;
++
++  gst_av1_encoder_ref_frames_view (priv->gop.ref_list, ref_frames);
++
++  if (!gst_av1_encoder_assign_ref_index (self, ref_frames,
++          priv->gop.num_ref_frames, priv->config.max_num_references,
++          av1_frame))
++    return GST_FLOW_ERROR;
++
++  /* bug A2: project the name map onto the shape an accelerator binds --
++   * the distinct reference set, the per-name index into it and the
++   * per-slot order hints -- so the subclass consumes a resolved view
++   * instead of re-deriving one from the raw VBI. */
++  gst_av1_encoder_resolve_refs (ref_frames, av1_frame);
++
++  gst_av1_encoder_find_ref_to_update (ref_frames, priv->gop.num_ref_frames,
++      priv->config.max_num_references, av1_frame);
++
++  g_assert (klass->encode_frame);
++  ret = klass->encode_frame (self, frame, av1_frame, priv->gop.ref_list);
++  if (ret != GST_FLOW_OK) {
++    GST_ERROR_OBJECT (self, "Failed to encode the frame: %s",
++        gst_flow_get_name (ret));
++    return ret;
++  }
++
++  gst_av1_encoder_update_ref_list (self, frame);
++
++  g_queue_push_tail (&priv->output_list, gst_video_codec_frame_ref (frame));
++
++  return GST_FLOW_OK;
++}
++
++static GstFlowReturn
++gst_av1_encoder_drain (GstAV1Encoder * self)
++{
++  GstAV1EncoderPrivate *priv = _GET_PRIV (self);
++  GstFlowReturn ret = GST_FLOW_OK;
++
++  GST_DEBUG_OBJECT (self, "Encoder is draining");
++
++  /* No reorder list: every handled frame was encoded immediately, only the
++   * output queue can hold frames back. */
++  while (!g_queue_is_empty (&priv->output_list)) {
++    ret = gst_av1_encoder_finish_last_frame (self);
++    if (ret != GST_FLOW_OK)
++      break;
++  }
++
++  gst_av1_encoder_clear_ref_list (self);
++  /* the next frame starts a fresh GOP */
++  priv->gop.frame_num = 0;
++  priv->gop.frames_since_gf = 0;
++
++  return ret;
++}
++
++static GstFlowReturn
++gst_av1_encoder_configure (GstAV1Encoder * self)
++{
++  GstAV1EncoderPrivate *priv = _GET_PRIV (self);
++  GstAV1EncoderClass *klass = GST_AV1_ENCODER_GET_CLASS (self);
++  GstFlowReturn ret;
++
++  if (!priv->input_state)
++    return GST_FLOW_NOT_NEGOTIATED;
++
++  if (gst_av1_encoder_drain (self) != GST_FLOW_OK)
++    return GST_FLOW_ERROR;
++
++  GST_LOG_OBJECT (self, "Configuring encoder");
++
++  gst_av1_encoder_reset (self);
++
++  /* If not set, generate a key frame every second. gst_av1_encoder_
++   * get_keyframe_period() applies the same auto derivation (bug A4: it is
++   * the single formula every effective-period reader now shares), so this
++   * just captures the result back into priv->gop / priv->prop. */
++  if (priv->gop.keyframe_period == 0) {
++    priv->gop.keyframe_period = gst_av1_encoder_get_keyframe_period (self);
++    GST_OBJECT_LOCK (self);
++    priv->prop.keyframe_period = priv->gop.keyframe_period;
++    GST_OBJECT_UNLOCK (self);
++    g_object_notify_by_pspec (G_OBJECT (self),
++        properties[PROP_KEYFRAME_PERIOD]);
++  }
++
++  if (klass->negotiate) {
++    ret = klass->negotiate (self, priv->input_state);
++    if (ret != GST_FLOW_OK)
++      return ret;
++  }
++
++  g_assert (klass->new_sequence);
++  ret = klass->new_sequence (self, priv->input_state);
++  if (ret != GST_FLOW_OK)
++    return ret;
++
++  /* the accelerator limits are known now */
++  if (priv->gop.num_ref_frames > priv->config.max_num_references) {
++    priv->gop.num_ref_frames = MAX (priv->config.max_num_references, 1);
++    GST_INFO_OBJECT (self, "Lowering num-ref-frames to %d",
++        priv->gop.num_ref_frames);
++  }
++
++  /* latency */
++  {
++    GstVideoEncoder *encoder = GST_VIDEO_ENCODER (self);
++    guint frames_latency = priv->config.preferred_output_delay;
++    GstClockTime latency = gst_util_uint64_scale (frames_latency,
++        priv->fps_d * GST_SECOND, priv->fps_n);
++    gst_video_encoder_set_latency (encoder, latency, latency);
++  }
++
++  return GST_FLOW_OK;
++}
++
++static GstFlowReturn
++gst_av1_encoder_handle_frame (GstVideoEncoder * encoder,
++    GstVideoCodecFrame * frame)
++{
++  GstAV1Encoder *self = GST_AV1_ENCODER (encoder);
++  GstAV1EncoderPrivate *priv = _GET_PRIV (self);
++  GstAV1EncoderClass *klass = GST_AV1_ENCODER_GET_CLASS (self);
++  GstFlowReturn ret = GST_FLOW_ERROR;
++  GstAV1EncoderFrame *av1_frame;
++  gboolean force_key;
++
++  GST_LOG_OBJECT (encoder, "handle frame id %d, dts %" GST_TIME_FORMAT
++      ", pts %" GST_TIME_FORMAT, frame->system_frame_number,
++      GST_TIME_ARGS (GST_BUFFER_DTS (frame->input_buffer)),
++      GST_TIME_ARGS (GST_BUFFER_PTS (frame->input_buffer)));
++
++  if (g_atomic_int_compare_and_exchange (&priv->need_configure, TRUE, FALSE)) {
++    if (gst_av1_encoder_configure (self) != GST_FLOW_OK) {
++      gst_video_encoder_finish_frame (encoder, frame);
++      return GST_FLOW_ERROR;
++    }
++  }
++
++  /* trap 9b: a property write never resets the GOP; the live values are
++   * re-read here so e.g. a keyframe-period retarget just takes effect at
++   * the next comparison, and a rate-control retarget in the subclass never
++   * routes through gst_av1_encoder_configure(). Only a caps/format change
++   * raises need_configure. */
++  GST_OBJECT_LOCK (self);
++  priv->gop.keyframe_period = priv->prop.keyframe_period;
++  priv->gop.gf_group_size = priv->prop.gf_group_size;
++  priv->gop.num_ref_frames = MIN (priv->prop.num_ref_frames,
++      MAX (priv->config.max_num_references, 1));
++  GST_OBJECT_UNLOCK (self);
++
++  /* 0 means auto: one key frame per second (bug A4: routed through the
++   * accessor so this matches every other effective-period reader) */
++  if (priv->gop.keyframe_period == 0)
++    priv->gop.keyframe_period = gst_av1_encoder_get_keyframe_period (self);
++
++  av1_frame = gst_av1_encoder_frame_new ();
++  gst_video_codec_frame_set_user_data (frame, av1_frame,
++      gst_av1_encoder_frame_unref);
++
++  if (klass->new_output) {
++    ret = klass->new_output (self, frame, av1_frame);
++    if (ret != GST_FLOW_OK)
++      goto error_new_frame;
++  }
++
++  force_key = GST_VIDEO_CODEC_FRAME_IS_FORCE_KEYFRAME (frame);
++
++  if (force_key || priv->gop.frame_num >= priv->gop.keyframe_period)
++    priv->gop.frame_num = 0;
++
++  av1_frame->frame_num = priv->gop.frame_num;
++  av1_frame->force_keyframe = force_key;
++  av1_frame->type = priv->gop.frame_num == 0 ?
++      GST_AV1_KEY_FRAME : GST_AV1_INTER_FRAME;
++  av1_frame->order_hint = gst_av1_encoder_order_hint (av1_frame->frame_num);
++
++  /* golden-frame group: the key frame anchors a group; a new anchor is
++   * designated every gf_group_size frames. */
++  if (av1_frame->type == GST_AV1_KEY_FRAME) {
++    av1_frame->is_golden = TRUE;
++    priv->gop.frames_since_gf = 0;
++  } else if (priv->gop.frames_since_gf >= priv->gop.gf_group_size) {
++    av1_frame->is_golden = TRUE;
++    priv->gop.frames_since_gf = 0;
++  }
++
++  GST_LOG_OBJECT (self, "frame %u: type %s, order_hint %u%s",
++      av1_frame->frame_num,
++      av1_frame->type == GST_AV1_KEY_FRAME ? "key" : "inter",
++      av1_frame->order_hint, av1_frame->is_golden ? " (golden)" : "");
++
++  ret = gst_av1_encoder_encode_frame (self, frame, FALSE);
++  if (ret != GST_FLOW_OK)
++    goto error_encode;
++
++  priv->gop.frame_num++;
++  priv->gop.frames_since_gf++;
++
++  /* pass it to the output list and we should not use it again. */
++  frame = NULL;
++
++  while (ret == GST_FLOW_OK && g_queue_get_length (&priv->output_list) >
++      priv->config.preferred_output_delay)
++    ret = gst_av1_encoder_finish_last_frame (self);
++
++  if (ret != GST_FLOW_OK)
++    goto error_push_buffer;
++
++  return ret;
++
++error_new_frame:
++  {
++    GST_ELEMENT_ERROR (encoder, STREAM, ENCODE,
++        ("Failed to create the input frame."), (NULL));
++    gst_clear_buffer (&frame->output_buffer);
++    gst_video_encoder_finish_frame (encoder, frame);
++    return GST_FLOW_ERROR;
++  }
++error_encode:
++  {
++    GST_ELEMENT_ERROR (encoder, STREAM, ENCODE,
++        ("Failed to encode the frame %s.", gst_flow_get_name (ret)), (NULL));
++    gst_clear_buffer (&frame->output_buffer);
++    gst_video_encoder_finish_frame (encoder, frame);
++    return ret;
++  }
++error_push_buffer:
++  {
++    GST_ELEMENT_ERROR (encoder, STREAM, ENCODE,
++        ("Failed to finish frame."), (NULL));
++    return ret;
++  }
++}
++
++static gboolean
++gst_av1_encoder_flush (GstVideoEncoder * encoder)
++{
++  GstAV1Encoder *self = GST_AV1_ENCODER (encoder);
++  GstAV1EncoderPrivate *priv = _GET_PRIV (self);
++
++  gst_av1_encoder_flush_lists (self);
++
++  /* begin from a key frame after flush. */
++  priv->gop.frame_num = 0;
++  priv->gop.frames_since_gf = 0;
++
++  return TRUE;
++}
++
++static GstFlowReturn
++gst_av1_encoder_finish (GstVideoEncoder * encoder)
++{
++  return gst_av1_encoder_drain (GST_AV1_ENCODER (encoder));
++}
++
++static void
++gst_av1_encoder_init (GstAV1Encoder * self)
++{
++  GstAV1EncoderPrivate *priv = _GET_PRIV (self);
++
++  g_queue_init (&priv->output_list);
++
++  priv->config.max_num_references = 1;
++  priv->config.preferred_output_delay = 0;
++
++  /* default values */
++  priv->prop.keyframe_period = AV1ENC_KEYFRAME_PERIOD_DEFAULT;
++  priv->prop.num_ref_frames = AV1ENC_NUM_REF_FRAMES_DEFAULT;
++  priv->prop.gf_group_size = AV1ENC_GF_GROUP_SIZE_DEFAULT;
++}
++
++static void
++gst_av1_encoder_dispose (GObject * object)
++{
++  gst_av1_encoder_flush_lists (GST_AV1_ENCODER (object));
++
++  G_OBJECT_CLASS (parent_class)->dispose (object);
++}
++
++static void
++gst_av1_encoder_get_property (GObject * object, guint property_id,
++    GValue * value, GParamSpec * pspec)
++{
++  GstAV1Encoder *self = GST_AV1_ENCODER (object);
++  GstAV1EncoderPrivate *priv = _GET_PRIV (self);
++
++  GST_OBJECT_LOCK (self);
++  switch (property_id) {
++    case PROP_KEYFRAME_PERIOD:
++      g_value_set_uint (value, priv->prop.keyframe_period);
++      break;
++    case PROP_NUM_REF_FRAMES:
++      g_value_set_uint (value, priv->prop.num_ref_frames);
++      break;
++    case PROP_GF_GROUP_SIZE:
++      g_value_set_uint (value, priv->prop.gf_group_size);
++      break;
++    default:
++      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
++      break;
++  }
++  GST_OBJECT_UNLOCK (self);
++}
++
++static void
++gst_av1_encoder_set_property (GObject * object, guint property_id,
++    const GValue * value, GParamSpec * pspec)
++{
++  GstAV1Encoder *self = GST_AV1_ENCODER (object);
++  GstAV1EncoderPrivate *priv = _GET_PRIV (self);
++
++  /* trap 9b: none of these raise need_configure. They are re-read at the
++   * top of handle_frame(), so a live change (e.g. an ABR keyframe-period
++   * retarget) applies to the running GOP without draining the encoder or
++   * resetting the GOP index -- which is exactly the base-class-reconfigure
++   * IDR source the h264 element had to patch out. */
++  GST_OBJECT_LOCK (self);
++  switch (property_id) {
++    case PROP_KEYFRAME_PERIOD:
++      priv->prop.keyframe_period = g_value_get_uint (value);
++      break;
++    case PROP_NUM_REF_FRAMES:
++      priv->prop.num_ref_frames = g_value_get_uint (value);
++      break;
++    case PROP_GF_GROUP_SIZE:
++      priv->prop.gf_group_size = g_value_get_uint (value);
++      break;
++    default:
++      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
++      break;
++  }
++  GST_OBJECT_UNLOCK (self);
++}
++
++static void
++gst_av1_encoder_class_init (GstAV1EncoderClass * klass)
++{
++  GstVideoEncoderClass *encoder_class = GST_VIDEO_ENCODER_CLASS (klass);
++  GObjectClass *object_class = G_OBJECT_CLASS (klass);
++  GParamFlags param_flags = G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS
++      | G_PARAM_CONSTRUCT | GST_PARAM_MUTABLE_PLAYING;
++
++  object_class->get_property = gst_av1_encoder_get_property;
++  object_class->set_property = gst_av1_encoder_set_property;
++  object_class->dispose = gst_av1_encoder_dispose;
++
++  encoder_class->start = GST_DEBUG_FUNCPTR (gst_av1_encoder_start);
++  encoder_class->stop = GST_DEBUG_FUNCPTR (gst_av1_encoder_stop);
++  encoder_class->set_format = GST_DEBUG_FUNCPTR (gst_av1_encoder_set_format);
++  encoder_class->handle_frame =
++      GST_DEBUG_FUNCPTR (gst_av1_encoder_handle_frame);
++  encoder_class->flush = GST_DEBUG_FUNCPTR (gst_av1_encoder_flush);
++  encoder_class->finish = GST_DEBUG_FUNCPTR (gst_av1_encoder_finish);
++
++  /**
++   * GstAV1Encoder:idr-period:
++   *
++   * Maximum number of frames between two key frames. Named after the h26x
++   * sibling encoders' property for interface uniformity; AV1 has no IDR
++   * concept, this is the key frame period.
++   *
++   * Set 0 to auto-calculate it (one key frame per second).
++   *
++   * Since: 1.28
++   */
++  properties[PROP_KEYFRAME_PERIOD] = g_param_spec_uint ("idr-period",
++      "Maximum GOP size", "Maximum number of frames between two key frames",
++      0, MIN (G_MAXINT, 1 << 30), AV1ENC_KEYFRAME_PERIOD_DEFAULT, param_flags);
++
++  /**
++   * GstAV1Encoder:num-ref-frames:
++   *
++   * The number of distinct reference frames an inter frame may use (the
++   * LAST/LAST2/LAST3/GOLDEN forward set). Higher values will usually result
++   * in a more efficient compression, at the cost of encoding time. The
++   * effective value is clamped by the accelerator's limits.
++   *
++   * Since: 1.28
++   */
++  properties[PROP_NUM_REF_FRAMES] = g_param_spec_uint ("num-ref-frames",
++      "Number of reference frames",
++      "Number of distinct frames referenced by inter frames", 1, 4,
++      AV1ENC_NUM_REF_FRAMES_DEFAULT, param_flags);
++
++  /**
++   * GstAV1Encoder:gf-group-size:
++   *
++   * The length of a golden-frame group: every this many frames a new frame
++   * is designated as the GOLDEN reference anchor.
++   *
++   * Since: 1.28
++   */
++  properties[PROP_GF_GROUP_SIZE] = g_param_spec_uint ("gf-group-size",
++      "Golden frame group size",
++      "Number of frames between two golden-frame anchors", 1, 32,
++      AV1ENC_GF_GROUP_SIZE_DEFAULT, param_flags);
++
++  g_object_class_install_properties (object_class, N_PROPERTIES, properties);
++
++  gst_type_mark_as_plugin_api (GST_TYPE_AV1_ENCODER, 0);
++}
++
++/**
++ * gst_av1_encoder_set_max_num_references:
++ * @self: A #GstAV1Encoder
++ * @max_refs: the maximum number of distinct reference pictures per frame
++ *
++ * Set the maximum number of distinct reference pictures allowed by the
++ * accelerator.
++ */
++void
++gst_av1_encoder_set_max_num_references (GstAV1Encoder * self, guint max_refs)
++{
++  GstAV1EncoderPrivate *priv;
++
++  g_return_if_fail (GST_IS_AV1_ENCODER (self));
++
++  priv = _GET_PRIV (self);
++
++  priv->config.max_num_references = max_refs;
++}
++
++/**
++ * gst_av1_encoder_set_preferred_output_delay:
++ * @self: a #GstAV1Encoder
++ * @delay: the number of frames to hold and process
++ *
++ * Some accelerators have better performance if they hold a group of frames
++ * to process.
++ */
++void
++gst_av1_encoder_set_preferred_output_delay (GstAV1Encoder * self, guint delay)
++{
++  GstAV1EncoderPrivate *priv;
++
++  g_return_if_fail (GST_IS_AV1_ENCODER (self));
++
++  priv = _GET_PRIV (self);
++  priv->config.preferred_output_delay = delay;
++}
++
++/**
++ * gst_av1_encoder_is_live:
++ * @self: a #GstAV1Encoder
++ *
++ * Returns: whether the current stream is live
++ */
++gboolean
++gst_av1_encoder_is_live (GstAV1Encoder * self)
++{
++  GstAV1EncoderPrivate *priv;
++
++  g_return_val_if_fail (GST_IS_AV1_ENCODER (self), FALSE);
++
++  priv = _GET_PRIV (self);
++  return priv->is_live;
++}
++
++/**
++ * gst_av1_encoder_reconfigure:
++ * @self: a #GstAV1Encoder
++ * @force: whether the configuration will run now or on the next input frame
++ *
++ * Through this method the subclass can request the encoder reconfiguration
++ * and downstream renegotiation. This drains the encoder and starts a fresh
++ * sequence, so it is meant for format/profile changes only -- rate-control
++ * value changes must go through the subclass's live update path instead.
++ */
++gboolean
++gst_av1_encoder_reconfigure (GstAV1Encoder * self, gboolean force)
++{
++  GstAV1EncoderPrivate *priv;
++
++  g_return_val_if_fail (GST_IS_AV1_ENCODER (self), FALSE);
++
++  priv = _GET_PRIV (self);
++
++  if (!force) {
++    g_atomic_int_set (&priv->need_configure, TRUE);
++    return TRUE;
++  } else {
++    if (g_atomic_int_compare_and_exchange (&priv->need_configure, TRUE, FALSE)) {
++      return (gst_av1_encoder_configure (self) == GST_FLOW_OK);
++    }
++    return TRUE;
++  }
++}
++
++/**
++ * gst_av1_encoder_get_keyframe_period:
++ * @self: a #GstAV1Encoder
++ *
++ * Returns the EFFECTIVE key frame period, without the marshalling burden of
++ * GObject properties: if the "idr-period" property is 0 (auto), this
++ * resolves it against the negotiated framerate the same way
++ * gst_av1_encoder_configure() seeds priv->gop.keyframe_period (one key
++ * frame per second), instead of handing the caller a literal 0. Every
++ * internal reader of the effective period (rate-control setup, per-frame
++ * GOP-remaining accounting) must go through this accessor rather than
++ * re-deriving the formula locally (bug A4: one such site used to read the
++ * raw property and silently treat idr-period=0 as "no key frames").
++ *
++ * To read the raw, user-set property value (0 included), use
++ * g_object_get() on "idr-period" instead.
++ *
++ * Returns: the effective key frame period
++ */
++guint32
++gst_av1_encoder_get_keyframe_period (GstAV1Encoder * self)
++{
++  GstAV1EncoderPrivate *priv;
++  guint32 ret;
++
++  g_return_val_if_fail (GST_IS_AV1_ENCODER (self), -1);
++
++  priv = _GET_PRIV (self);
++
++  GST_OBJECT_LOCK (self);
++  ret = priv->prop.keyframe_period;
++  GST_OBJECT_UNLOCK (self);
++
++  /* 0 means auto: derive one key frame per second from the negotiated fps,
++   * the same formula gst_av1_encoder_configure() uses. Only reached once
++   * gst_av1_encoder_set_format() has run (fps_d is never 0 after that). */
++  if (ret == 0 && priv->fps_d > 0)
++    ret = (priv->fps_n + priv->fps_d - 1) / priv->fps_d;
++
++  return ret;
++}
+diff --git a/subprojects/gst-plugins-bad/ext/vulkan/base/gstav1encoder.h b/subprojects/gst-plugins-bad/ext/vulkan/base/gstav1encoder.h
+new file mode 100644
+index 00000000..2387e1f1
+--- /dev/null
++++ b/subprojects/gst-plugins-bad/ext/vulkan/base/gstav1encoder.h
+@@ -0,0 +1,328 @@
++/* GStreamer
++ * Copyright (C) 2026 Igalia, S.L.
++ *
++ * This library is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU Library General Public
++ * License as published by the Free Software Foundation; either
++ * version 2 of the License, or (at your option) any later version.
++ *
++ * This library is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++ * Library General Public License for more details.
++ *
++ * You should have received a copy of the GNU Library General Public
++ * License along with this library; if not, write to the
++ * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
++ * Boston, MA 02110-1301, USA.
++ */
++
++#pragma once
++
++#include <gst/codecparsers/gstav1parser.h>
++#include <gst/video/gstvideoencoder.h>
++
++G_BEGIN_DECLS
++
++typedef struct _GstAV1Encoder GstAV1Encoder;
++typedef struct _GstAV1EncoderClass GstAV1EncoderClass;
++typedef struct _GstAV1EncoderFrame GstAV1EncoderFrame;
++
++#define GST_TYPE_AV1_ENCODER            (gst_av1_encoder_get_type())
++#define GST_AV1_ENCODER(obj)            (G_TYPE_CHECK_INSTANCE_CAST((obj), GST_TYPE_AV1_ENCODER, GstAV1Encoder))
++#define GST_AV1_ENCODER_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST((klass), GST_TYPE_AV1_ENCODER, GstAV1EncoderClass))
++#define GST_AV1_ENCODER_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS((obj), GST_TYPE_AV1_ENCODER, GstAV1EncoderClass))
++#define GST_IS_AV1_ENCODER(obj)         (G_TYPE_CHECK_INSTANCE_TYPE((obj), GST_TYPE_AV1_ENCODER))
++#define GST_IS_AV1_ENCODER_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass), GST_TYPE_AV1_ENCODER))
++
++_GLIB_DEFINE_AUTOPTR_CHAINUP (GstAV1Encoder, GstVideoEncoder)
++G_DEFINE_AUTOPTR_CLEANUP_FUNC (GstAV1EncoderClass, g_type_class_unref)
++
++struct _GstAV1Encoder
++{
++  GstVideoEncoder parent_instance;
++};
++
++/**
++ * GstAV1EncoderClass:
++ *
++ * The opaque #GstAV1EncoderClass data structure.
++ *
++ * Since: 1.28
++ */
++struct _GstAV1EncoderClass
++{
++  GstVideoEncoderClass parent_class;
++
++  /**
++   * GstAV1EncoderClass::negotiate:
++   * @encoder: a #GstAV1Encoder
++   * @in_state: (transfer none): the input #GstVideoCodecState
++   *
++   * Optional. Allows the subclass to negotiate the stream properties with
++   * downstream. The default implementation validates that AV1 Main profile
++   * is acceptable downstream.
++   *
++   * Since: 1.28
++   */
++  GstFlowReturn       (*negotiate)                           (GstAV1Encoder * encoder,
++                                                              GstVideoCodecState * in_state);
++
++  /**
++   * GstAV1EncoderClass::new_sequence:
++   * @encoder: a #GstAV1Encoder
++   * @in_state: (transfer none): the input #GstVideoCodecState
++   *
++   * Mandatory. Called when a new sequence starts (stream start or
++   * reconfiguration). The subclass is expected to open a session with the
++   * hardware accelerator, verify its limitations (calling
++   * gst_av1_encoder_set_max_num_references()), build the sequence header,
++   * and call gst_video_encoder_set_output_state() to (re)negotiate
++   * downstream.
++   *
++   * AV1 session parameters are not updatable, so a change of the coded
++   * resolution or profile requires the subclass to tear the previous
++   * session down and create a fresh one here.
++   *
++   * Since: 1.28
++   */
++  GstFlowReturn       (*new_sequence)                        (GstAV1Encoder * encoder,
++                                                              GstVideoCodecState * in_state);
++
++  /**
++   * GstAV1EncoderClass::new_output:
++   * @encoder: a #GstAV1Encoder
++   * @frame: (transfer none): a #GstVideoCodecFrame
++   * @av1_frame: (transfer none): a #GstAV1EncoderFrame
++   *
++   * Optional. Called whenever a new #GstAV1EncoderFrame is created. Subclass
++   * can set implementation specific user data on #GstAV1EncoderFrame via
++   * gst_av1_encoder_frame_set_user_data()
++   *
++   * Since: 1.28
++   */
++  GstFlowReturn       (*new_output)                          (GstAV1Encoder * encoder,
++                                                              GstVideoCodecFrame * frame,
++                                                              GstAV1EncoderFrame * av1_frame);
++
++  /**
++   * GstAV1EncoderClass::encode_frame:
++   * @encoder: a #GstAV1Encoder
++   * @frame: (transfer none): a #GstVideoCodecFrame
++   * @av1_frame: (transfer none): a #GstAV1EncoderFrame
++   * @ref_list: (transfer none) (array fixed-size=8): the virtual buffer
++   *   index (VBI), i.e. the 8-slot AV1 reference frame list. Entries are
++   *   %NULL or a #GstVideoCodecFrame currently held as reference.
++   *
++   * Mandatory. Provide the frame to be encoded. @av1_frame carries the
++   * frame type, order hint, the 7-entry reference-name to VBI-slot map
++   * (#GstAV1EncoderFrame.ref_frame_idx) and the refresh_frame_flags
++   * bitmask already computed by the base class.
++   *
++   * It also carries the *resolved* reference view
++   * (#GstAV1EncoderFrame.distinct_refs, .num_distinct_refs,
++   * .ref_distinct_idx and .ref_order_hint): the deduplicated set of
++   * referenced pictures, the per-name index into it, and the per-slot
++   * order hints. A subclass binding one accelerator reference per distinct
++   * picture should consume those rather than re-deriving them from
++   * @ref_list, which is kept for subclasses that need the codec frames
++   * themselves.
++   *
++   * Since: 1.28
++   */
++  GstFlowReturn       (*encode_frame)                        (GstAV1Encoder * encoder,
++                                                              GstVideoCodecFrame * frame,
++                                                              GstAV1EncoderFrame * av1_frame,
++                                                              GstVideoCodecFrame ** ref_list);
++
++  /**
++   * GstAV1EncoderClass::prepare_output:
++   * @encoder: a #GstAV1Encoder
++   * @frame: (transfer none): a #GstVideoCodecFrame
++   *
++   * Optional. It's called before pushing @frame downstream. It's intended to
++   * assemble the temporal unit (temporal delimiter OBU, sequence header OBU
++   * on key frames, frame OBU) into @frame's output buffer.
++   *
++   * Since: 1.28
++   */
++  GstFlowReturn       (*prepare_output)                      (GstAV1Encoder * encoder,
++                                                              GstVideoCodecFrame * frame);
++
++  /**
++   * GstAV1EncoderClass::reset:
++   * @encoder: a #GstAV1Encoder
++   *
++   * Optional. It's called when resetting the global state of the encoder.
++   * Allows the subclass to re-initialize its internal variables.
++   *
++   * Since: 1.28
++   */
++  void                (*reset)                               (GstAV1Encoder * encoder);
++
++  /*< private > */
++  gpointer padding[GST_PADDING_LARGE];
++};
++
++GType                gst_av1_encoder_get_type                (void);
++
++void                 gst_av1_encoder_set_max_num_references  (GstAV1Encoder * self,
++                                                              guint max_refs);
++
++void                 gst_av1_encoder_set_preferred_output_delay
++                                                             (GstAV1Encoder * self,
++                                                              guint delay);
++
++gboolean             gst_av1_encoder_is_live                 (GstAV1Encoder * self);
++
++gboolean             gst_av1_encoder_reconfigure             (GstAV1Encoder * self,
++                                                              gboolean force);
++
++guint32              gst_av1_encoder_get_keyframe_period     (GstAV1Encoder * self);
++
++/* AV1 encoder frame */
++
++#define GST_TYPE_AV1_ENCODER_FRAME    (gst_av1_encoder_frame_get_type ())
++#define GST_IS_AV1_ENCODER_FRAME(obj) (GST_IS_MINI_OBJECT_TYPE (obj, GST_TYPE_AV1_ENCODER_FRAME))
++#define GST_AV1_ENCODER_FRAME(obj)    ((GstAV1EncoderFrame *)obj)
++
++/**
++ * GstAV1EncoderFrame:
++ *
++ * Represents a frame that is going to be encoded with AV1.
++ *
++ * Since: 1.28
++ */
++struct _GstAV1EncoderFrame
++{
++  GstMiniObject parent;
++
++  /*< private >*/
++  /* GST_AV1_KEY_FRAME or GST_AV1_INTER_FRAME (MVP: no intra-only, no
++   * switch frames, no show_existing_frame) */
++  GstAV1FrameType type;
++
++  /* Frame number since the last key frame. 0 means key frame. */
++  guint32 frame_num;
++
++  /* order_hint value, modulo 1 << OrderHintBits */
++  guint32 order_hint;
++
++  /* Whether this frame is the golden-frame-group anchor. */
++  gboolean is_golden;
++
++  gboolean force_keyframe;
++  gboolean last_frame;
++
++  /* Reference-name to VBI-slot map, indexed by #GstAV1ReferenceFrame
++   * (index 0, INTRA_FRAME, is unused). -1 when the name is unused. */
++  gint ref_frame_idx[GST_AV1_NUM_REF_FRAMES];
++
++  /* The VBI slot this frame refreshes, or -1 when the frame is not kept
++   * as a reference. */
++  gint update_index;
++
++  /* Bitmask over the 8 VBI slots this frame refreshes. */
++  guint8 refresh_frame_flags;
++
++  /* The resolved reference view, computed by the base class right after the
++   * names have been assigned (gst_av1_encoder_resolve_refs()). It is the
++   * shape an accelerator binds: reference names routinely alias the same
++   * picture -- LAST3 falls back on LAST when the budget runs out, the three
++   * backward names always alias GOLDEN, and after a key frame every VBI
++   * slot holds the same picture -- while a hardware DPB slot must be bound
++   * exactly once. */
++
++  /* The referenced pictures, deduplicated by identity, in order of first
++   * appearance scanning the names LAST..ALTREF. Borrowed pointers into the
++   * VBI: valid for the duration of the encode_frame() call, no reference
++   * taken. Empty on a key frame. */
++  GstAV1EncoderFrame *distinct_refs[GST_AV1_NUM_REF_FRAMES];
++
++  /* Number of valid entries in @distinct_refs. */
++  guint num_distinct_refs;
++
++  /* Indexed by reference name, like @ref_frame_idx: the @distinct_refs
++   * entry this name resolves to, or -1 when the name is unused
++   * (GST_AV1_REF_INTRA_FRAME, and every name on a key frame). */
++  gint ref_distinct_idx[GST_AV1_NUM_REF_FRAMES];
++
++  /* Indexed by VBI slot: the order hint of the picture that slot holds,
++   * 0 for an empty slot. */
++  guint8 ref_order_hint[GST_AV1_NUM_REF_FRAMES];
++
++  gpointer user_data;
++  GDestroyNotify user_data_destroy_notify;
++};
++
++GType                gst_av1_encoder_frame_get_type          (void);
++
++GstAV1EncoderFrame  *gst_av1_encoder_frame_new               (void);
++
++/*< private >*/
++/* internal: test seam
++ *
++ * The AV1 reference-model decision logic -- reference-name assignment, VBI
++ * slot selection, golden demotion and the order-hint mask -- factored out of
++ * the instance so that it reads only its explicit inputs. Everything it needs
++ * is the reference-model view of the VBI (the #GstAV1EncoderFrame attached to
++ * each held codec frame) plus the reference budget, so the whole model can be
++ * exercised with no accelerator, no #GstAV1Encoder instance and no VkDevice.
++ *
++ * This is NOT public API and carries no export macro: it is hidden in the
++ * built plugin, so the unit test reaches it by including gstav1encoder.c
++ * directly (see tests/check/libs/vkvideoencodeav1refs.c). The declarations
++ * are kept here as the documented shape of the seam.
++ */
++
++G_GNUC_INTERNAL
++gboolean             gst_av1_encoder_assign_ref_index        (GstAV1Encoder * self,
++                                                              GstAV1EncoderFrame ** ref_frames,
++                                                              guint num_ref_frames,
++                                                              guint max_num_references,
++                                                              GstAV1EncoderFrame * av1_frame);
++
++G_GNUC_INTERNAL
++guint                gst_av1_encoder_effective_refs          (guint num_ref_frames,
++                                                              guint max_num_references);
++
++G_GNUC_INTERNAL
++void                 gst_av1_encoder_resolve_refs            (GstAV1EncoderFrame ** ref_frames,
++                                                              GstAV1EncoderFrame * av1_frame);
++
++G_GNUC_INTERNAL
++void                 gst_av1_encoder_find_ref_to_update      (GstAV1EncoderFrame ** ref_frames,
++                                                              guint num_ref_frames,
++                                                              guint max_num_references,
++                                                              GstAV1EncoderFrame * av1_frame);
++
++G_GNUC_INTERNAL
++void                 gst_av1_encoder_demote_golden           (GstAV1EncoderFrame ** ref_frames,
++                                                              GstAV1EncoderFrame * av1_frame);
++
++G_GNUC_INTERNAL
++guint32              gst_av1_encoder_order_hint              (guint32 frame_num);
++
++void                 gst_av1_encoder_frame_set_user_data     (GstAV1EncoderFrame * frame,
++                                                              gpointer user_data,
++                                                              GDestroyNotify notify);
++
++static inline gpointer
++gst_av1_encoder_frame_get_user_data (GstAV1EncoderFrame * frame)
++{
++  return frame->user_data;
++}
++
++static inline GstAV1EncoderFrame *
++gst_av1_encoder_frame_ref (GstAV1EncoderFrame * frame)
++{
++  return (GstAV1EncoderFrame *) gst_mini_object_ref (GST_MINI_OBJECT_CAST (frame));
++}
++
++static inline void
++gst_av1_encoder_frame_unref (void * frame)
++{
++  gst_mini_object_unref (GST_MINI_OBJECT_CAST (frame));
++}
++
++G_END_DECLS
+diff --git a/subprojects/gst-plugins-bad/ext/vulkan/vkav1enc.c b/subprojects/gst-plugins-bad/ext/vulkan/vkav1enc.c
+new file mode 100644
+index 00000000..fb56a309
+--- /dev/null
++++ b/subprojects/gst-plugins-bad/ext/vulkan/vkav1enc.c
+@@ -0,0 +1,2316 @@
++/* GStreamer
++ * Copyright (C) 2026 Igalia, S.L.
++ *
++ * This library is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU Library General Public
++ * License as published by the Free Software Foundation; either
++ * version 2 of the License, or (at your option) any later version.
++ *
++ * This library is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++ * Library General Public License for more details.
++ *
++ * You should have received a copy of the GNU Library General Public
++ * License along with this library; if not, write to the
++ * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
++ * Boston, MA 02110-1301, USA.
++ */
++
++/**
++ * SECTION:element-vkav1enc
++ * @title: vkav1enc
++ * @short_description: A Vulkan based AV1 video encoder
++ *
++ * vkav1enc encodes raw video surfaces into AV1 bitstreams using
++ * Vulkan video extensions.
++ *
++ *
++ * ## Example launch line
++ * ```
++ * gst-launch-1.0 videotestsrc num-buffers=60 ! timeoverlay ! vulkanupload ! vulkanav1enc ! av1parse ! matroskamux ! filesink location=test.mkv
++ * ```
++ *
++ * Since: 1.28
++ */
++
++/*
++ * TODO:
++ *
++ * + support multiple tiles
++ * + support 10-bit (Main profile high bit depth)
++ * + support bidirectional compound prediction (B frames)
++ * + support show_existing_frame
++ */
++
++#ifdef HAVE_CONFIG_H
++#include "config.h"
++#endif
++
++#include "vkav1enc.h"
++
++#include <gst/codecparsers/gstav1bitwriter.h>
++#include <gst/codecparsers/gstav1parser.h>
++#include <gst/video/video-color.h>
++
++#include "base/gstav1encoder.h"
++#include "gst/vulkan/gstvkencoder-private.h"
++#include "gstvkvideocaps.h"
++#include "gstvulkanelements.h"
++
++typedef struct _GstVulkanAV1Encoder GstVulkanAV1Encoder;
++typedef struct _GstVulkanAV1EncoderClass GstVulkanAV1EncoderClass;
++typedef struct _GstVulkanAV1EncoderFrame GstVulkanAV1EncoderFrame;
++
++enum
++{
++  PROP_BITRATE = 1,
++  PROP_QUALITY,
++  PROP_RATECONTROL,
++  PROP_QP_I,
++  PROP_QP_P,
++  PROP_MAX_QP,
++  PROP_MIN_QP,
++  N_PROPERTIES
++};
++
++static GParamSpec *properties[N_PROPERTIES];
++
++/* M0.5 measured: virtualBufferSizeInMs is the tracking-tightness knob
++ * (1000 ms -> +10.4% error, 200 ms -> +4.1%, steady state +0.4%), and
++ * initialVirtualBufferSizeInMs is ignored by the NVIDIA driver.
++ * (trap 11: small VBV, 200 ms) */
++#define AV1ENC_VBV_SIZE_MS 200
++
++struct _GstVulkanAV1Encoder
++{
++  /*< private > */
++  GstAV1Encoder parent;
++
++  GstVideoCodecState *in_state;
++
++  gint coded_width;
++  gint coded_height;
++  /* the input video info with the coded (aligned) size, handed to
++   * gst_vulkan_encoder_encode() */
++  GstVideoInfo coded_info;
++
++  GstVulkanInstance *instance;
++  GstVulkanDevice *device;
++  GstVulkanQueue *encode_queue;
++  GstVulkanEncoder *encoder;
++
++  /* sequence configuration */
++  GstVulkanVideoProfile profile;
++  gsize coded_buffer_size;
++
++  struct
++  {
++    StdVideoAV1SequenceHeader seq_hdr;
++    StdVideoAV1ColorConfig color_config;
++    StdVideoEncodeAV1DecoderModelInfo model_info;
++    StdVideoEncodeAV1OperatingPointInfo op_info;
++  } params;
++
++  /* trap 1: the sequence header comes from the driver
++   * (vkGetEncodedVideoSessionParametersKHR) and is emitted verbatim on key
++   * frames. No hand-written OBU_SEQUENCE_HEADER exists in this element. */
++  guint8 *seq_hdr_data;
++  gsize seq_hdr_size;
++
++  /* driver capability shortcuts, valid while the encoder is started */
++  struct
++  {
++    guint max_refs;
++    gboolean unidir_compound;
++    gboolean per_group_qindex;
++    gboolean primary_ref_frame;
++    gboolean use_gop_remaining;
++    gboolean enable_cdef;
++    guint32 min_qindex;
++    guint32 max_qindex;
++  } hw;
++
++  struct
++  {
++    guint bitrate;
++    guint32 quality;
++    VkVideoEncodeRateControlModeFlagBitsKHR ratecontrol;
++    guint32 qp_i;
++    guint32 qp_p;
++    guint32 max_qp;
++    guint32 min_qp;
++  } prop;
++
++  gboolean update_props;
++
++  struct
++  {
++    guint bitrate;
++    guint max_bitrate;
++    guint32 quality;
++    VkVideoEncodeRateControlModeFlagBitsKHR ratecontrol;
++    guint32 max_qp;
++    guint32 min_qp;
++    guint32 qp_i;
++    guint32 qp_p;
++  } rc;
++
++  /* per-frame GOP-remaining hints, refreshed in encode_frame() */
++  guint32 gop_remaining_intra;
++  guint32 gop_remaining_predictive;
++};
++
++struct _GstVulkanAV1EncoderClass
++{
++  GstAV1EncoderClass parent;
++
++  gint device_index;
++};
++
++struct _GstVulkanAV1EncoderFrame
++{
++  GstVulkanEncoderPicture picture;
++  GstVulkanEncoder *encoder;
++
++  VkVideoEncodeAV1RateControlInfoKHR vkrc_info;
++  VkVideoEncodeAV1RateControlLayerInfoKHR vkrc_layer_info;
++  VkVideoEncodeAV1GopRemainingFrameInfoKHR gop_remaining;
++
++  StdVideoEncodeAV1PictureInfo pic_info;
++  VkVideoEncodeAV1PictureInfoKHR vkav1pic_info;
++
++  StdVideoAV1TileInfo tile_info;
++  StdVideoAV1LoopFilter loop_filter;
++  StdVideoAV1CDEF cdef;
++
++  StdVideoEncodeAV1ReferenceInfo ref_info;
++  VkVideoEncodeAV1DpbSlotInfoKHR vkref_info;
++};
++
++struct CData
++{
++  gchar *description;
++  gint device_index;
++  GstCaps *codec;
++  GstCaps *raw;
++};
++
++#define GST_VULKAN_AV1_ENCODER(obj) ((GstVulkanAV1Encoder *)obj)
++#define GST_VULKAN_AV1_ENCODER_GET_CLASS(obj)                           \
++    (G_TYPE_INSTANCE_GET_CLASS((obj), G_TYPE_FROM_INSTANCE(obj),        \
++                               GstVulkanAV1EncoderClass))
++#define GST_VULKAN_AV1_ENCODER_CLASS(klass)     \
++    ((GstVulkanAV1EncoderClass *)klass)
++
++static GstElementClass *parent_class = NULL;
++
++GST_DEBUG_CATEGORY_STATIC (gst_vulkan_av1_encoder_debug);
++#define GST_CAT_DEFAULT gst_vulkan_av1_encoder_debug
++
++static gpointer
++_register_debug_category (gpointer data)
++{
++  GST_DEBUG_CATEGORY_INIT (gst_vulkan_av1_encoder_debug, "vulkanav1enc", 0,
++      "Vulkan AV1 encoder");
++
++  return NULL;
++}
++
++#define update_property(type, obj, old_val, new_val, prop_id)         \
++static inline void                                                    \
++gst_vulkan_av1_encoder_update_property_##type (GstVulkanAV1Encoder * encoder, type * old_val, type new_val, guint prop_id) \
++{ \
++ GST_OBJECT_LOCK (encoder);                     \
++ if (*old_val == new_val) {                     \
++   GST_OBJECT_UNLOCK (encoder);                 \
++   return;                                      \
++ }                                                                      \
++ *old_val = new_val;                                                    \
++ GST_OBJECT_UNLOCK (encoder);                                           \
++ if (prop_id > 0)                                                       \
++   g_object_notify_by_pspec (G_OBJECT (encoder), properties[prop_id]);  \
++}
++
++update_property (guint, obj, old_val, new_val, prop_id);
++#undef update_property
++
++#define update_property_uint(obj, old_val, new_val, prop_id)      \
++  gst_vulkan_av1_encoder_update_property_guint (obj, old_val, new_val, prop_id)
++
++/* *INDENT-OFF* */
++/* AV1 spec, Annex A: levels. Only the general (Main profile, tier 0)
++ * constraints this element checks. MaxDisplayRate is in luma samples per
++ * second. */
++static const struct
++{
++  StdVideoAV1Level level;
++  guint32 max_pic_size;
++  guint32 max_h_size;
++  guint32 max_v_size;
++  guint64 max_display_rate;
++} _av1_levels[] = {
++  { STD_VIDEO_AV1_LEVEL_2_0,   147456,  2048, 1152,    4423680 },
++  { STD_VIDEO_AV1_LEVEL_2_1,   278784,  2816, 1584,    8363520 },
++  { STD_VIDEO_AV1_LEVEL_3_0,   665856,  4352, 2448,   19975680 },
++  { STD_VIDEO_AV1_LEVEL_3_1,  1065024,  5504, 3096,   31950720 },
++  { STD_VIDEO_AV1_LEVEL_4_0,  2359296,  6144, 3456,   70778880 },
++  { STD_VIDEO_AV1_LEVEL_4_1,  2359296,  6144, 3456,  141557760 },
++  { STD_VIDEO_AV1_LEVEL_5_0,  8912896,  8192, 4352,  267386880 },
++  { STD_VIDEO_AV1_LEVEL_5_1,  8912896,  8192, 4352,  534773760 },
++  { STD_VIDEO_AV1_LEVEL_5_2,  8912896,  8192, 4352, 1069547520 },
++  { STD_VIDEO_AV1_LEVEL_5_3,  8912896,  8192, 4352, 1069547520 },
++  { STD_VIDEO_AV1_LEVEL_6_0, 35651584, 16384, 8704, 1069547520 },
++  { STD_VIDEO_AV1_LEVEL_6_1, 35651584, 16384, 8704, 2139095040 },
++  { STD_VIDEO_AV1_LEVEL_6_2, 35651584, 16384, 8704, 4278190080 },
++  { STD_VIDEO_AV1_LEVEL_6_3, 35651584, 16384, 8704, 4278190080 },
++};
++/* *INDENT-ON* */
++
++static StdVideoAV1Level
++gst_vulkan_av1_get_level (guint width, guint height, guint fps_n, guint fps_d,
++    StdVideoAV1Level max_level)
++{
++  guint32 pic_size = width * height;
++  guint64 display_rate;
++  guint i;
++
++  display_rate = gst_util_uint64_scale (pic_size, fps_n, MAX (fps_d, 1));
++
++  for (i = 0; i < G_N_ELEMENTS (_av1_levels); i++) {
++    if (pic_size > _av1_levels[i].max_pic_size)
++      continue;
++    if (width > _av1_levels[i].max_h_size)
++      continue;
++    if (height > _av1_levels[i].max_v_size)
++      continue;
++    if (display_rate > _av1_levels[i].max_display_rate)
++      continue;
++
++    return MIN (_av1_levels[i].level, max_level);
++  }
++
++  GST_WARNING ("No suitable AV1 level found, using the driver maximum");
++  return max_level;
++}
++
++static gint
++_av1_helper_msb (guint n)
++{
++  gint log = 0;
++  guint value = n;
++  gint i;
++
++  g_assert (n != 0);
++
++  for (i = 4; i >= 0; --i) {
++    const gint shift = (1 << i);
++    const guint x = value >> shift;
++    if (x != 0) {
++      value = x;
++      log += shift;
++    }
++  }
++
++  return log;
++}
++
++static GstVulkanAV1EncoderFrame *
++gst_vulkan_av1_encoder_frame_new (GstVulkanAV1Encoder * self,
++    GstVideoCodecFrame * frame)
++{
++  GstVulkanAV1EncoderFrame *vkframe;
++
++  if (self->coded_buffer_size == 0) {
++    /* Generous upper bound proven in practice: three times the luma plane.
++     * AV1 has no coded-size formula helper like H.26x. */
++    self->coded_buffer_size =
++        (gsize) self->coded_width * self->coded_height * 3;
++    if (self->coded_buffer_size == 0)
++      goto fail;
++    GST_DEBUG_OBJECT (self, "Calculated coded buffer size: %" G_GSIZE_FORMAT,
++        self->coded_buffer_size);
++  }
++
++  vkframe = g_new0 (GstVulkanAV1EncoderFrame, 1);
++  vkframe->encoder = gst_object_ref (self->encoder);
++  if (!gst_vulkan_encoder_picture_init (&vkframe->picture, self->encoder,
++          frame->input_buffer, self->coded_buffer_size)) {
++    gst_object_unref (vkframe->encoder);
++    g_free (vkframe);
++    goto fail;
++  }
++
++  return vkframe;
++
++fail:
++  {
++    GST_DEBUG_OBJECT (self, "Failed to allocate a vulkan encoding frame");
++    return NULL;
++  }
++}
++
++static void
++gst_vulkan_av1_encoder_frame_free (gpointer frame)
++{
++  GstVulkanAV1EncoderFrame *vkframe = frame;
++  gst_vulkan_encoder_picture_clear (&vkframe->picture, vkframe->encoder);
++  gst_object_unref (vkframe->encoder);
++  g_free (vkframe);
++}
++
++static inline GstVulkanAV1EncoderFrame *
++_GET_FRAME (GstAV1EncoderFrame * frame)
++{
++  GstVulkanAV1EncoderFrame *enc_frame =
++      gst_av1_encoder_frame_get_user_data (frame);
++  g_assert (enc_frame);
++  return enc_frame;
++}
++
++static StdVideoAV1FrameType
++gst_vulkan_av1_frame_type (GstAV1FrameType type)
++{
++  switch (type) {
++    case GST_AV1_KEY_FRAME:
++      return STD_VIDEO_AV1_FRAME_TYPE_KEY;
++    case GST_AV1_INTER_FRAME:
++      return STD_VIDEO_AV1_FRAME_TYPE_INTER;
++    case GST_AV1_INTRA_ONLY_FRAME:
++      return STD_VIDEO_AV1_FRAME_TYPE_INTRA_ONLY;
++    case GST_AV1_SWITCH_FRAME:
++      return STD_VIDEO_AV1_FRAME_TYPE_SWITCH;
++    default:
++      GST_WARNING ("Unsupported frame type '%d'", type);
++      return STD_VIDEO_AV1_FRAME_TYPE_KEY;
++  }
++}
++
++/* bug A6: THE rate-control derivation. Four sites used to each carry their
++ * own copy of some of this (new_sequence's post-start block,
++ * _configure_rate_control(), _reset_rc_props() and _update_live_bitrate()),
++ * which is how the live retarget path came to clamp the bitrate differently
++ * from the configure path. The numbers are derived here and only here:
++ *
++ *  - the requested bitrate (self->rc.bitrate, which the caller seeds -- it
++ *    is the property, or the auto-computed default new_sequence() picked)
++ *    clamped against the driver maximum,
++ *  - the implied maximum bitrate: CBR must have max == average (trap 5/11),
++ *    VBR uses the 66% target percentage the VA/vkh264 siblings use, and any
++ *    other mode gets max == average so the value is never stale,
++ *  - the AV1 Q index bounds and the constant-QP indices, clamped into the
++ *    driver's [minQIndex, maxQIndex] range (0 means "bound disabled").
++ *
++ * What deliberately stays AT THE CALL SITES, because it genuinely differs:
++ *  - only _configure_rate_control() publishes: it mirrors the clamped
++ *    bitrate back onto the property and emits the bitrate tags downstream.
++ *    A live retarget must not re-emit a tag event.
++ *  - only _reset_rc_props() touches the QP-ish properties (qp-i, qp-p,
++ *    min-qp, max-qp) and the rate-control mode handshake with the driver
++ *    (_sync_rc_mode()).
++ *  - only _update_live_bitrate() must avoid a reconfigure: it derives and
++ *    then raises ENCODE_RATE_CONTROL_BIT alone (trap 9b), so the session
++ *    keeps its DPB and no key frame is forced.
++ *  - new_sequence()'s post-start block reads the quality level and settles
++ *    the effective rate-control mode BEFORE this runs, because the mode is
++ *    an input to the derivation (trap 8 ordering).
++ *
++ * Call with the object lock NOT held. */
++static void
++_derive_rc_targets (GstVulkanAV1Encoder * self,
++    GstVulkanVideoCapabilities * vk_caps)
++{
++  guint max_kbps = vk_caps->encoder.caps.maxBitrate / 1024;
++
++  /* The cached driver Q index range: written here from the caps the caller
++   * queried, and read by the clamps just below, which are its only
++   * consumers. */
++  self->hw.min_qindex = vk_caps->encoder.codec.av1.minQIndex;
++  self->hw.max_qindex = vk_caps->encoder.codec.av1.maxQIndex;
++
++  GST_OBJECT_LOCK (self);
++
++  self->rc.bitrate = MIN (self->rc.bitrate, max_kbps);
++
++  switch (self->rc.ratecontrol) {
++    case VK_VIDEO_ENCODE_RATE_CONTROL_MODE_VBR_BIT_KHR:
++      /* by default max bitrate is 66% target percentage, like vah264enc */
++      self->rc.max_bitrate = MIN ((guint)
++          gst_util_uint64_scale_int (self->rc.bitrate, 100, 66), max_kbps);
++      break;
++    default:
++      /* trap 5/11: CBR requires maxBitrate == averageBitrate. The other
++       * modes do not read max_bitrate at all (_setup_rc_pic() only fills
++       * the rate-control layer for an active mode), but keeping it equal
++       * to the average keeps the published tags deterministic. */
++      self->rc.max_bitrate = self->rc.bitrate;
++      break;
++  }
++
++  self->rc.min_qp = (self->prop.min_qp > 0) ?
++      MAX (self->prop.min_qp, self->hw.min_qindex) : 0;
++  self->rc.max_qp = (self->prop.max_qp > 0) ?
++      MIN (self->prop.max_qp, self->hw.max_qindex) : 0;
++
++  if (self->rc.ratecontrol ==
++      VK_VIDEO_ENCODE_RATE_CONTROL_MODE_DISABLED_BIT_KHR) {
++    self->rc.qp_i = CLAMP (self->prop.qp_i, self->hw.min_qindex,
++        self->hw.max_qindex);
++    self->rc.qp_p = CLAMP (self->prop.qp_p, self->hw.min_qindex,
++        self->hw.max_qindex);
++  } else {
++    /* constantQIndex must be 0 whenever rate control is not DISABLED */
++    self->rc.qp_i = 0;
++    self->rc.qp_p = 0;
++  }
++
++  GST_OBJECT_UNLOCK (self);
++}
++
++/* Push the requested rate-control mode into the encoder and adopt the mode
++ * the driver actually granted.
++ *
++ * trap 8: the push must happen BEFORE the read-back, or the read-back
++ * overwrites the user's cbr with the driver default and the stream is
++ * silently constant-QP (the vkh264enc rc-fix's Fix A). A read-back of -1
++ * means "unknown": keep the requested mode rather than storing -1 into an
++ * unsigned flag field.
++ *
++ * Call with the object lock NOT held (update_property_uint() takes it). */
++static void
++_sync_rc_mode (GstVulkanAV1Encoder * self,
++    VkVideoEncodeRateControlModeFlagBitsKHR requested)
++{
++  gint32 rc_mode;
++
++  self->rc.ratecontrol = requested;
++
++  gst_vulkan_encoder_set_rc_mode (self->encoder, requested);
++  rc_mode = gst_vulkan_encoder_rc_mode (self->encoder);
++  if (rc_mode != -1)
++    self->rc.ratecontrol = rc_mode;
++
++  update_property_uint (self, &self->prop.ratecontrol, self->rc.ratecontrol,
++      PROP_RATECONTROL);
++}
++
++static inline void
++_configure_rate_control (GstVulkanAV1Encoder * self,
++    GstVulkanVideoCapabilities * vk_caps)
++{
++  _derive_rc_targets (self, vk_caps);
++
++  /* the publishing half, which only this call site does */
++  update_property_uint (self, &self->prop.bitrate, self->rc.bitrate,
++      PROP_BITRATE);
++
++  {
++    GstTagList *tags = gst_tag_list_new_empty ();
++    gst_tag_list_add (tags, GST_TAG_MERGE_REPLACE, GST_TAG_NOMINAL_BITRATE,
++        self->rc.bitrate, GST_TAG_MAXIMUM_BITRATE, self->rc.max_bitrate,
++        GST_TAG_CODEC, "AV1", GST_TAG_ENCODER, "vulkanav1enc", NULL);
++
++    gst_video_encoder_merge_tags (GST_VIDEO_ENCODER (self), tags,
++        GST_TAG_MERGE_REPLACE);
++    gst_tag_list_unref (tags);
++  }
++}
++
++static gboolean
++gst_vulkan_av1_encoder_init_sequence_header (GstVulkanAV1Encoder * self,
++    GstVideoInfo * in_info, StdVideoAV1Level level)
++{
++  guint32 keyframe_period =
++      gst_av1_encoder_get_keyframe_period (GST_AV1_ENCODER (self));
++
++  /* *INDENT-OFF* */
++  self->params.color_config = (StdVideoAV1ColorConfig) {
++    .flags = (StdVideoAV1ColorConfigFlags) {
++      .mono_chrome = 0,
++      .color_range = 0,
++      .separate_uv_delta_q = 0,
++      .color_description_present_flag = 0,
++    },
++    .BitDepth = 8,
++    .subsampling_x = 1,
++    .subsampling_y = 1,
++    .color_primaries = STD_VIDEO_AV1_COLOR_PRIMARIES_BT_UNSPECIFIED,
++    .transfer_characteristics =
++        STD_VIDEO_AV1_TRANSFER_CHARACTERISTICS_UNSPECIFIED,
++    .matrix_coefficients = STD_VIDEO_AV1_MATRIX_COEFFICIENTS_UNSPECIFIED,
++    .chroma_sample_position = STD_VIDEO_AV1_CHROMA_SAMPLE_POSITION_UNKNOWN,
++  };
++
++  self->params.seq_hdr = (StdVideoAV1SequenceHeader) {
++    .flags = (StdVideoAV1SequenceHeaderFlags) {
++      .still_picture = 0,
++      .reduced_still_picture_header = 0,
++      .use_128x128_superblock = 0,
++      .enable_filter_intra = 0,
++      .enable_intra_edge_filter = 0,
++      .enable_interintra_compound = 0,
++      .enable_masked_compound = 0,
++      .enable_warped_motion = 0,
++      .enable_dual_filter = 0,
++      .enable_order_hint = 1,
++      .enable_jnt_comp = 0,
++      .enable_ref_frame_mvs = 0,
++      .frame_id_numbers_present_flag = 0,
++      .enable_superres = 0,
++      .enable_cdef = self->hw.enable_cdef,
++      .enable_restoration = 0,
++      .film_grain_params_present = 0,
++      .timing_info_present_flag = 0,
++      .initial_display_delay_present_flag = 0,
++    },
++    .seq_profile = STD_VIDEO_AV1_PROFILE_MAIN,
++    .frame_width_bits_minus_1 = _av1_helper_msb (self->coded_width),
++    .frame_height_bits_minus_1 = _av1_helper_msb (self->coded_height),
++    /* trap 4: the sequence header carries the CODED (aligned) size; the
++     * per-frame render_width/height signal the true display size so
++     * decoders crop. */
++    .max_frame_width_minus_1 = self->coded_width - 1,
++    .max_frame_height_minus_1 = self->coded_height - 1,
++    /* values from vk_video_samples, matching the upstream conformance
++     * test; unused while frame_id_numbers_present_flag is 0 */
++    .delta_frame_id_length_minus_2 = 14 - 2,
++    .additional_frame_id_length_minus_1 = 15 - 14 - 1,
++    /* trap 5: order_hint_bits_minus_1 clamped to 7. The field is 3 bits
++     * wide and OrderHintBits cannot exceed 8; an unclamped derivation from
++     * the GOP size emitted an illegal sequence header for any GOP > 255
++     * frames. The base class always runs with OrderHintBits == 8. */
++    .order_hint_bits_minus_1 = 7,
++    .seq_force_integer_mv = 0,
++    .seq_force_screen_content_tools = 0,
++    .pColorConfig = &self->params.color_config,
++    .pTimingInfo = NULL,
++  };
++
++  self->params.model_info = (StdVideoEncodeAV1DecoderModelInfo) {
++    .buffer_delay_length_minus_1 = 0,
++    .buffer_removal_time_length_minus_1 = 0,
++    .frame_presentation_time_length_minus_1 = 0,
++    .num_units_in_decoding_tick = 0,
++  };
++
++  self->params.op_info = (StdVideoEncodeAV1OperatingPointInfo) {
++    .flags = (StdVideoEncodeAV1OperatingPointInfoFlags) {
++      .decoder_model_present_for_this_op = 0,
++      .low_delay_mode_flag = 0,
++      .initial_display_delay_present_for_this_op = 0,
++    },
++    .operating_point_idc = 0,
++    .seq_level_idx = level,
++    .seq_tier = 0,
++    .decoder_buffer_delay = 0,
++    .encoder_buffer_delay = 0,
++    .initial_display_delay_minus_1 = 0,
++  };
++  /* *INDENT-ON* */
++
++  GST_DEBUG_OBJECT (self, "sequence: coded %dx%d, display %dx%d, level %d,"
++      " keyframe period %u", self->coded_width, self->coded_height,
++      GST_VIDEO_INFO_WIDTH (in_info), GST_VIDEO_INFO_HEIGHT (in_info),
++      level, keyframe_period);
++
++  return TRUE;
++}
++
++static GstFlowReturn
++gst_vulkan_av1_encoder_update_session_parameters (GstVulkanAV1Encoder * self)
++{
++  GError *err = NULL;
++  GstVulkanEncoderParameters enc_params;
++
++  /* trap 6: AV1 session parameters are immutable -- there is no "add"
++   * operation like H.26x SPS/PPS sets. This creates a fresh
++   * VkVideoSessionParametersKHR; any sequence change (resolution, profile)
++   * goes through a full encoder stop/start plus this call. */
++  /* *INDENT-OFF* */
++  enc_params.av1 = (VkVideoEncodeAV1SessionParametersCreateInfoKHR) {
++    .sType =
++        VK_STRUCTURE_TYPE_VIDEO_ENCODE_AV1_SESSION_PARAMETERS_CREATE_INFO_KHR,
++    .pNext = NULL,
++    .pStdSequenceHeader = &self->params.seq_hdr,
++    .pStdDecoderModelInfo = &self->params.model_info,
++    .stdOperatingPointCount = 1,
++    .pStdOperatingPoints = &self->params.op_info,
++  };
++  /* *INDENT-ON* */
++
++  if (!gst_vulkan_encoder_update_video_session_parameters (self->encoder,
++          &enc_params, &err)) {
++    GST_ELEMENT_ERROR (self, RESOURCE, NOT_FOUND,
++        ("Unable to update session parameters with error %s", err->message),
++        (NULL));
++    g_clear_error (&err);
++    return GST_FLOW_ERROR;
++  }
++
++  return GST_FLOW_OK;
++}
++
++static GstFlowReturn
++gst_vulkan_av1_encoder_fetch_sequence_header (GstVulkanAV1Encoder * self)
++{
++  GError *err = NULL;
++
++  g_clear_pointer (&self->seq_hdr_data, g_free);
++  self->seq_hdr_size = 0;
++
++  /* trap 1: the only valid AV1 sequence header is the driver-encoded
++   * OBU_SEQUENCE_HEADER returned by vkGetEncodedVideoSessionParametersKHR.
++   * For AV1 the encoder library requires NULL overrides/feedback.
++   * trap 7 (rev-1): the library force-sets feedback_info.hasOverrides = 1
++   * to work around an NVIDIA driver bug; nothing to do here beyond relying
++   * on it. */
++  if (!gst_vulkan_encoder_video_session_parameters_overrides (self->encoder,
++          NULL, NULL, &self->seq_hdr_size, (gpointer *) & self->seq_hdr_data,
++          &err)) {
++    GST_ELEMENT_ERROR (self, RESOURCE, NOT_FOUND,
++        ("Unable to get the encoded sequence header with error %s",
++            err ? err->message : "unknown"), (NULL));
++    g_clear_error (&err);
++    return GST_FLOW_ERROR;
++  }
++
++  if (!self->seq_hdr_data || self->seq_hdr_size == 0) {
++    GST_ELEMENT_ERROR (self, STREAM, ENCODE,
++        ("Driver returned an empty sequence header"), (NULL));
++    return GST_FLOW_ERROR;
++  }
++
++  GST_DEBUG_OBJECT (self, "Driver sequence header: %" G_GSIZE_FORMAT " bytes",
++      self->seq_hdr_size);
++  GST_MEMDUMP_OBJECT (self, "OBU_SEQUENCE_HEADER", self->seq_hdr_data,
++      self->seq_hdr_size);
++
++  return GST_FLOW_OK;
++}
++
++static void
++_reset_rc_props (GstVulkanAV1Encoder * self)
++{
++  GstVulkanVideoCapabilities vk_caps;
++  VkVideoEncodeRateControlModeFlagBitsKHR requested;
++
++  if (!self->encoder)
++    return;
++
++  /* only available once the vulkan encoder has been started, which is why
++   * the very first configure() pass through here is a no-op */
++  if (!gst_vulkan_encoder_caps (self->encoder, &vk_caps))
++    return;
++
++  GST_OBJECT_LOCK (self);
++  requested = self->prop.ratecontrol;
++  self->rc.ratecontrol = requested;
++  GST_OBJECT_UNLOCK (self);
++
++  /* bug A6: the shared derivation, run with the mode the user asked for --
++   * the same order as before, where the Q indices were derived ahead of the
++   * driver's mode read-back below. */
++  _derive_rc_targets (self, &vk_caps);
++
++  /* the mode handshake and the property mirroring, which only this call
++   * site does */
++  _sync_rc_mode (self, requested);
++
++  update_property_uint (self, &self->prop.qp_i, self->rc.qp_i, PROP_QP_I);
++  update_property_uint (self, &self->prop.qp_p, self->rc.qp_p, PROP_QP_P);
++  update_property_uint (self, &self->prop.min_qp, self->rc.min_qp, PROP_MIN_QP);
++  update_property_uint (self, &self->prop.max_qp, self->rc.max_qp, PROP_MAX_QP);
++}
++
++/* Publishes the state GstVideoEncoder/downstream see. Must run on EVERY
++ * new_sequence() call, whether or not the vulkan session was (re)started:
++ * the early-return path (trap 8, same coded W x H) can still be reached by a
++ * caps renegotiation that changes only framerate or colorimetry, or by any
++ * property write that is routed back through this vfunc, and none of those
++ * touch resolution. Skipping this tail there would leave the driver's rate
++ * control fed a stale fps and would regress trap 10's colorimetry/
++ * chroma-site output-caps signalling on a mid-stream renegotiate. */
++static void
++_publish_sequence_state (GstVulkanAV1Encoder * self,
++    GstVideoCodecState * in_state)
++{
++  GstVideoInfo *in_info = &in_state->info;
++  GstCaps *caps;
++  GstVideoCodecState *out_state;
++
++  gst_av1_encoder_set_max_num_references (GST_AV1_ENCODER (self),
++      self->hw.max_refs);
++
++  if (self->in_state)
++    gst_video_codec_state_unref (self->in_state);
++  self->in_state = gst_video_codec_state_ref (in_state);
++
++  /* the video info handed to gst_vulkan_encoder_encode(): coded size, and
++   * an explicit framerate -- the rate-control layer's
++   * frameRateNumerator/Denominator come from this info, and 0/0 would
++   * break the driver's rate maths. */
++  if (GST_VIDEO_INFO_FPS_N (in_info) > 0 && GST_VIDEO_INFO_FPS_D (in_info) > 0) {
++    GST_VIDEO_INFO_FPS_N (&self->coded_info) = GST_VIDEO_INFO_FPS_N (in_info);
++    GST_VIDEO_INFO_FPS_D (&self->coded_info) = GST_VIDEO_INFO_FPS_D (in_info);
++  } else {
++    GST_VIDEO_INFO_FPS_N (&self->coded_info) = 30;
++    GST_VIDEO_INFO_FPS_D (&self->coded_info) = 1;
++  }
++
++  /* output caps */
++  caps = gst_caps_new_simple ("video/x-av1", "profile", G_TYPE_STRING,
++      "main", "width", G_TYPE_INT, GST_VIDEO_INFO_WIDTH (in_info),
++      "height", G_TYPE_INT, GST_VIDEO_INFO_HEIGHT (in_info),
++      "alignment", G_TYPE_STRING, "tu",
++      "stream-format", G_TYPE_STRING, "obu-stream", NULL);
++
++  /* trap 10: propagate the input colorimetry (and chroma siting) onto
++   * the coded-video caps, exactly as the other hardware encoders do.
++   * webrtcbin derives the WebRTC color-space signalling from these caps;
++   * with them absent a receiver has no out-of-band color-space and e.g.
++   * VideoToolbox falls back to per-frame guessing, rendering as
++   * whole-image light/dark alternation. */
++  {
++    gchar *colorimetry = gst_video_colorimetry_to_string
++        (&in_info->colorimetry);
++    if (colorimetry) {
++      gst_caps_set_simple (caps, "colorimetry", G_TYPE_STRING, colorimetry,
++          NULL);
++      g_free (colorimetry);
++    }
++    if (in_info->chroma_site != GST_VIDEO_CHROMA_SITE_UNKNOWN) {
++      gchar *chroma_site =
++          gst_video_chroma_site_to_string (in_info->chroma_site);
++      if (chroma_site) {
++        gst_caps_set_simple (caps, "chroma-site", G_TYPE_STRING, chroma_site,
++            NULL);
++        g_free (chroma_site);
++      }
++    }
++  }
++
++  out_state =
++      gst_video_encoder_set_output_state (GST_VIDEO_ENCODER_CAST (self),
++      caps, self->in_state);
++  gst_video_codec_state_unref (out_state);
++}
++
++static GstFlowReturn
++gst_vulkan_av1_encoder_new_sequence (GstAV1Encoder * encoder,
++    GstVideoCodecState * in_state)
++{
++  GstVulkanAV1Encoder *self = GST_VULKAN_AV1_ENCODER (encoder);
++  GError *err = NULL;
++  GstVideoInfo *in_info = &in_state->info;
++  GstVulkanVideoCapabilities vk_caps;
++  VkVideoEncodeAV1CapabilitiesKHR *vk_av1_caps;
++  GstVulkanEncoderQualityProperties quality_props;
++  StdVideoAV1Level level;
++  guint align_w, align_h;
++
++  if (!self->encoder) {
++    GST_ELEMENT_ERROR (self, RESOURCE, NOT_FOUND,
++        ("The vulkan encoder has not been initialized properly"), (NULL));
++    return GST_FLOW_ERROR;
++  }
++
++  if (GST_VIDEO_INFO_FORMAT (in_info) != GST_VIDEO_FORMAT_NV12
++      || GST_VIDEO_INFO_COMP_DEPTH (in_info, 0) != 8) {
++    GST_ERROR_OBJECT (self, "Only 8-bit 4:2:0 NV12 is supported");
++    return GST_FLOW_NOT_NEGOTIATED;
++  }
++
++  /* profile configuration: Main, 8-bit, 4:2:0 */
++  /* *INDENT-OFF* */
++  self->profile = (GstVulkanVideoProfile) {
++    .profile = (VkVideoProfileInfoKHR) {
++      .sType = VK_STRUCTURE_TYPE_VIDEO_PROFILE_INFO_KHR,
++      .pNext = &self->profile.usage.encode,
++      .videoCodecOperation = VK_VIDEO_CODEC_OPERATION_ENCODE_AV1_BIT_KHR,
++      .chromaSubsampling = VK_VIDEO_CHROMA_SUBSAMPLING_420_BIT_KHR,
++      .chromaBitDepth = VK_VIDEO_COMPONENT_BIT_DEPTH_8_BIT_KHR,
++      .lumaBitDepth = VK_VIDEO_COMPONENT_BIT_DEPTH_8_BIT_KHR,
++    },
++    .usage.encode = (VkVideoEncodeUsageInfoKHR) {
++      .pNext = &self->profile.codec.av1enc,
++      .sType = VK_STRUCTURE_TYPE_VIDEO_ENCODE_USAGE_INFO_KHR,
++      .videoUsageHints = VK_VIDEO_ENCODE_USAGE_DEFAULT_KHR,
++      .videoContentHints = VK_VIDEO_ENCODE_CONTENT_DEFAULT_KHR,
++      .tuningMode = VK_VIDEO_ENCODE_TUNING_MODE_DEFAULT_KHR,
++    },
++    .codec.av1enc = (VkVideoEncodeAV1ProfileInfoKHR) {
++      .sType = VK_STRUCTURE_TYPE_VIDEO_ENCODE_AV1_PROFILE_INFO_KHR,
++      .stdProfile = STD_VIDEO_AV1_PROFILE_MAIN,
++    },
++  };
++  quality_props = (GstVulkanEncoderQualityProperties) {
++    .quality_level = self->rc.quality,
++    .codec.av1 = {
++      .sType = VK_STRUCTURE_TYPE_VIDEO_ENCODE_AV1_QUALITY_LEVEL_PROPERTIES_KHR,
++    },
++  };
++  /* *INDENT-ON* */
++
++  if (gst_vulkan_encoder_is_started (self->encoder)) {
++    /* profile is constant (Main, 8-bit 4:2:0), so the input resolution is
++     * the only thing that can invalidate the running sequence */
++    if (self->in_state
++        && GST_VIDEO_INFO_WIDTH (&self->in_state->info) ==
++        GST_VIDEO_INFO_WIDTH (in_info)
++        && GST_VIDEO_INFO_HEIGHT (&self->in_state->info) ==
++        GST_VIDEO_INFO_HEIGHT (in_info)) {
++      /* trap 8: same sequence, the session is not restarted, but a
++       * reconfigure may have changed the rate-control values. Re-apply
++       * rate control via vkCmdControlVideoCoding with
++       * ENCODE_RATE_CONTROL_BIT only; a reset would raise RESET_BIT,
++       * invalidate the DPB and force a key frame on every retarget. */
++      gst_vulkan_encoder_request_rc_update (self->encoder);
++      /* bug A1: the session-recreate work below (start, caps re-query,
++       * sequence header re-fetch) is skipped on this path, but the state
++       * GstVideoEncoder/downstream see is not -- a caps change that keeps
++       * W x H (fps, colorimetry) must still take effect. */
++      _publish_sequence_state (self, in_state);
++      return GST_FLOW_OK;
++    } else {
++      /* trap 6: AV1 session parameters do not support updates; a coded
++       * resolution change requires a fresh video session and fresh
++       * session parameters. */
++      GST_DEBUG_OBJECT (self, "Restarting vulkan encoder");
++      gst_vulkan_encoder_stop (self->encoder);
++    }
++  }
++
++  if (!gst_vulkan_encoder_start (self->encoder, &self->profile, &quality_props,
++          &err)) {
++    GST_ELEMENT_ERROR (self, RESOURCE, NOT_FOUND,
++        ("Unable to start vulkan encoder with error %s", err->message), (NULL));
++    g_clear_error (&err);
++    return GST_FLOW_ERROR;
++  }
++
++  /* quality & rate-control configuration */
++  {
++    VkVideoEncodeRateControlModeFlagBitsKHR requested;
++
++    self->rc.quality = gst_vulkan_encoder_quality_level (self->encoder);
++    update_property_uint (self, &self->prop.quality, self->rc.quality,
++        PROP_QUALITY);
++
++    GST_OBJECT_LOCK (self);
++    requested = self->prop.ratecontrol;
++    GST_OBJECT_UNLOCK (self);
++
++    /* trap 8 (bug A6: the set-then-read-back handshake is now one shared
++     * helper): the mode must be pushed right after start() and BEFORE it
++     * is read back, and it must settle before _configure_rate_control()
++     * derives the targets, because the effective mode is an input to the
++     * derivation. */
++    _sync_rc_mode (self, requested);
++  }
++
++  if (!gst_vulkan_encoder_caps (self->encoder, &vk_caps)) {
++    GST_ELEMENT_ERROR (self, RESOURCE, NOT_FOUND,
++        ("Unable to query the vulkan encoder capabilities"), (NULL));
++    gst_vulkan_encoder_stop (self->encoder);
++    return GST_FLOW_ERROR;
++  }
++  vk_av1_caps = &vk_caps.encoder.codec.av1;
++
++  GST_LOG_OBJECT (self, "AV1 encoder capabilities:\n"
++      "    capability flags: 0x%x\n"
++      "    maxLevel: %i\n"
++      "    codedPictureAlignment: %ux%u\n"
++      "    maxTiles: %ux%u\n"
++      "    minTileSize: %ux%u\n"
++      "    maxTileSize: %ux%u\n"
++      "    superblockSizes: 0x%x\n"
++      "    maxSingleReferenceCount: %u (mask 0x%x)\n"
++      "    maxUnidirectionalCompoundReferenceCount: %u\n"
++      "    maxBidirectionalCompoundReferenceCount: %u\n"
++      "    maxTemporalLayerCount: %u\n"
++      "    min/max QIndex: [%u, %u]\n"
++      "    prefers/requiresGopRemainingFrames: %u/%u\n"
++      "    stdSyntaxFlags: 0x%x",
++      vk_av1_caps->flags,
++      vk_av1_caps->maxLevel,
++      vk_av1_caps->codedPictureAlignment.width,
++      vk_av1_caps->codedPictureAlignment.height,
++      vk_av1_caps->maxTiles.width, vk_av1_caps->maxTiles.height,
++      vk_av1_caps->minTileSize.width, vk_av1_caps->minTileSize.height,
++      vk_av1_caps->maxTileSize.width, vk_av1_caps->maxTileSize.height,
++      vk_av1_caps->superblockSizes,
++      vk_av1_caps->maxSingleReferenceCount,
++      vk_av1_caps->singleReferenceNameMask,
++      vk_av1_caps->maxUnidirectionalCompoundReferenceCount,
++      vk_av1_caps->maxBidirectionalCompoundReferenceCount,
++      vk_av1_caps->maxTemporalLayerCount,
++      vk_av1_caps->minQIndex, vk_av1_caps->maxQIndex,
++      vk_av1_caps->prefersGopRemainingFrames,
++      vk_av1_caps->requiresGopRemainingFrames, vk_av1_caps->stdSyntaxFlags);
++
++  if (GST_VIDEO_INFO_WIDTH (in_info) > vk_caps.caps.maxCodedExtent.width
++      || GST_VIDEO_INFO_HEIGHT (in_info) > vk_caps.caps.maxCodedExtent.height
++      || GST_VIDEO_INFO_WIDTH (in_info) < vk_caps.caps.minCodedExtent.width
++      || GST_VIDEO_INFO_HEIGHT (in_info) < vk_caps.caps.minCodedExtent.height) {
++    GST_ERROR_OBJECT (self, "Frame size is out of driver limits");
++    gst_vulkan_encoder_stop (self->encoder);
++    return GST_FLOW_NOT_NEGOTIATED;
++  }
++
++  if (vk_av1_caps->maxSingleReferenceCount == 0) {
++    GST_ERROR_OBJECT (self, "Driver is intra-only (maxSingleReferenceCount "
++        "== 0), not usable");
++    gst_vulkan_encoder_stop (self->encoder);
++    return GST_FLOW_NOT_NEGOTIATED;
++  }
++
++  /* single tile (MVP): the whole coded frame must fit in one tile */
++  if (GST_VIDEO_INFO_WIDTH (in_info) > vk_av1_caps->maxTileSize.width
++      || GST_VIDEO_INFO_HEIGHT (in_info) > vk_av1_caps->maxTileSize.height) {
++    GST_ERROR_OBJECT (self, "Frame does not fit a single tile (max %ux%u); "
++        "multi-tile is not implemented", vk_av1_caps->maxTileSize.width,
++        vk_av1_caps->maxTileSize.height);
++    gst_vulkan_encoder_stop (self->encoder);
++    return GST_FLOW_NOT_NEGOTIATED;
++  }
++
++  /* driver capability shortcuts */
++  self->hw.unidir_compound =
++      vk_av1_caps->maxUnidirectionalCompoundReferenceCount > 0;
++  self->hw.max_refs = self->hw.unidir_compound ?
++      MIN (vk_av1_caps->maxUnidirectionalCompoundReferenceCount, 4) : 1;
++  self->hw.per_group_qindex = (vk_av1_caps->flags &
++      VK_VIDEO_ENCODE_AV1_CAPABILITY_PER_RATE_CONTROL_GROUP_MIN_MAX_Q_INDEX_BIT_KHR)
++      != 0;
++  self->hw.primary_ref_frame = (vk_av1_caps->stdSyntaxFlags &
++      VK_VIDEO_ENCODE_AV1_STD_PRIMARY_REF_FRAME_BIT_KHR) != 0;
++  /* trap 12: requiresGopRemainingFrames was 0 on the measured drivers, but
++   * the spec allows it; honour both requires and prefers by chaining
++   * VkVideoEncodeAV1GopRemainingFrameInfoKHR per frame. */
++  self->hw.use_gop_remaining = vk_av1_caps->requiresGopRemainingFrames
++      || vk_av1_caps->prefersGopRemainingFrames;
++  self->hw.enable_cdef = TRUE;
++  /* bug A6: hw.min_qindex / hw.max_qindex are cached (and consumed) by
++   * _derive_rc_targets(), which _configure_rate_control() calls a few lines
++   * below with this same capabilities struct. They used to be written here
++   * and read nowhere. */
++
++  /* low latency: no output delay */
++  gst_av1_encoder_set_preferred_output_delay (encoder, 0);
++
++  /* trap 4: AV1 codedPictureAlignment is 8x8 (the 64 in early probes was
++   * the generic pictureAccessGranularity), so 1080 lines need no 1088
++   * padding. Still honour whatever the driver reports: code at the aligned
++   * size and signal the true size via render_width/height so decoders
++   * crop. Note h26x's 16-pixel macroblock granularity means the sibling
++   * elements never exercise this. */
++  align_w = MAX (vk_av1_caps->codedPictureAlignment.width, 1);
++  align_h = MAX (vk_av1_caps->codedPictureAlignment.height, 1);
++  self->coded_width = GST_ROUND_UP_N (GST_VIDEO_INFO_WIDTH (in_info), align_w);
++  self->coded_height =
++      GST_ROUND_UP_N (GST_VIDEO_INFO_HEIGHT (in_info), align_h);
++
++  /* also align to the input-picture granularity for the upstream pool */
++  self->coded_width = GST_ROUND_UP_N (self->coded_width,
++      MAX (vk_caps.encoder.caps.encodeInputPictureGranularity.width, 1));
++  self->coded_height = GST_ROUND_UP_N (self->coded_height,
++      MAX (vk_caps.encoder.caps.encodeInputPictureGranularity.height, 1));
++
++  /* the video info handed to gst_vulkan_encoder_encode(): coded size, and
++   * an explicit framerate -- the rate-control layer's
++   * frameRateNumerator/Denominator come from this info, and 0/0 would
++   * break the driver's rate maths. Also re-set (redundantly, harmlessly) by
++   * _publish_sequence_state() below, which is what keeps this fresh on the
++   * trap-8 early-return path where this block never runs. */
++  gst_video_info_set_format (&self->coded_info, GST_VIDEO_FORMAT_NV12,
++      self->coded_width, self->coded_height);
++  if (GST_VIDEO_INFO_FPS_N (in_info) > 0 && GST_VIDEO_INFO_FPS_D (in_info) > 0) {
++    GST_VIDEO_INFO_FPS_N (&self->coded_info) = GST_VIDEO_INFO_FPS_N (in_info);
++    GST_VIDEO_INFO_FPS_D (&self->coded_info) = GST_VIDEO_INFO_FPS_D (in_info);
++  } else {
++    GST_VIDEO_INFO_FPS_N (&self->coded_info) = 30;
++    GST_VIDEO_INFO_FPS_D (&self->coded_info) = 1;
++  }
++
++  if (self->rc.bitrate == 0) {
++    /* 0.1 bit per pixel per frame; e.g. ~12.4 Mbps at 1080p60 */
++    self->rc.bitrate = (guint) gst_util_uint64_scale (
++        (guint64) self->coded_width * self->coded_height *
++        GST_VIDEO_INFO_FPS_N (&self->coded_info),
++        1, (guint64) GST_VIDEO_INFO_FPS_D (&self->coded_info) * 10 * 1024);
++  }
++
++  _configure_rate_control (self, &vk_caps);
++
++  level = gst_vulkan_av1_get_level (self->coded_width, self->coded_height,
++      GST_VIDEO_INFO_FPS_N (&self->coded_info),
++      GST_VIDEO_INFO_FPS_D (&self->coded_info), vk_av1_caps->maxLevel);
++
++  if (!gst_vulkan_av1_encoder_init_sequence_header (self, in_info, level))
++    return GST_FLOW_ERROR;
++
++  if (gst_vulkan_av1_encoder_update_session_parameters (self) != GST_FLOW_OK)
++    return GST_FLOW_ERROR;
++
++  if (gst_vulkan_av1_encoder_fetch_sequence_header (self) != GST_FLOW_OK)
++    return GST_FLOW_ERROR;
++
++  self->coded_buffer_size = 0;
++
++  /* Create the DPB pool here rather than in propose_allocation(): the
++   * allocation query can run before the format is known, while
++   * new_sequence always runs after. */
++  {
++    GstVideoInfo dpb_info;
++    GstCaps *dpb_caps;
++
++    gst_video_info_set_format (&dpb_info, GST_VIDEO_FORMAT_NV12,
++        self->coded_width, self->coded_height);
++    dpb_caps = gst_video_info_to_caps (&dpb_info);
++    gst_caps_set_features_simple (dpb_caps,
++        gst_caps_features_new (GST_CAPS_FEATURE_MEMORY_VULKAN_IMAGE, NULL));
++
++    if (!gst_vulkan_encoder_create_dpb_pool (self->encoder, dpb_caps)) {
++      GST_ERROR_OBJECT (self, "Unable to create the dpb pool");
++      gst_caps_unref (dpb_caps);
++      return GST_FLOW_ERROR;
++    }
++    gst_caps_unref (dpb_caps);
++  }
++
++  /* bug A1: publishes the state GstVideoEncoder/downstream see (fps,
++   * max-num-references, in_state, output caps with colorimetry/chroma-site)
++   * -- the same call the trap-8 early-return path above makes, so this
++   * happens unconditionally on every new_sequence(), not only when the
++   * session was actually (re)started. */
++  _publish_sequence_state (self, in_state);
++
++  return GST_FLOW_OK;
++}
++
++static GstFlowReturn
++gst_vulkan_av1_encoder_new_output (GstAV1Encoder * base,
++    GstVideoCodecFrame * codec_frame, GstAV1EncoderFrame * av1_frame)
++{
++  GstVulkanAV1EncoderFrame *vk_frame;
++  GstVulkanAV1Encoder *self = GST_VULKAN_AV1_ENCODER (base);
++
++  vk_frame = gst_vulkan_av1_encoder_frame_new (self, codec_frame);
++  if (!vk_frame)
++    return GST_FLOW_NOT_NEGOTIATED;
++
++  gst_av1_encoder_frame_set_user_data (av1_frame, vk_frame,
++      gst_vulkan_av1_encoder_frame_free);
++
++  return GST_FLOW_OK;
++}
++
++/* trap 11: VkVideoEncodeAV1RateControlInfoKHR chained onto the common rate
++ * control info, VkVideoEncodeAV1RateControlLayerInfoKHR onto the layer,
++ * mirroring vkh264enc's _setup_rc_pic. Constraints measured on the real
++ * driver:
++ * - temporalLayerCount must equal the library's layerCount: 1 when a rate
++ *   control mode is active, 0 when DISABLED.
++ * - rc_layer is UNINITIALISED stack memory when the mode is DISABLED (the
++ *   library only fills it for an active mode): it must not be touched.
++ * - AV1 Q bounds are per-rate-control-group and only honoured with the
++ *   per-group capability bit. */
++static void
++_setup_rc_pic (GstVulkanEncoderPicture * pic,
++    VkVideoEncodeRateControlInfoKHR * rc_info,
++    VkVideoEncodeRateControlLayerInfoKHR * rc_layer, gpointer data)
++{
++  GstVulkanAV1Encoder *self = data;
++  GstVulkanAV1EncoderFrame *vk_frame = (GstVulkanAV1EncoderFrame *) pic;
++  /* bug A4: gst_av1_encoder_get_keyframe_period() already returns the
++   * EFFECTIVE period (0 = auto is resolved against the negotiated fps
++   * inside the accessor), so no local re-derivation is needed here. */
++  guint32 keyframe_period =
++      gst_av1_encoder_get_keyframe_period (GST_AV1_ENCODER (self));
++
++  /* *INDENT-OFF* */
++  vk_frame->vkrc_info = (VkVideoEncodeAV1RateControlInfoKHR) {
++    .sType = VK_STRUCTURE_TYPE_VIDEO_ENCODE_AV1_RATE_CONTROL_INFO_KHR,
++    .pNext = NULL,
++    .flags = VK_VIDEO_ENCODE_AV1_RATE_CONTROL_REFERENCE_PATTERN_FLAT_BIT_KHR |
++        VK_VIDEO_ENCODE_AV1_RATE_CONTROL_REGULAR_GOP_BIT_KHR,
++    .gopFrameCount = keyframe_period,
++    .keyFramePeriod = keyframe_period,
++    .consecutiveBipredictiveFrameCount = 0,
++    .temporalLayerCount = 0,
++  };
++  /* *INDENT-ON* */
++
++  rc_info->pNext = &vk_frame->vkrc_info;
++
++  if (rc_info->rateControlMode >
++      VK_VIDEO_ENCODE_RATE_CONTROL_MODE_DISABLED_BIT_KHR) {
++    rc_layer->averageBitrate = (guint64) self->rc.bitrate * 1024;
++    rc_layer->maxBitrate = (guint64) self->rc.max_bitrate * 1024;
++
++    rc_info->virtualBufferSizeInMs = AV1ENC_VBV_SIZE_MS;
++    /* measured: ignored by the NVIDIA driver, keep it deterministic */
++    rc_info->initialVirtualBufferSizeInMs = 0;
++
++    /* *INDENT-OFF* */
++    vk_frame->vkrc_layer_info = (VkVideoEncodeAV1RateControlLayerInfoKHR) {
++      .sType = VK_STRUCTURE_TYPE_VIDEO_ENCODE_AV1_RATE_CONTROL_LAYER_INFO_KHR,
++      .pNext = NULL,
++
++      .useMinQIndex = self->hw.per_group_qindex && self->rc.min_qp > 0,
++      .minQIndex = {
++        .intraQIndex = self->rc.min_qp,
++        .predictiveQIndex = self->rc.min_qp,
++        .bipredictiveQIndex = self->rc.min_qp,
++      },
++
++      .useMaxQIndex = self->hw.per_group_qindex && self->rc.max_qp > 0,
++      .maxQIndex = {
++        .intraQIndex = self->rc.max_qp,
++        .predictiveQIndex = self->rc.max_qp,
++        .bipredictiveQIndex = self->rc.max_qp,
++      },
++
++      .useMaxFrameSize = VK_FALSE,
++    };
++    /* *INDENT-ON* */
++
++    rc_layer->pNext = &vk_frame->vkrc_layer_info;
++    vk_frame->vkrc_info.temporalLayerCount = 1;
++  }
++}
++
++static void
++_setup_codec_pic (GstVulkanEncoderPicture * pic, VkVideoEncodeInfoKHR * info,
++    gpointer data)
++{
++  GstVulkanAV1Encoder *self = data;
++  GstVulkanAV1EncoderFrame *vk_frame = (GstVulkanAV1EncoderFrame *) pic;
++
++  info->pNext = &vk_frame->vkav1pic_info;
++  pic->dpb_slot.pNext = &vk_frame->vkref_info;
++
++  /* *INDENT-OFF* */
++  vk_frame->vkref_info = (VkVideoEncodeAV1DpbSlotInfoKHR) {
++    .sType = VK_STRUCTURE_TYPE_VIDEO_ENCODE_AV1_DPB_SLOT_INFO_KHR,
++    .pNext = NULL,
++    .pStdReferenceInfo = &vk_frame->ref_info,
++  };
++  /* *INDENT-ON* */
++
++  /* trap 12: chained only when the driver asks for GOP-remaining hints */
++  if (self->hw.use_gop_remaining) {
++    /* *INDENT-OFF* */
++    vk_frame->gop_remaining = (VkVideoEncodeAV1GopRemainingFrameInfoKHR) {
++      .sType = VK_STRUCTURE_TYPE_VIDEO_ENCODE_AV1_GOP_REMAINING_FRAME_INFO_KHR,
++      .pNext = NULL,
++      .useGopRemainingFrames = VK_TRUE,
++      .gopRemainingIntra = self->gop_remaining_intra,
++      .gopRemainingPredictive = self->gop_remaining_predictive,
++      .gopRemainingBipredictive = 0,
++    };
++    /* *INDENT-ON* */
++    vk_frame->vkav1pic_info.pNext = &vk_frame->gop_remaining;
++  }
++}
++
++/* Quality tuning ported from gstvaav1enc: in constant-QP mode compute the
++ * in-loop filter strengths from the Q index; in bitrate-controlled modes
++ * the driver's rate controller picks them per frame, so the structures are
++ * left NULL and the driver fills in. */
++static guint8
++_av1_calculate_filter_level (guint32 base_qindex, gboolean chroma)
++{
++  /* *INDENT-OFF* */
++  static const guint8 loop_filter_levels_luma[256] = {
++    0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
++    0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
++    0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
++    0,  0,  0,  0,  0,  0,  0,  0,  0,  1,  1,  1,  1,  1,  1,  2,
++    2,  2,  2,  2,  2,  2,  3,  3,  3,  3,  3,  3,  3,  4,  4,  4,
++    4,  4,  4,  4,  5,  5,  5,  5,  5,  5,  5,  6,  6,  6,  6,  6,
++    6,  7,  7,  7,  8,  8,  8,  8,  9,  9,  9,  9,  10, 10, 10, 10,
++    11, 11, 11, 11, 12, 12, 12, 12, 13, 13, 13, 14, 14, 14, 15, 15,
++    15, 16, 16, 16, 17, 17, 17, 17, 18, 18, 18, 19, 19, 20, 20, 20,
++    21, 21, 21, 22, 22, 22, 23, 23, 24, 24, 24, 25, 25, 25, 26, 26,
++    27, 27, 27, 28, 28, 29, 29, 29, 30, 30, 31, 31, 31, 32, 32, 33,
++    33, 34, 34, 34, 35, 35, 36, 36, 37, 37, 38, 38, 39, 39, 40, 41,
++    41, 42, 42, 43, 44, 45, 45, 46, 47, 48, 49, 50, 51, 52, 53, 55,
++    56, 58, 59, 61, 63, 63, 63, 63, 63, 63, 63, 63, 63, 63, 63, 63,
++    63, 63, 63, 63, 63, 63, 63, 63, 63, 63, 63, 63, 63, 63, 63, 63,
++    63, 63, 63, 63, 63, 63, 63, 63, 63, 63, 63, 63, 63, 63, 63, 63
++  };
++
++  static const guint8 loop_filter_levels_chroma[256] = {
++    0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
++    0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
++    0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
++    0,  0,  0,  0,  0,  0,  0,  1,  1,  1,  1,  1,  1,  1,  1,  2,
++    2,  2,  2,  2,  2,  2,  2,  2,  2,  3,  3,  3,  3,  3,  3,  3,
++    3,  3,  3,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,
++    5,  5,  5,  5,  5,  5,  5,  5,  6,  6,  6,  6,  6,  6,  6,  6,
++    6,  6,  7,  7,  7,  7,  7,  7,  7,  7,  7,  7,  7,  7,  8,  8,
++    8,  8,  8,  8,  8,  8,  8,  8,  9,  9,  9,  9,  9,  9,  9,  10,
++    10, 10, 10, 10, 11, 11, 11, 11, 12, 12, 13, 13, 14, 14, 15, 15,
++    16, 17, 18, 19, 20, 21, 22, 24, 25, 26, 28, 30, 31, 31, 31, 31,
++    31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31,
++    31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31,
++    31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31,
++    31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31,
++    31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31
++  };
++  /* *INDENT-ON* */
++
++  if (!chroma)
++    return loop_filter_levels_luma[base_qindex];
++
++  return loop_filter_levels_chroma[base_qindex];
++}
++
++static void
++_av1_fill_loop_filter (GstVulkanAV1Encoder * self,
++    GstVulkanAV1EncoderFrame * vk_frame, guint32 base_qindex)
++{
++  guint8 level_y = _av1_calculate_filter_level (base_qindex, FALSE);
++  guint8 level_uv = _av1_calculate_filter_level (base_qindex, TRUE);
++
++  /* *INDENT-OFF* */
++  vk_frame->loop_filter = (StdVideoAV1LoopFilter) {
++    .flags = (StdVideoAV1LoopFilterFlags) {
++      .loop_filter_delta_enabled = 0,
++      .loop_filter_delta_update = 0,
++    },
++    .loop_filter_level = { level_y, level_y, level_uv, level_uv },
++    .loop_filter_sharpness = 0,
++    .loop_filter_ref_deltas = { 1, 0, 0, 0, -1, 0, -1, -1 },
++    .loop_filter_mode_deltas = { 0, 0 },
++  };
++  /* *INDENT-ON* */
++}
++
++static void
++_av1_fill_cdef (GstVulkanAV1Encoder * self,
++    GstVulkanAV1EncoderFrame * vk_frame, guint32 base_qindex, guint width,
++    guint height)
++{
++  /* combined VA-style strengths (primary << 2 | secondary), split below */
++  guint32 strengths[STD_VIDEO_AV1_MAX_CDEF_FILTER_STRENGTHS] =
++      { 36, 50, 0, 24, 8, 17, 4, 9 };
++  guint8 cdef_bits = 3;
++  guint cdef_damping;
++  guint i;
++
++  /* Adjust the CDEF parameters for CQP mode; the values and Q-index bands
++   * follow gstvaav1enc's _av1_calculate_cdef_param. */
++  if (base_qindex < 90) {
++    strengths[0] = 5;
++    strengths[1] = 41;
++    strengths[3] = 6;
++    strengths[5] = 16;
++  } else if (base_qindex > 140) {
++    cdef_bits = 2;
++    strengths[1] = 63;
++    if (base_qindex > 210) {
++      cdef_bits = 1;
++      strengths[0] = 0;
++    }
++  } else {
++    cdef_bits = 2;
++    strengths[1] = 63;
++
++    if (width < 1600 && height < 1600)
++      strengths[3] = 1;
++    else
++      strengths[3] = 32;
++  }
++
++  cdef_damping = (base_qindex >> 6) + 3;
++
++  vk_frame->cdef = (StdVideoAV1CDEF) {
++    .cdef_damping_minus_3 = cdef_damping - 3,
++    .cdef_bits = cdef_bits,
++  };
++
++  for (i = 0; i < STD_VIDEO_AV1_MAX_CDEF_FILTER_STRENGTHS; i++) {
++    vk_frame->cdef.cdef_y_pri_strength[i] = strengths[i] >> 2;
++    vk_frame->cdef.cdef_y_sec_strength[i] = strengths[i] & 0x3;
++    vk_frame->cdef.cdef_uv_pri_strength[i] = strengths[i] >> 2;
++    vk_frame->cdef.cdef_uv_sec_strength[i] = strengths[i] & 0x3;
++  }
++}
++
++/* Single uniform tile (5.9.15 Tile info syntax, degenerated to
++ * TileCols == TileRows == 1); ported from gstvaav1enc's
++ * _av1_setup_tile_partition. The fit within the driver's tile limits was
++ * validated in new_sequence(). */
++static void
++_av1_fill_tile_info (GstVulkanAV1Encoder * self,
++    GstVulkanAV1EncoderFrame * vk_frame)
++{
++  /* *INDENT-OFF* */
++  vk_frame->tile_info = (StdVideoAV1TileInfo) {
++    .flags = (StdVideoAV1TileInfoFlags) {
++      .uniform_tile_spacing_flag = 1,
++    },
++    .TileCols = 1,
++    .TileRows = 1,
++    .context_update_tile_id = 0,
++    .tile_size_bytes_minus_1 = 3,
++    .pMiColStarts = NULL,
++    .pMiRowStarts = NULL,
++    .pWidthInSbsMinus1 = NULL,
++    .pHeightInSbsMinus1 = NULL,
++  };
++  /* *INDENT-ON* */
++}
++
++static void
++update_properties_unlocked (GstVulkanAV1Encoder * self)
++{
++  if (!self->update_props)
++    return;
++
++  GST_OBJECT_UNLOCK (self);
++  _reset_rc_props (self);
++  GST_OBJECT_LOCK (self);
++
++  self->update_props = FALSE;
++}
++
++/* bug A2: @ref_list, the raw 8-slot VBI, is deliberately unused here. This
++ * element needs the resolved reference view the base class computed
++ * (av1_frame->distinct_refs / ref_distinct_idx / ref_order_hint), not the
++ * codec frames; the vfunc keeps the parameter for subclasses that do. */
++static GstFlowReturn
++gst_vulkan_av1_encoder_encode_frame (GstAV1Encoder * base,
++    GstVideoCodecFrame * frame, GstAV1EncoderFrame * av1_frame,
++    GstVideoCodecFrame ** ref_list)
++{
++  GstVulkanAV1Encoder *self = GST_VULKAN_AV1_ENCODER (base);
++  GstVulkanAV1EncoderFrame *vk_frame = _GET_FRAME (av1_frame);
++  GstVulkanEncoderPicture *ref_pics[GST_AV1_NUM_REF_FRAMES] = { NULL, };
++  guint ref_pics_num = 0;
++  gboolean is_key = av1_frame->type == GST_AV1_KEY_FRAME;
++  guint32 keyframe_period, cqp;
++  gboolean rc_disabled;
++  gint i;
++
++  if (!gst_vulkan_encoder_is_started (self->encoder))
++    return GST_FLOW_NOT_NEGOTIATED;
++
++  GST_OBJECT_LOCK (self);
++  update_properties_unlocked (self);
++  GST_OBJECT_UNLOCK (self);
++
++  rc_disabled = self->rc.ratecontrol ==
++      VK_VIDEO_ENCODE_RATE_CONTROL_MODE_DISABLED_BIT_KHR;
++  cqp = is_key ? self->rc.qp_i : self->rc.qp_p;
++
++  keyframe_period = gst_av1_encoder_get_keyframe_period (base);
++  self->gop_remaining_intra = is_key ? 1 : 0;
++  self->gop_remaining_predictive = keyframe_period > av1_frame->frame_num + 1 ?
++      keyframe_period - 1 - av1_frame->frame_num : 0;
++
++  /* *INDENT-OFF* */
++  vk_frame->pic_info = (StdVideoEncodeAV1PictureInfo) {
++    .flags = (StdVideoEncodeAV1PictureInfoFlags) {
++      .error_resilient_mode = is_key,
++      .disable_cdf_update = 0,
++      .use_superres = 0,
++      .render_and_frame_size_different =
++          self->coded_width != GST_VIDEO_INFO_WIDTH (&self->in_state->info) ||
++          self->coded_height != GST_VIDEO_INFO_HEIGHT (&self->in_state->info),
++      .allow_screen_content_tools = 0,
++      .is_filter_switchable = 0,
++      .force_integer_mv = 0,
++      .frame_size_override_flag = 0,
++      .buffer_removal_time_present_flag = 0,
++      .allow_intrabc = 0,
++      .frame_refs_short_signaling = 0,
++      .allow_high_precision_mv = 0,
++      .is_motion_mode_switchable = 0,
++      .use_ref_frame_mvs = 0,
++      .disable_frame_end_update_cdf = 0,
++      .allow_warped_motion = 0,
++      .reduced_tx_set = 0,
++      .skip_mode_present = 0,
++      .delta_q_present = 0,
++      .delta_lf_present = 0,
++      .delta_lf_multi = 0,
++      .segmentation_enabled = 0,
++      .segmentation_update_map = 0,
++      .segmentation_temporal_update = 0,
++      .segmentation_update_data = 0,
++      .UsesLr = 0,
++      .usesChromaLr = 0,
++      .show_frame = 1,
++      .showable_frame = !is_key,
++    },
++    .frame_type = gst_vulkan_av1_frame_type (av1_frame->type),
++    .frame_presentation_time = 0,
++    .current_frame_id = av1_frame->frame_num,
++    .order_hint = av1_frame->order_hint,
++    /* quality: inherit the CDF/context state from LAST rather than
++     * resetting it every frame, when the driver supports the
++     * primary_ref_frame syntax (stdSyntaxFlags bit) */
++    .primary_ref_frame = (!is_key && self->hw.primary_ref_frame) ?
++        0 /* LAST */ : STD_VIDEO_AV1_PRIMARY_REF_NONE,
++    .refresh_frame_flags = av1_frame->refresh_frame_flags,
++    .coded_denom = 0,
++    .render_width_minus_1 = GST_VIDEO_INFO_WIDTH (&self->in_state->info) - 1,
++    .render_height_minus_1 = GST_VIDEO_INFO_HEIGHT (&self->in_state->info) - 1,
++    .interpolation_filter = STD_VIDEO_AV1_INTERPOLATION_FILTER_EIGHTTAP,
++    .TxMode = STD_VIDEO_AV1_TX_MODE_SELECT,
++    .delta_q_res = 0,
++    .delta_lf_res = 0,
++    .pTileInfo = &vk_frame->tile_info,
++    .pQuantization = NULL,
++    .pSegmentation = NULL,
++    .pLoopFilter = NULL,
++    .pCDEF = NULL,
++    .pLoopRestoration = NULL,
++    .pGlobalMotion = NULL,
++    .pExtensionHeader = NULL,
++    .pBufferRemovalTimes = NULL,
++  };
++
++  vk_frame->vkav1pic_info = (VkVideoEncodeAV1PictureInfoKHR) {
++    .sType = VK_STRUCTURE_TYPE_VIDEO_ENCODE_AV1_PICTURE_INFO_KHR,
++    .pNext = NULL, /* may become gop_remaining in _setup_codec_pic() */
++    .predictionMode = VK_VIDEO_ENCODE_AV1_PREDICTION_MODE_INTRA_ONLY_KHR,
++    .rateControlGroup = VK_VIDEO_ENCODE_AV1_RATE_CONTROL_GROUP_INTRA_KHR,
++    /* constantQIndex must be 0 whenever rate control is not DISABLED */
++    .constantQIndex = rc_disabled ? cqp : 0,
++    .pStdPictureInfo = &vk_frame->pic_info,
++    .primaryReferenceCdfOnly = VK_FALSE,
++    .generateObuExtensionHeader = VK_FALSE,
++  };
++  /* *INDENT-ON* */
++
++  memset (vk_frame->pic_info.ref_frame_idx, 0, STD_VIDEO_AV1_REFS_PER_FRAME);
++  memset (vk_frame->pic_info.delta_frame_id_minus_1, 0,
++      STD_VIDEO_AV1_REFS_PER_FRAME * sizeof (uint32_t));
++
++  _av1_fill_tile_info (self, vk_frame);
++
++  /* quality substructures: only meaningful in constant-QP mode; in CBR/VBR
++   * the driver's rate controller computes them per frame (NULL lets the
++   * driver fill in), following the gstvaav1enc policy. */
++  if (rc_disabled) {
++    _av1_fill_loop_filter (self, vk_frame, cqp);
++    vk_frame->pic_info.pLoopFilter = &vk_frame->loop_filter;
++
++    if (self->hw.enable_cdef) {
++      _av1_fill_cdef (self, vk_frame, cqp, self->coded_width,
++          self->coded_height);
++      vk_frame->pic_info.pCDEF = &vk_frame->cdef;
++    }
++  }
++
++  /* trap 7 (rev-1): referenceNameSlotIndices entries not backed by a real
++   * reference must be -1; anything else crashes the NVIDIA driver. */
++  memset (vk_frame->vkav1pic_info.referenceNameSlotIndices, -1,
++      STD_VIDEO_AV1_REFS_PER_FRAME * sizeof (int32_t));
++
++  /* bug A2: per-VBI-slot order hints, for all 8 slots. The base class
++   * prefilled them (0 for an empty slot) while it resolved the reference
++   * view, so there is no walk of the reference list here. */
++  for (i = 0; i < GST_AV1_NUM_REF_FRAMES; i++)
++    vk_frame->pic_info.ref_order_hint[i] = av1_frame->ref_order_hint[i];
++
++  if (!is_key) {
++    /* bug A2: the full 7-name reference map. Every name carries its VBI
++     * index in the bitstream, and the base class already collapsed the
++     * names that alias the same picture onto a distinct set, so each
++     * Vulkan DPB slot is bound exactly once (a requirement of
++     * gst_vulkan_encoder_encode()) without a dedup loop here. */
++    for (i = GST_AV1_REF_LAST_FRAME; i <= GST_AV1_REF_ALTREF_FRAME; i++) {
++      gint vbi_idx = av1_frame->ref_frame_idx[i];
++      gint distinct_idx = av1_frame->ref_distinct_idx[i];
++
++      g_assert (vbi_idx >= 0 && vbi_idx < GST_AV1_NUM_REF_FRAMES);
++      g_assert (distinct_idx >= 0
++          && distinct_idx < (gint) av1_frame->num_distinct_refs);
++
++      vk_frame->pic_info.ref_frame_idx[i - GST_AV1_REF_LAST_FRAME] = vbi_idx;
++
++      vk_frame->vkav1pic_info.referenceNameSlotIndices[i -
++          GST_AV1_REF_LAST_FRAME] =
++          _GET_FRAME (av1_frame->distinct_refs[distinct_idx])->picture.
++          dpb_slot.slotIndex;
++    }
++
++    for (i = 0; i < (gint) av1_frame->num_distinct_refs; i++)
++      ref_pics[i] = &_GET_FRAME (av1_frame->distinct_refs[i])->picture;
++    ref_pics_num = av1_frame->num_distinct_refs;
++
++    if (ref_pics_num > 1 && self->hw.unidir_compound) {
++      vk_frame->vkav1pic_info.predictionMode =
++          VK_VIDEO_ENCODE_AV1_PREDICTION_MODE_UNIDIRECTIONAL_COMPOUND_KHR;
++    } else {
++      vk_frame->vkav1pic_info.predictionMode =
++          VK_VIDEO_ENCODE_AV1_PREDICTION_MODE_SINGLE_REFERENCE_KHR;
++    }
++    vk_frame->vkav1pic_info.rateControlGroup =
++        VK_VIDEO_ENCODE_AV1_RATE_CONTROL_GROUP_PREDICTIVE_KHR;
++  }
++
++  /* *INDENT-OFF* */
++  vk_frame->ref_info = (StdVideoEncodeAV1ReferenceInfo) {
++    .flags = (StdVideoEncodeAV1ReferenceInfoFlags) {
++      .disable_frame_end_update_cdf = 0,
++      .segmentation_enabled = 0,
++    },
++    .RefFrameId = 0,
++    .frame_type = vk_frame->pic_info.frame_type,
++    .OrderHint = av1_frame->order_hint,
++    .pExtensionHeader = NULL,
++  };
++  /* *INDENT-ON* */
++
++  vk_frame->picture.codec_rc_info = &vk_frame->vkrc_info;
++
++  /* trap 3: keep picture.offset at 0 -- the temporal unit is assembled by
++   * concatenation in prepare_output() (the gstvaav1enc
++   * _av1_create_tu_output_buffer route), which sidesteps
++   * minBitstreamBufferOffsetAlignment padding entirely; AV1 has no filler
++   * OBU writer. */
++  vk_frame->picture.offset = 0;
++
++  if (!gst_vulkan_encoder_encode (self->encoder, &self->coded_info,
++          &vk_frame->picture, ref_pics_num, ref_pics)) {
++    GST_ERROR_OBJECT (self, "Encode frame error");
++    return GST_FLOW_ERROR;
++  }
++
++  /* The encode operation is fully synchronous (the library waits on the
++   * operation before returning) and later frames reference this picture
++   * only through its DPB reconstruction (dpb_buffer / dpb_slot), never
++   * through the source image.  Release the input buffer NOW rather than
++   * when the picture is evicted from the reference list: the base class
++   * keeps up to 8 pictures in the VBI, and holding 8 upstream buffers
++   * starves any fixed-ring upstream pool (e.g. a compositor exporting a
++   * small ring of VulkanImage buffers), serializing the whole pipeline on
++   * slot recycling.  gst_vulkan_encoder_picture_clear() unrefs img_view
++   * unconditionally, so swap it for a ref of the (still needed) DPB view
++   * instead of leaving it NULL. */
++  gst_clear_buffer (&vk_frame->picture.in_buffer);
++  gst_vulkan_image_view_unref (vk_frame->picture.img_view);
++  vk_frame->picture.img_view =
++      gst_vulkan_image_view_ref (vk_frame->picture.dpb_view);
++
++  return GST_FLOW_OK;
++}
++
++static GstFlowReturn
++gst_vulkan_av1_encoder_prepare_output (GstAV1Encoder * base,
++    GstVideoCodecFrame * frame)
++{
++  GstVulkanAV1Encoder *self = GST_VULKAN_AV1_ENCODER (base);
++  GstAV1EncoderFrame *av1_frame;
++  GstVulkanAV1EncoderFrame *vk_frame;
++  GstBuffer *buffer;
++  GstMapInfo info;
++  guint8 td_obu[8] = { 0, };
++  guint td_size = sizeof (td_obu);
++  gboolean is_key;
++  gsize total, offset = 0;
++
++  av1_frame = gst_video_codec_frame_get_user_data (frame);
++  vk_frame = _GET_FRAME (av1_frame);
++  is_key = av1_frame->type == GST_AV1_KEY_FRAME;
++
++  /* trap 2: the driver emits exactly one OBU_FRAME per encode operation,
++   * with has_size_field set and NO temporal delimiter. av1parse and
++   * rtpav1pay want one TD per temporal unit, so it is synthesized here
++   * (2 bytes). */
++  if (gst_av1_bit_writer_temporal_delimiter_obu (TRUE, td_obu, &td_size)
++      != GST_AV1_BIT_WRITER_OK) {
++    GST_ERROR_OBJECT (self, "Failed to write the temporal delimiter OBU");
++    return GST_FLOW_ERROR;
++  }
++
++  if (!gst_buffer_map (vk_frame->picture.out_buffer, &info, GST_MAP_READ)) {
++    GST_ERROR_OBJECT (self, "Failed to map the encoded buffer");
++    return GST_FLOW_ERROR;
++  }
++
++  total = td_size + (is_key ? self->seq_hdr_size : 0) + info.size;
++
++  buffer = gst_video_encoder_allocate_output_buffer
++      (GST_VIDEO_ENCODER_CAST (self), total);
++  if (!buffer) {
++    gst_buffer_unmap (vk_frame->picture.out_buffer, &info);
++    GST_ERROR_OBJECT (self, "Failed to allocate the output buffer");
++    return GST_FLOW_ERROR;
++  }
++
++  gst_buffer_fill (buffer, offset, td_obu, td_size);
++  offset += td_size;
++
++  /* trap 1: the driver-encoded OBU_SEQUENCE_HEADER bytes, verbatim, on
++   * every key frame */
++  if (is_key) {
++    gst_buffer_fill (buffer, offset, self->seq_hdr_data, self->seq_hdr_size);
++    offset += self->seq_hdr_size;
++  }
++
++  gst_buffer_fill (buffer, offset, info.data, info.size);
++  offset += info.size;
++
++  gst_buffer_unmap (vk_frame->picture.out_buffer, &info);
++
++  g_assert (offset == total);
++
++  gst_buffer_replace (&frame->output_buffer, buffer);
++  gst_buffer_unref (buffer);
++
++  return GST_FLOW_OK;
++}
++
++/* trap 9b: apply a bitrate change to an already-STARTED encoder without a
++ * reconfigure. The base-class configure() path would drain the encoder and
++ * reset the GOP index, making the very next frame a key frame -- so under
++ * sustained ABR the keyframe interval would collapse to the retarget
++ * interval (the exact defect the h264 element's rc-fix patched out).
++ * Shares _derive_rc_targets() with the configure path (bug A6: it used to
++ * carry its own copy of the clamp, which is how the two drifted). */
++static void
++_update_live_bitrate (GstVulkanAV1Encoder * self)
++{
++  GstVulkanVideoCapabilities vk_caps;
++
++  if (!gst_vulkan_encoder_caps (self->encoder, &vk_caps))
++    return;
++
++  GST_OBJECT_LOCK (self);
++  /* the property write that got us here is the new request; everything
++   * else is derived from it */
++  self->rc.bitrate = self->prop.bitrate;
++  GST_OBJECT_UNLOCK (self);
++
++  /* bug A6: the shared derivation. This call site neither publishes tags
++   * nor touches the QP properties -- and above all it does not
++   * reconfigure. */
++  _derive_rc_targets (self, &vk_caps);
++
++  GST_DEBUG_OBJECT (self, "live bitrate retarget to %u kbps (max %u): no "
++      "session reset, no reconfigure", self->rc.bitrate, self->rc.max_bitrate);
++
++  /* trap 9a companion: request_rc_update raises ENCODE_RATE_CONTROL_BIT
++   * only, so the video session keeps its DPB and no key frame is forced */
++  gst_vulkan_encoder_request_rc_update (self->encoder);
++}
++
++static void
++gst_vulkan_av1_encoder_reset (GstAV1Encoder * base)
++{
++  GstVulkanAV1Encoder *self = GST_VULKAN_AV1_ENCODER (base);
++
++  GST_OBJECT_LOCK (self);
++  self->rc.bitrate = self->prop.bitrate;
++  self->rc.quality = self->prop.quality;
++  GST_OBJECT_UNLOCK (self);
++
++  _reset_rc_props (self);
++
++  self->coded_buffer_size = 0;
++}
++
++static gboolean
++gst_vulkan_av1_encoder_open (GstVideoEncoder * base)
++{
++  GstVulkanAV1Encoder *self = GST_VULKAN_AV1_ENCODER (base);
++  GstVulkanAV1EncoderClass *klass = GST_VULKAN_AV1_ENCODER_GET_CLASS (self);
++  GstVulkanEncoderCallbacks callbacks = { _setup_codec_pic, _setup_rc_pic };
++
++  if (!gst_vulkan_ensure_element_data (GST_ELEMENT (self), NULL,
++          &self->instance)) {
++    GST_ELEMENT_ERROR (self, RESOURCE, NOT_FOUND,
++        ("Failed to retrieve vulkan instance"), (NULL));
++    return FALSE;
++  }
++
++  if (!gst_vulkan_ensure_element_device (GST_ELEMENT (self), self->instance,
++          &self->device, klass->device_index)) {
++    return FALSE;
++  }
++
++  self->encode_queue = gst_vulkan_device_select_queue (self->device,
++      VK_QUEUE_VIDEO_ENCODE_BIT_KHR);
++  if (!self->encode_queue) {
++    GST_ELEMENT_ERROR (self, RESOURCE, NOT_FOUND,
++        ("Failed to create/retrieve vulkan AV1 encoder queue"), (NULL));
++    gst_clear_object (&self->instance);
++    return FALSE;
++  }
++
++  self->encoder =
++      gst_vulkan_encoder_create_from_queue (self->encode_queue,
++      VK_VIDEO_CODEC_OPERATION_ENCODE_AV1_BIT_KHR);
++
++  if (!self->encoder) {
++    GST_ELEMENT_ERROR (self, RESOURCE, NOT_FOUND,
++        ("Failed to retrieve vulkan encoder"), (NULL));
++    return FALSE;
++  }
++
++  gst_vulkan_encoder_set_callbacks (self->encoder, &callbacks, self, NULL);
++
++  return TRUE;
++}
++
++static gboolean
++gst_vulkan_av1_encoder_close (GstVideoEncoder * encoder)
++{
++  GstVulkanAV1Encoder *self = GST_VULKAN_AV1_ENCODER (encoder);
++
++  gst_clear_object (&self->encoder);
++  gst_clear_object (&self->encode_queue);
++  gst_clear_object (&self->device);
++  gst_clear_object (&self->instance);
++
++  return TRUE;
++}
++
++static gboolean
++gst_vulkan_av1_encoder_stop (GstVideoEncoder * encoder)
++{
++  GstVulkanAV1Encoder *self = GST_VULKAN_AV1_ENCODER (encoder);
++
++  if (self->in_state)
++    gst_video_codec_state_unref (self->in_state);
++  self->in_state = NULL;
++
++  g_clear_pointer (&self->seq_hdr_data, g_free);
++  self->seq_hdr_size = 0;
++
++  gst_vulkan_encoder_stop (self->encoder);
++
++  return GST_VIDEO_ENCODER_CLASS (parent_class)->stop (encoder);
++}
++
++static gboolean
++_query_context (GstVulkanAV1Encoder * self, GstQuery * query)
++{
++  if (!self->encoder)
++    return FALSE;
++  if (gst_vulkan_handle_context_query (GST_ELEMENT (self), query, NULL,
++          self->instance, self->device))
++    return TRUE;
++
++  if (gst_vulkan_queue_handle_context_query (GST_ELEMENT (self), query,
++          self->encode_queue))
++    return TRUE;
++
++  return FALSE;
++}
++
++static gboolean
++gst_vulkan_av1_encoder_src_query (GstVideoEncoder * encoder, GstQuery * query)
++{
++  gboolean ret = FALSE;
++
++  switch (GST_QUERY_TYPE (query)) {
++    case GST_QUERY_CONTEXT:
++      ret = _query_context (GST_VULKAN_AV1_ENCODER (encoder), query);
++      break;
++    default:
++      ret = GST_VIDEO_ENCODER_CLASS (parent_class)->src_query (encoder, query);
++      break;
++  }
++
++  return ret;
++}
++
++static gboolean
++gst_vulkan_av1_encoder_sink_query (GstVideoEncoder * encoder, GstQuery * query)
++{
++  gboolean ret = FALSE;
++
++  switch (GST_QUERY_TYPE (query)) {
++    case GST_QUERY_CONTEXT:
++      ret = _query_context (GST_VULKAN_AV1_ENCODER (encoder), query);
++      break;
++    default:
++      ret = GST_VIDEO_ENCODER_CLASS (parent_class)->sink_query (encoder, query);
++      break;
++  }
++
++  return ret;
++}
++
++static gboolean
++gst_vulkan_av1_encoder_propose_allocation (GstVideoEncoder * venc,
++    GstQuery * query)
++{
++  gboolean need_pool;
++  GstCaps *caps, *profile_caps;
++  GstVideoInfo info;
++  guint size;
++  GstBufferPool *pool = NULL;
++  GstVulkanAV1Encoder *self = GST_VULKAN_AV1_ENCODER (venc);
++
++  if (!self->encoder) {
++    GST_ELEMENT_ERROR (self, RESOURCE, NOT_FOUND,
++        ("The vulkan encoder has not been initialized properly"), (NULL));
++    return FALSE;
++  }
++
++  gst_query_parse_allocation (query, &caps, &need_pool);
++
++  if (caps == NULL)
++    return FALSE;
++
++  if (!gst_video_info_from_caps (&info, caps))
++    return FALSE;
++
++  /* the normal size of a frame */
++  size = info.size;
++
++  if (!need_pool) {
++    gint height, width;
++
++    width = GST_VIDEO_INFO_WIDTH (&info);
++    height = GST_VIDEO_INFO_HEIGHT (&info);
++    need_pool = self->coded_width != width || self->coded_height != height;
++  }
++
++  if (need_pool) {
++    GstCaps *new_caps;
++    GstStructure *config;
++    GstVulkanVideoCapabilities vk_caps;
++
++    new_caps = gst_caps_copy (caps);
++    gst_caps_set_simple (new_caps, "width", G_TYPE_INT, self->coded_width,
++        "height", G_TYPE_INT, self->coded_height, NULL);
++
++    pool = gst_vulkan_image_buffer_pool_new (self->device);
++    config = gst_buffer_pool_get_config (pool);
++    gst_buffer_pool_config_set_params (config, new_caps, size, 0, 0);
++    gst_caps_unref (new_caps);
++
++    profile_caps = gst_vulkan_encoder_profile_caps (self->encoder);
++    gst_vulkan_image_buffer_pool_config_set_encode_caps (config, profile_caps);
++    gst_caps_unref (profile_caps);
++
++    gst_vulkan_image_buffer_pool_config_set_allocation_params (config,
++        VK_IMAGE_USAGE_TRANSFER_DST_BIT |
++        VK_IMAGE_USAGE_VIDEO_ENCODE_SRC_BIT_KHR,
++        VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
++        VK_IMAGE_LAYOUT_VIDEO_ENCODE_SRC_KHR,
++        VK_ACCESS_TRANSFER_READ_BIT | VK_ACCESS_TRANSFER_WRITE_BIT);
++
++    if (!gst_vulkan_encoder_caps (self->encoder, &vk_caps)) {
++      gst_structure_free (config);
++      g_object_unref (pool);
++      return FALSE;
++    }
++    if ((vk_caps.caps.
++            flags & VK_VIDEO_CAPABILITY_SEPARATE_REFERENCE_IMAGES_BIT_KHR)
++        == 0) {
++      gst_structure_set (config, "num-layers", G_TYPE_UINT,
++          vk_caps.caps.maxDpbSlots, NULL);
++    }
++
++    if (!gst_buffer_pool_set_config (pool, config)) {
++      GST_WARNING_OBJECT (self, "Failed to set pool config");
++      g_object_unref (pool);
++      return FALSE;
++    }
++  }
++
++  /* the 8-slot VBI plus the current frame */
++  gst_query_add_allocation_pool (query, pool, size,
++      GST_AV1_NUM_REF_FRAMES + 1, 0);
++  if (pool)
++    gst_object_unref (pool);
++
++  /* idempotent: already created in new_sequence() when the format ran
++   * first; covers the query-before-format ordering otherwise */
++  if (!gst_vulkan_encoder_create_dpb_pool (self->encoder, caps)) {
++    GST_ERROR_OBJECT (self, "Unable to create the dpb pool");
++    return FALSE;
++  }
++
++  return TRUE;
++}
++
++static gboolean
++gst_vulkan_av1_encoder_set_format (GstVideoEncoder * encoder,
++    GstVideoCodecState * state)
++{
++  gboolean ret;
++
++  ret = GST_VIDEO_ENCODER_CLASS (parent_class)->set_format (encoder, state);
++  if (ret)
++    ret = gst_av1_encoder_reconfigure (GST_AV1_ENCODER (encoder), TRUE);
++  return ret;
++}
++
++static void
++gst_vulkan_av1_encoder_init (GTypeInstance * instance, gpointer g_class)
++{
++  GstVulkanAV1Encoder *self = GST_VULKAN_AV1_ENCODER (instance);
++
++  gst_vulkan_buffer_memory_init_once ();
++
++  self->prop.qp_i = 128;
++  self->prop.qp_p = 128;
++  self->prop.max_qp = 0;
++  self->prop.min_qp = 0;
++  self->prop.ratecontrol = VK_VIDEO_ENCODE_RATE_CONTROL_MODE_DISABLED_BIT_KHR;
++  self->prop.quality = 2;
++}
++
++static void
++gst_vulkan_av1_encoder_get_property (GObject * object, guint property_id,
++    GValue * value, GParamSpec * pspec)
++{
++  GstVulkanAV1Encoder *self = GST_VULKAN_AV1_ENCODER (object);
++
++  GST_OBJECT_LOCK (self);
++  switch (property_id) {
++    case PROP_BITRATE:
++      g_value_set_uint (value, self->prop.bitrate);
++      break;
++    case PROP_QUALITY:
++      g_value_set_uint (value, self->prop.quality);
++      break;
++    case PROP_RATECONTROL:
++      g_value_set_enum (value, self->prop.ratecontrol);
++      break;
++    case PROP_QP_I:
++      g_value_set_uint (value, self->prop.qp_i);
++      break;
++    case PROP_QP_P:
++      g_value_set_uint (value, self->prop.qp_p);
++      break;
++    case PROP_MAX_QP:
++      g_value_set_uint (value, self->prop.max_qp);
++      break;
++    case PROP_MIN_QP:
++      g_value_set_uint (value, self->prop.min_qp);
++      break;
++    default:
++      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
++      break;
++  }
++  GST_OBJECT_UNLOCK (self);
++}
++
++static void
++gst_vulkan_av1_encoder_set_property (GObject * object, guint property_id,
++    const GValue * value, GParamSpec * pspec)
++{
++  GstVulkanAV1Encoder *self = GST_VULKAN_AV1_ENCODER (object);
++  GstAV1Encoder *av1enc = GST_AV1_ENCODER (object);
++  gboolean reconfigure = FALSE;
++  gboolean bitrate_changed = FALSE;
++
++  GST_OBJECT_LOCK (self);
++  switch (property_id) {
++    case PROP_BITRATE:
++      self->prop.bitrate = g_value_get_uint (value);
++      bitrate_changed = TRUE;
++      break;
++    case PROP_QUALITY:
++      self->prop.quality = g_value_get_uint (value);
++      reconfigure = TRUE;
++      break;
++    case PROP_RATECONTROL:
++      self->prop.ratecontrol = g_value_get_enum (value);
++      reconfigure = TRUE;
++      break;
++    case PROP_QP_I:
++      self->prop.qp_i = g_value_get_uint (value);
++      self->update_props = TRUE;
++      break;
++    case PROP_QP_P:
++      self->prop.qp_p = g_value_get_uint (value);
++      self->update_props = TRUE;
++      break;
++    case PROP_MAX_QP:
++      self->prop.max_qp = g_value_get_uint (value);
++      self->update_props = TRUE;
++      break;
++    case PROP_MIN_QP:
++      self->prop.min_qp = g_value_get_uint (value);
++      self->update_props = TRUE;
++      break;
++    default:
++      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
++      break;
++  }
++  GST_OBJECT_UNLOCK (self);
++
++  /* trap 9b: a live bitrate change must NOT go through
++   * gst_av1_encoder_reconfigure() -- configure() drains the encoder and
++   * resets the GOP, so the very next frame would be a key frame and under
++   * sustained ABR the keyframe interval would collapse to the retarget
++   * interval. Before start() there is nothing live to update, so the
++   * normal reconfigure path still runs. */
++  if (bitrate_changed) {
++    if (self->encoder && gst_vulkan_encoder_is_started (self->encoder))
++      _update_live_bitrate (self);
++    else
++      reconfigure = TRUE;
++  }
++
++  if (reconfigure)
++    gst_av1_encoder_reconfigure (av1enc, FALSE);
++}
++
++static void
++gst_vulkan_av1_encoder_class_init (gpointer g_klass, gpointer class_data)
++{
++  GstVulkanAV1EncoderClass *klass = g_klass;
++  GstElementClass *element_class = GST_ELEMENT_CLASS (klass);
++  GstVideoEncoderClass *encoder_class = GST_VIDEO_ENCODER_CLASS (klass);
++  GstAV1EncoderClass *av1encoder_class = GST_AV1_ENCODER_CLASS (klass);
++  GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
++  struct CData *cdata = class_data;
++  GParamFlags param_flags =
++      G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS | G_PARAM_CONSTRUCT
++      | GST_PARAM_MUTABLE_PLAYING;
++  gchar *long_name;
++  const gchar *name;
++  GstPadTemplate *sink_pad_template, *src_pad_template;
++  GstCaps *sink_doc_caps, *src_doc_caps;
++
++  name = "Vulkan AV1 encoder";
++  if (cdata->description)
++    long_name = g_strdup_printf ("%s on %s", name, cdata->description);
++  else
++    long_name = g_strdup (name);
++
++  klass->device_index = cdata->device_index;
++
++  gst_element_class_set_metadata (element_class, long_name,
++      "Codec/Encoder/Video/Hardware", "An AV1 video encoder based on Vulkan",
++      "Igalia, S.L.");
++
++  parent_class = g_type_class_peek_parent (klass);
++
++  src_doc_caps = gst_caps_from_string ("video/x-av1, "
++      "profile = (string) main, "
++      "stream-format = (string) obu-stream, alignment = (string) tu");
++  sink_doc_caps = gst_caps_from_string (GST_VIDEO_CAPS_MAKE_WITH_FEATURES
++      (GST_CAPS_FEATURE_MEMORY_VULKAN_IMAGE, "NV12"));
++
++  sink_pad_template =
++      gst_pad_template_new ("sink", GST_PAD_SINK, GST_PAD_ALWAYS, cdata->raw);
++  gst_element_class_add_pad_template (element_class, sink_pad_template);
++
++  src_pad_template =
++      gst_pad_template_new ("src", GST_PAD_SRC, GST_PAD_ALWAYS, cdata->codec);
++  gst_element_class_add_pad_template (element_class, src_pad_template);
++
++  gst_pad_template_set_documentation_caps (sink_pad_template, sink_doc_caps);
++  gst_caps_unref (sink_doc_caps);
++
++  gst_pad_template_set_documentation_caps (src_pad_template, src_doc_caps);
++  gst_caps_unref (src_doc_caps);
++
++  gobject_class->set_property =
++      GST_DEBUG_FUNCPTR (gst_vulkan_av1_encoder_set_property);
++  gobject_class->get_property =
++      GST_DEBUG_FUNCPTR (gst_vulkan_av1_encoder_get_property);
++
++  encoder_class->open = GST_DEBUG_FUNCPTR (gst_vulkan_av1_encoder_open);
++  encoder_class->close = GST_DEBUG_FUNCPTR (gst_vulkan_av1_encoder_close);
++  encoder_class->stop = GST_DEBUG_FUNCPTR (gst_vulkan_av1_encoder_stop);
++  encoder_class->src_query =
++      GST_DEBUG_FUNCPTR (gst_vulkan_av1_encoder_src_query);
++  encoder_class->sink_query =
++      GST_DEBUG_FUNCPTR (gst_vulkan_av1_encoder_sink_query);
++  encoder_class->propose_allocation =
++      GST_DEBUG_FUNCPTR (gst_vulkan_av1_encoder_propose_allocation);
++  encoder_class->set_format =
++      GST_DEBUG_FUNCPTR (gst_vulkan_av1_encoder_set_format);
++
++  av1encoder_class->new_sequence =
++      GST_DEBUG_FUNCPTR (gst_vulkan_av1_encoder_new_sequence);
++  av1encoder_class->new_output =
++      GST_DEBUG_FUNCPTR (gst_vulkan_av1_encoder_new_output);
++  av1encoder_class->encode_frame =
++      GST_DEBUG_FUNCPTR (gst_vulkan_av1_encoder_encode_frame);
++  av1encoder_class->prepare_output =
++      GST_DEBUG_FUNCPTR (gst_vulkan_av1_encoder_prepare_output);
++  av1encoder_class->reset = GST_DEBUG_FUNCPTR (gst_vulkan_av1_encoder_reset);
++
++  /**
++   * GstVulkanAV1Encoder:bitrate:
++   *
++   * Bitrate is the amount of data (in kilobits) to process per second. It's
++   * both a function of the encoded bitstream data size of the encoded
++   * pictures as well as the frame rate used by the video sequence.
++   *
++   * A higher bitrate will result in a better visual quality but it will
++   * result in a bigger file. A lower bitrate will result in a smaller file,
++   * but it will also result in a worse visual quality.
++   *
++   * Since: 1.28
++   */
++  properties[PROP_BITRATE] = g_param_spec_uint ("bitrate", "Bitrate (kbps)",
++      "The desired bitrate expressed in kbps (0: auto-calculate)",
++      0, G_MAXUINT, 0, param_flags);
++
++  /**
++   * GstVulkanAV1Encoder:qp-i:
++   *
++   * Indicates the quantization index for each intra frame. It's only
++   * applied when the rate control mode (#GstVulkanAV1Encoder:rate-control)
++   * is CQP (constant quantization).
++   *
++   * Lower Q index values mean higher video quality, but larger file sizes
++   * or higher bitrates.
++   *
++   * Since: 1.28
++   */
++  properties[PROP_QP_I] = g_param_spec_uint ("qp-i", "Constant key frame QI",
++      "Constant quantization index for each key frame", 0, 255, 128,
++      param_flags);
++
++  /**
++   * GstVulkanAV1Encoder:qp-p:
++   *
++   * Indicates the quantization index for each inter frame. It's only
++   * applied when the rate control mode (#GstVulkanAV1Encoder:rate-control)
++   * is CQP (constant quantization).
++   *
++   * Lower Q index values mean higher video quality, but larger file sizes
++   * or higher bitrates.
++   *
++   * Since: 1.28
++   */
++  properties[PROP_QP_P] = g_param_spec_uint ("qp-p", "Constant inter frame QI",
++      "Constant quantization index for each inter frame", 0, 255, 128,
++      param_flags);
++
++  /**
++   * GstVulkanAV1Encoder:max-qp:
++   *
++   * Indicates the quantization index upper bound for each frame. It's only
++   * applied when the rate control mode (#GstVulkanAV1Encoder:rate-control)
++   * is either CBR (constant bitrate) or VBR (variable bitrate), and only
++   * honoured when the driver supports per-rate-control-group Q index
++   * bounds.
++   *
++   * If zero, the upper bound will not be clamped.
++   *
++   * Since: 1.28
++   */
++  properties[PROP_MAX_QP] = g_param_spec_uint ("max-qp", "Maximum QI",
++      "Maximum quantization index for each frame (0: disabled)", 0, 255, 0,
++      param_flags);
++
++  /**
++   * GstVulkanAV1Encoder:min-qp:
++   *
++   * Indicates the quantization index lower bound for each frame. It's only
++   * applied when the rate control mode (#GstVulkanAV1Encoder:rate-control)
++   * is either CBR (constant bitrate) or VBR (variable bitrate), and only
++   * honoured when the driver supports per-rate-control-group Q index
++   * bounds.
++   *
++   * If zero, the lower bound will not be clamped.
++   *
++   * Since: 1.28
++   */
++  properties[PROP_MIN_QP] = g_param_spec_uint ("min-qp", "Minimum QI",
++      "Minimum quantization index for each frame (0: disabled)", 0, 255, 0,
++      param_flags);
++
++  /**
++   * GstVulkanAV1Encoder:rate-control:
++   *
++   * Rate control algorithms adjust encoding parameters dynamically to
++   * regulate the output bitrate.
++   *
++   * Since: 1.28
++   */
++  properties[PROP_RATECONTROL] = g_param_spec_enum ("rate-control",
++      "rate control mode", "The encoding rate control mode to use",
++      GST_TYPE_VULKAN_ENCODER_RATE_CONTROL_MODE,
++      VK_VIDEO_ENCODE_RATE_CONTROL_MODE_DISABLED_BIT_KHR, param_flags);
++
++  /**
++   * GstVulkanAV1Encoder:quality:
++   *
++   * Video encode quality level.
++   *
++   * Higher quality levels may produce higher quality videos at the cost of
++   * additional processing time.
++   *
++   * Since: 1.28
++   */
++  properties[PROP_QUALITY] = g_param_spec_uint ("quality", "quality level",
++      "Video encoding quality level", 0, 10, 2, param_flags);
++
++  g_object_class_install_properties (gobject_class, N_PROPERTIES, properties);
++
++  /* since GstVulkanEncoder is private API */
++  gst_type_mark_as_plugin_api (GST_TYPE_VULKAN_ENCODER_RATE_CONTROL_MODE, 0);
++
++  g_free (long_name);
++  g_free (cdata->description);
++  gst_clear_caps (&cdata->codec);
++  gst_clear_caps (&cdata->raw);
++  g_free (cdata);
++}
++
++gboolean
++gst_vulkan_av1_encoder_register (GstPlugin * plugin, GstVulkanDevice * device,
++    guint rank)
++{
++  static GOnce debug_once = G_ONCE_INIT;
++  GType type;
++  GTypeInfo type_info = {
++    .class_size = sizeof (GstVulkanAV1EncoderClass),
++    .class_init = gst_vulkan_av1_encoder_class_init,
++    .instance_size = sizeof (GstVulkanAV1Encoder),
++    .instance_init = gst_vulkan_av1_encoder_init,
++  };
++  struct CData *cdata;
++  gboolean ret;
++  gchar *type_name, *feature_name;
++  GstCaps *codec = NULL, *raw = NULL;
++
++  g_return_val_if_fail (GST_IS_PLUGIN (plugin), FALSE);
++  g_return_val_if_fail (GST_IS_VULKAN_DEVICE (device), FALSE);
++
++  if (!gst_vulkan_physical_device_codec_caps (device->physical_device,
++          VK_VIDEO_CODEC_OPERATION_ENCODE_AV1_BIT_KHR, &codec, &raw)) {
++    gst_plugin_add_status_warning (plugin,
++        "Unable to query AV1 encoder properties");
++    return FALSE;
++  }
++
++  cdata = g_new (struct CData, 1);
++  cdata->description = NULL;
++  cdata->device_index = device->physical_device->device_index;
++  cdata->codec = codec;
++  cdata->raw = raw;
++
++  /* class data will be leaked if the element never gets instantiated */
++  GST_MINI_OBJECT_FLAG_SET (cdata->codec, GST_MINI_OBJECT_FLAG_MAY_BE_LEAKED);
++  GST_MINI_OBJECT_FLAG_SET (cdata->raw, GST_MINI_OBJECT_FLAG_MAY_BE_LEAKED);
++
++  gst_vulkan_create_feature_name (device, "GstVulkanAV1Encoder",
++      "GstVulkanAV1Device%dEncoder", &type_name, "vulkanav1enc",
++      "vulkanav1device%denc", &feature_name, &cdata->description, &rank);
++
++  type_info.class_data = cdata;
++
++  g_once (&debug_once, _register_debug_category, NULL);
++  type = g_type_register_static (GST_TYPE_AV1_ENCODER,
++      type_name, &type_info, 0);
++
++  ret = gst_element_register (plugin, feature_name, rank, type);
++
++  g_free (type_name);
++  g_free (feature_name);
++
++  return ret;
++}
+diff --git a/subprojects/gst-plugins-bad/ext/vulkan/vkav1enc.h b/subprojects/gst-plugins-bad/ext/vulkan/vkav1enc.h
+new file mode 100644
+index 00000000..276a5cd0
+--- /dev/null
++++ b/subprojects/gst-plugins-bad/ext/vulkan/vkav1enc.h
+@@ -0,0 +1,30 @@
++/* GStreamer
++ * Copyright (C) 2026 Igalia, S.L.
++ *
++ * This library is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU Library General Public
++ * License as published by the Free Software Foundation; either
++ * version 2 of the License, or (at your option) any later version.
++ *
++ * This library is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++ * Library General Public License for more details.
++ *
++ * You should have received a copy of the GNU Library General Public
++ * License along with this library; if not, write to the
++ * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
++ * Boston, MA 02110-1301, USA.
++ */
++
++#pragma once
++
++#include <gst/vulkan/vulkan.h>
++
++G_BEGIN_DECLS
++
++gboolean                gst_vulkan_av1_encoder_register         (GstPlugin * plugin,
++                                                                 GstVulkanDevice * device,
++                                                                 guint rank);
++
++G_END_DECLS
+diff --git a/subprojects/gst-plugins-bad/tests/check/libs/vkvideoencodeav1refs.c b/subprojects/gst-plugins-bad/tests/check/libs/vkvideoencodeav1refs.c
+new file mode 100644
+index 00000000..4813c371
+--- /dev/null
++++ b/subprojects/gst-plugins-bad/tests/check/libs/vkvideoencodeav1refs.c
+@@ -0,0 +1,1173 @@
++/* GStreamer
++ *
++ * Copyright (C) 2026 Igalia, S.L.
++ *
++ * This library is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU Library General Public
++ * License as published by the Free Software Foundation; either
++ * version 2 of the License, or (at your option) any later version.
++ *
++ * This library is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++ * Library General Public License for more details.
++ *
++ * You should have received a copy of the GNU Library General Public
++ * License along with this library; if not, write to the
++ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
++ * Boston, MA 02111-1307, USA.
++ */
++
++/* Unit tests for the GstAV1Encoder reference model: reference-name
++ * assignment, VBI slot selection/eviction, golden-frame demotion and the
++ * order-hint mask.
++ *
++ * Unlike libs/vkvideoencodeav1.c and the CBR experiment, this suite needs NO
++ * Vulkan at all -- no instance, no device, no GPU, no display and no
++ * GST_STATE_IGNORE_ELEMENTS. It drives the base class's decision logic
++ * directly through the internal test seam declared in gstav1encoder.h.
++ *
++ * The base-class object is only ever built INSIDE the vulkan plugin
++ * (ext/vulkan/base/gstav1encoder.c is a plugin source, and its symbols carry
++ * no export macro, so they are hidden in the built .so). There is therefore
++ * nothing to link against: the test includes the implementation file
++ * directly, which is the accepted gst-check pattern for plugin-internal code.
++ * The G_GNUC_INTERNAL prototypes in gstav1encoder.h are consequently not
++ * needed for linking; they are kept as the documented shape of the seam.
++ *
++ * Register it in subprojects/gst-plugins-bad/tests/check/meson.build, right
++ * after the existing libs/vkvideoencodeav1.c entry:
++ *
++ *  [['libs/vkvideoencodeav1refs.c'], false, [gstvideo_dep, gstcodecparsers_dep]],
++ *
++ * then:
++ *   ninja -C build subprojects/gst-plugins-bad/tests/check/libs_vkvideoencodeav1refs
++ *   meson test -C build libs_vkvideoencodeav1refs --verbose
++ */
++
++#ifdef HAVE_CONFIG_H
++#include "config.h"
++#endif
++
++#include <gst/check/gstcheck.h>
++
++/* gstcheck.h defines GST_CAT_DEFAULT as check_debug and gstav1encoder.c
++ * defines its own category; drop ours before pulling the implementation in,
++ * otherwise the macro is redefined. */
++#undef GST_CAT_DEFAULT
++
++#include "../../../ext/vulkan/base/gstav1encoder.c"
++
++/* Every #GstAV1EncoderFrame created by a test lands here and is released at
++ * teardown, so the VBI arrays below can hold plain borrowed pointers (which
++ * is exactly what the seam sees at runtime). */
++static GPtrArray *test_frames;
++
++static void
++setup (void)
++{
++  /* Registers the type, which is what runs GST_DEBUG_CATEGORY_INIT for
++   * gst_av1_encoder_debug -- the seam's GST_ERROR_OBJECT/GST_WARNING_OBJECT
++   * calls would otherwise log against an uninitialised category. */
++  (void) gst_av1_encoder_get_type ();
++
++  test_frames = g_ptr_array_new_with_free_func (gst_av1_encoder_frame_unref);
++}
++
++static void
++teardown (void)
++{
++  g_clear_pointer (&test_frames, g_ptr_array_unref);
++}
++
++static GstAV1EncoderFrame *
++make_frame (GstAV1FrameType type, guint32 frame_num, gboolean is_golden)
++{
++  GstAV1EncoderFrame *frame = gst_av1_encoder_frame_new ();
++
++  frame->type = type;
++  frame->frame_num = frame_num;
++  frame->order_hint = gst_av1_encoder_order_hint (frame_num);
++  frame->is_golden = is_golden;
++
++  g_ptr_array_add (test_frames, frame);
++
++  return frame;
++}
++
++static void
++clear_refs (GstAV1EncoderFrame ** refs)
++{
++  gint i;
++
++  for (i = 0; i < GST_AV1_NUM_REF_FRAMES; i++)
++    refs[i] = NULL;
++}
++
++/* How many DISTINCT VBI slots the 7 reference names resolve to. */
++static gint
++distinct_ref_slots (GstAV1EncoderFrame * frame)
++{
++  gboolean seen[GST_AV1_NUM_REF_FRAMES] = { FALSE, };
++  gint i, n = 0;
++
++  for (i = GST_AV1_REF_LAST_FRAME; i < GST_AV1_NUM_REF_FRAMES; i++) {
++    gint idx = frame->ref_frame_idx[i];
++
++    if (idx < 0)
++      continue;
++
++    if (!seen[idx]) {
++      seen[idx] = TRUE;
++      n++;
++    }
++  }
++
++  return n;
++}
++
++/* How many SLOTS hold a golden frame. */
++static gint
++count_goldens (GstAV1EncoderFrame ** refs)
++{
++  gint i, n = 0;
++
++  for (i = 0; i < GST_AV1_NUM_REF_FRAMES; i++) {
++    if (refs[i] && refs[i]->is_golden)
++      n++;
++  }
++
++  return n;
++}
++
++/* How many DISTINCT pictures the VBI holds. Slot occupancy is a different
++ * number: a key frame refreshes all eight slots with ONE picture (A9), so
++ * what the model really costs -- reference pictures, and therefore DPB
++ * images -- is counted here, and this is what the reference budget bounds
++ * (A3). */
++static guint
++distinct_refs_held (GstAV1EncoderFrame ** refs)
++{
++  GstAV1EncoderFrame *seen[GST_AV1_NUM_REF_FRAMES];
++  guint n = 0;
++  gint i, j;
++
++  for (i = 0; i < GST_AV1_NUM_REF_FRAMES; i++) {
++    if (!refs[i])
++      continue;
++
++    for (j = 0; j < (gint) n; j++) {
++      if (seen[j] == refs[i])
++        break;
++    }
++    if (j == (gint) n)
++      seen[n++] = refs[i];
++  }
++
++  return n;
++}
++
++/* Distinct golden PICTURES, which is the invariant the model maintains once
++ * one picture can occupy eight slots at a time. */
++static gint
++count_distinct_goldens (GstAV1EncoderFrame ** refs)
++{
++  GstAV1EncoderFrame *seen[GST_AV1_NUM_REF_FRAMES];
++  gint i, j, n = 0;
++
++  for (i = 0; i < GST_AV1_NUM_REF_FRAMES; i++) {
++    if (!refs[i] || !refs[i]->is_golden)
++      continue;
++
++    for (j = 0; j < n; j++) {
++      if (seen[j] == refs[i])
++        break;
++    }
++    if (j == n)
++      seen[n++] = refs[i];
++  }
++
++  return n;
++}
++
++/* How many slots hold @frame. */
++static gint
++ref_copies (GstAV1EncoderFrame ** refs, GstAV1EncoderFrame * frame)
++{
++  gint i, n = 0;
++
++  for (i = 0; i < GST_AV1_NUM_REF_FRAMES; i++) {
++    if (refs[i] == frame)
++      n++;
++  }
++
++  return n;
++}
++
++/* Mirror of gst_av1_encoder_update_ref_list(), which owns codec-frame
++ * refcounting and so is not part of the seam. A key frame lands in ALL
++ * EIGHT slots (bug A9: refresh_frame_flags == 0xff, which is what a decoder
++ * acts on); every other frame refreshes its single slot. Callers clear the
++ * VBI before a key frame, as update_ref_list() does. */
++static void
++vbi_update (GstAV1EncoderFrame ** refs, GstAV1EncoderFrame * frame)
++{
++  gint i;
++
++  if (frame->type == GST_AV1_KEY_FRAME) {
++    for (i = 0; i < GST_AV1_NUM_REF_FRAMES; i++)
++      refs[i] = frame;
++
++    gst_av1_encoder_demote_golden (refs, frame);
++    return;
++  }
++
++  if (frame->update_index < 0)
++    return;
++
++  refs[frame->update_index] = frame;
++  gst_av1_encoder_demote_golden (refs, frame);
++}
++
++/* Slot 0 holds the golden anchor (frame_num 0), slots 1..3 hold frames 1..3.
++ * The frame under test is inter frame_num 4. */
++static GstAV1EncoderFrame *
++setup_simple_gop (GstAV1EncoderFrame ** refs)
++{
++  clear_refs (refs);
++
++  refs[0] = make_frame (GST_AV1_KEY_FRAME, 0, TRUE);
++  refs[1] = make_frame (GST_AV1_INTER_FRAME, 1, FALSE);
++  refs[2] = make_frame (GST_AV1_INTER_FRAME, 2, FALSE);
++  refs[3] = make_frame (GST_AV1_INTER_FRAME, 3, FALSE);
++
++  return make_frame (GST_AV1_INTER_FRAME, 4, FALSE);
++}
++
++/* ------------------------------------------------------------------ */
++/* key frames                                                          */
++/* ------------------------------------------------------------------ */
++
++GST_START_TEST (test_av1_refs_key_frame)
++{
++  GstAV1EncoderFrame *refs[GST_AV1_NUM_REF_FRAMES];
++  GstAV1EncoderFrame *key;
++  gint i;
++
++  clear_refs (refs);
++  key = make_frame (GST_AV1_KEY_FRAME, 0, TRUE);
++
++  /* poison the name map so the reset is observable */
++  for (i = 0; i < GST_AV1_NUM_REF_FRAMES; i++)
++    key->ref_frame_idx[i] = 5;
++
++  fail_unless (gst_av1_encoder_assign_ref_index (NULL, refs, 3, 4, key));
++
++  /* a key frame references nothing, INTRA_FRAME (0) included */
++  for (i = 0; i < GST_AV1_NUM_REF_FRAMES; i++)
++    assert_equals_int (key->ref_frame_idx[i], -1);
++
++  gst_av1_encoder_find_ref_to_update (refs, 3, 4, key);
++
++  /* slot 0, and the whole VBI is refreshed */
++  assert_equals_int (key->update_index, 0);
++  assert_equals_int (key->refresh_frame_flags, 0xff);
++}
++
++GST_END_TEST;
++
++/* A key frame ignores whatever the VBI currently holds: it never assigns a
++ * name and it always lands on slot 0 with a full refresh mask. */
++GST_START_TEST (test_av1_refs_key_frame_ignores_ref_list)
++{
++  GstAV1EncoderFrame *refs[GST_AV1_NUM_REF_FRAMES];
++  GstAV1EncoderFrame *key;
++  gint i;
++
++  (void) setup_simple_gop (refs);
++  key = make_frame (GST_AV1_KEY_FRAME, 0, TRUE);
++
++  fail_unless (gst_av1_encoder_assign_ref_index (NULL, refs, 4, 4, key));
++  for (i = 0; i < GST_AV1_NUM_REF_FRAMES; i++)
++    assert_equals_int (key->ref_frame_idx[i], -1);
++
++  gst_av1_encoder_find_ref_to_update (refs, 4, 4, key);
++  assert_equals_int (key->update_index, 0);
++  assert_equals_int (key->refresh_frame_flags, 0xff);
++}
++
++GST_END_TEST;
++
++/* bug A9: refresh_frame_flags == 0xff is not decoration. A decoder puts the
++ * key frame in all eight reference slots, so the model must hold it in all
++ * eight too -- the two used to agree only by accident (the unmodelled slots
++ * were never named, and the subclass zero-filled the order hint of every
++ * slot it believed empty). This also pins the A3 interaction: the eight
++ * copies are ONE picture, and an inter frame recycles a redundant copy
++ * rather than the anchor. */
++GST_START_TEST (test_av1_refs_key_frame_fills_vbi)
++{
++  GstAV1EncoderFrame *refs[GST_AV1_NUM_REF_FRAMES];
++  GstAV1EncoderFrame *key, *inter;
++  gint i;
++
++  /* start from a populated VBI so the clear is observable */
++  (void) setup_simple_gop (refs);
++  key = make_frame (GST_AV1_KEY_FRAME, 0, TRUE);
++
++  fail_unless (gst_av1_encoder_assign_ref_index (NULL, refs, 3, 4, key));
++  gst_av1_encoder_resolve_refs (refs, key);
++  gst_av1_encoder_find_ref_to_update (refs, 3, 4, key);
++
++  assert_equals_int (key->refresh_frame_flags, 0xff);
++
++  clear_refs (refs);            /* update_ref_list() clears on a key frame */
++  vbi_update (refs, key);
++
++  for (i = 0; i < GST_AV1_NUM_REF_FRAMES; i++)
++    fail_unless (refs[i] == key, "slot %d does not hold the key frame", i);
++
++  assert_equals_int (ref_copies (refs, key), GST_AV1_NUM_REF_FRAMES);
++  /* eight slots, one picture: the model costs one DPB image, not eight */
++  assert_equals_int (distinct_refs_held (refs), 1);
++  assert_equals_int (count_goldens (refs), GST_AV1_NUM_REF_FRAMES);
++  assert_equals_int (count_distinct_goldens (refs), 1);
++
++  /* the next inter frame */
++  inter = make_frame (GST_AV1_INTER_FRAME, 1, FALSE);
++
++  fail_unless (gst_av1_encoder_assign_ref_index (NULL, refs, 3, 4, inter));
++  gst_av1_encoder_resolve_refs (refs, inter);
++  gst_av1_encoder_find_ref_to_update (refs, 3, 4, inter);
++
++  /* the names now legally spread over several slots -- which is exactly
++   * what the old model could not express -- and every one of them resolves
++   * to the same picture */
++  fail_unless (distinct_ref_slots (inter) > 1);
++  assert_equals_int (inter->num_distinct_refs, 1);
++  fail_unless (inter->distinct_refs[0] == key);
++  for (i = GST_AV1_REF_LAST_FRAME; i < GST_AV1_NUM_REF_FRAMES; i++) {
++    fail_unless (refs[inter->ref_frame_idx[i]] == key);
++    assert_equals_int (inter->ref_distinct_idx[i], 0);
++  }
++
++  /* the victim is a redundant copy, never slot 0 which holds the copy the
++   * model counts */
++  assert_equals_int (inter->update_index, 1);
++
++  vbi_update (refs, inter);
++
++  assert_equals_int (ref_copies (refs, key), GST_AV1_NUM_REF_FRAMES - 1);
++  assert_equals_int (distinct_refs_held (refs), 2);
++  /* the anchor survived being "evicted" */
++  fail_unless (key->is_golden);
++  assert_equals_int (count_distinct_goldens (refs), 1);
++}
++
++GST_END_TEST;
++
++/* ------------------------------------------------------------------ */
++/* forward-only inter frames                                           */
++/* ------------------------------------------------------------------ */
++
++/* LAST = most recent, GOLDEN = the anchor, LAST2/LAST3 = the next most
++ * recent distinct references, BWDREF/ALTREF2/ALTREF alias GOLDEN. */
++GST_START_TEST (test_av1_refs_forward_inter)
++{
++  GstAV1EncoderFrame *refs[GST_AV1_NUM_REF_FRAMES];
++  GstAV1EncoderFrame *cur = setup_simple_gop (refs);
++
++  fail_unless (gst_av1_encoder_assign_ref_index (NULL, refs, 4, 4, cur));
++
++  assert_equals_int (cur->ref_frame_idx[GST_AV1_REF_INTRA_FRAME], -1);
++  assert_equals_int (cur->ref_frame_idx[GST_AV1_REF_LAST_FRAME], 3);
++  assert_equals_int (cur->ref_frame_idx[GST_AV1_REF_LAST2_FRAME], 2);
++  assert_equals_int (cur->ref_frame_idx[GST_AV1_REF_LAST3_FRAME], 1);
++  assert_equals_int (cur->ref_frame_idx[GST_AV1_REF_GOLDEN_FRAME], 0);
++  assert_equals_int (cur->ref_frame_idx[GST_AV1_REF_BWDREF_FRAME], 0);
++  assert_equals_int (cur->ref_frame_idx[GST_AV1_REF_ALTREF2_FRAME], 0);
++  assert_equals_int (cur->ref_frame_idx[GST_AV1_REF_ALTREF_FRAME], 0);
++
++  assert_equals_int (distinct_ref_slots (cur), 4);
++}
++
++GST_END_TEST;
++
++/* With no golden in the list the most recent reference is promoted, so
++ * GOLDEN collapses onto LAST and costs no budget. */
++GST_START_TEST (test_av1_refs_no_golden_fallback)
++{
++  GstAV1EncoderFrame *refs[GST_AV1_NUM_REF_FRAMES];
++  GstAV1EncoderFrame *cur;
++
++  clear_refs (refs);
++  refs[1] = make_frame (GST_AV1_INTER_FRAME, 1, FALSE);
++  refs[2] = make_frame (GST_AV1_INTER_FRAME, 2, FALSE);
++  cur = make_frame (GST_AV1_INTER_FRAME, 3, FALSE);
++
++  fail_unless (gst_av1_encoder_assign_ref_index (NULL, refs, 4, 4, cur));
++
++  assert_equals_int (cur->ref_frame_idx[GST_AV1_REF_LAST_FRAME], 2);
++  assert_equals_int (cur->ref_frame_idx[GST_AV1_REF_GOLDEN_FRAME], 2);
++  assert_equals_int (cur->ref_frame_idx[GST_AV1_REF_LAST2_FRAME], 1);
++  /* nothing left to hand LAST3: it aliases LAST */
++  assert_equals_int (cur->ref_frame_idx[GST_AV1_REF_LAST3_FRAME], 2);
++  assert_equals_int (cur->ref_frame_idx[GST_AV1_REF_ALTREF_FRAME], 2);
++  assert_equals_int (distinct_ref_slots (cur), 2);
++}
++
++GST_END_TEST;
++
++/* An inter frame with an empty VBI is a hard error, not a silent intra. */
++GST_START_TEST (test_av1_refs_inter_without_references)
++{
++  GstAV1EncoderFrame *refs[GST_AV1_NUM_REF_FRAMES];
++  GstAV1EncoderFrame *cur;
++
++  clear_refs (refs);
++  cur = make_frame (GST_AV1_INTER_FRAME, 1, FALSE);
++
++  fail_if (gst_av1_encoder_assign_ref_index (NULL, refs, 3, 4, cur));
++}
++
++GST_END_TEST;
++
++/* ------------------------------------------------------------------ */
++/* the resolved reference view (bug A2)                                */
++/* ------------------------------------------------------------------ */
++
++/* The name map is a bitstream shape; an accelerator needs the opposite one,
++ * each reference picture bound exactly once. gst_av1_encoder_resolve_refs()
++ * projects one onto the other so no subclass has to. */
++GST_START_TEST (test_av1_refs_resolved_view)
++{
++  GstAV1EncoderFrame *refs[GST_AV1_NUM_REF_FRAMES];
++  GstAV1EncoderFrame *cur, *anchor;
++  gint i;
++
++  /* (a) four distinct references. The distinct list is ordered by first
++   *     appearance scanning the names LAST..ALTREF, NOT by VBI index. */
++  cur = setup_simple_gop (refs);
++  fail_unless (gst_av1_encoder_assign_ref_index (NULL, refs, 4, 4, cur));
++  gst_av1_encoder_resolve_refs (refs, cur);
++
++  assert_equals_int (cur->num_distinct_refs, 4);
++  fail_unless (cur->distinct_refs[0] == refs[3]);       /* LAST  */
++  fail_unless (cur->distinct_refs[1] == refs[2]);       /* LAST2 */
++  fail_unless (cur->distinct_refs[2] == refs[1]);       /* LAST3 */
++  fail_unless (cur->distinct_refs[3] == refs[0]);       /* GOLDEN */
++
++  assert_equals_int (cur->ref_distinct_idx[GST_AV1_REF_INTRA_FRAME], -1);
++  assert_equals_int (cur->ref_distinct_idx[GST_AV1_REF_LAST_FRAME], 0);
++  assert_equals_int (cur->ref_distinct_idx[GST_AV1_REF_LAST2_FRAME], 1);
++  assert_equals_int (cur->ref_distinct_idx[GST_AV1_REF_LAST3_FRAME], 2);
++  assert_equals_int (cur->ref_distinct_idx[GST_AV1_REF_GOLDEN_FRAME], 3);
++  /* the three backward names alias GOLDEN and cost no extra binding */
++  assert_equals_int (cur->ref_distinct_idx[GST_AV1_REF_BWDREF_FRAME], 3);
++  assert_equals_int (cur->ref_distinct_idx[GST_AV1_REF_ALTREF2_FRAME], 3);
++  assert_equals_int (cur->ref_distinct_idx[GST_AV1_REF_ALTREF_FRAME], 3);
++
++  /* order hints are prefilled for ALL eight slots, 0 where a slot is empty */
++  assert_equals_int (cur->ref_order_hint[0], 0);
++  assert_equals_int (cur->ref_order_hint[1], 1);
++  assert_equals_int (cur->ref_order_hint[2], 2);
++  assert_equals_int (cur->ref_order_hint[3], 3);
++  for (i = 4; i < GST_AV1_NUM_REF_FRAMES; i++)
++    assert_equals_int (cur->ref_order_hint[i], 0);
++
++  /* (b) budget 1: every name aliases LAST, so one picture is bound */
++  cur = setup_simple_gop (refs);
++  fail_unless (gst_av1_encoder_assign_ref_index (NULL, refs, 1, 4, cur));
++  gst_av1_encoder_resolve_refs (refs, cur);
++
++  assert_equals_int (cur->num_distinct_refs, 1);
++  fail_unless (cur->distinct_refs[0] == refs[3]);
++  for (i = GST_AV1_REF_LAST_FRAME; i < GST_AV1_NUM_REF_FRAMES; i++)
++    assert_equals_int (cur->ref_distinct_idx[i], 0);
++
++  /* (c) no golden held: GOLDEN collapses onto LAST and LAST3 aliases it
++   *     too, so seven names bind two pictures */
++  clear_refs (refs);
++  refs[1] = make_frame (GST_AV1_INTER_FRAME, 1, FALSE);
++  refs[2] = make_frame (GST_AV1_INTER_FRAME, 2, FALSE);
++  cur = make_frame (GST_AV1_INTER_FRAME, 3, FALSE);
++
++  fail_unless (gst_av1_encoder_assign_ref_index (NULL, refs, 4, 4, cur));
++  gst_av1_encoder_resolve_refs (refs, cur);
++
++  assert_equals_int (cur->num_distinct_refs, 2);
++  fail_unless (cur->distinct_refs[0] == refs[2]);
++  fail_unless (cur->distinct_refs[1] == refs[1]);
++  assert_equals_int (cur->ref_distinct_idx[GST_AV1_REF_LAST_FRAME], 0);
++  assert_equals_int (cur->ref_distinct_idx[GST_AV1_REF_LAST2_FRAME], 1);
++  assert_equals_int (cur->ref_distinct_idx[GST_AV1_REF_LAST3_FRAME], 0);
++  assert_equals_int (cur->ref_distinct_idx[GST_AV1_REF_GOLDEN_FRAME], 0);
++  assert_equals_int (cur->ref_order_hint[0], 0);
++  assert_equals_int (cur->ref_order_hint[1], 1);
++  assert_equals_int (cur->ref_order_hint[2], 2);
++
++  /* (d) a key frame binds nothing, but the per-slot order hints are still
++   *     filled from the VBI it is about to replace -- the subclass writes
++   *     them before it knows the frame type */
++  cur = make_frame (GST_AV1_KEY_FRAME, 0, TRUE);
++  fail_unless (gst_av1_encoder_assign_ref_index (NULL, refs, 4, 4, cur));
++  gst_av1_encoder_resolve_refs (refs, cur);
++
++  assert_equals_int (cur->num_distinct_refs, 0);
++  for (i = 0; i < GST_AV1_NUM_REF_FRAMES; i++) {
++    assert_equals_int (cur->ref_distinct_idx[i], -1);
++    fail_unless (cur->distinct_refs[i] == NULL);
++  }
++  assert_equals_int (cur->ref_order_hint[2], 2);
++
++  /* (e) the alias case only a key frame can create (A9): several slots hold
++   *     the SAME picture, so names resolving to different slots still bind
++   *     one reference. Deduplication is by picture, not by slot index. */
++  clear_refs (refs);
++  anchor = make_frame (GST_AV1_KEY_FRAME, 0, TRUE);
++  for (i = 0; i < GST_AV1_NUM_REF_FRAMES; i++)
++    refs[i] = anchor;
++  cur = make_frame (GST_AV1_INTER_FRAME, 1, FALSE);
++
++  fail_unless (gst_av1_encoder_assign_ref_index (NULL, refs, 4, 4, cur));
++  gst_av1_encoder_resolve_refs (refs, cur);
++
++  fail_unless (distinct_ref_slots (cur) > 1);
++  assert_equals_int (cur->num_distinct_refs, 1);
++  fail_unless (cur->distinct_refs[0] == anchor);
++  for (i = GST_AV1_REF_LAST_FRAME; i < GST_AV1_NUM_REF_FRAMES; i++)
++    assert_equals_int (cur->ref_distinct_idx[i], 0);
++  for (i = 0; i < GST_AV1_NUM_REF_FRAMES; i++)
++    assert_equals_int (cur->ref_order_hint[i], 0);
++}
++
++GST_END_TEST;
++
++/* ------------------------------------------------------------------ */
++/* reference budget                                                    */
++/* ------------------------------------------------------------------ */
++
++/* The budget is MAX (MIN (num-ref-frames, accelerator max), 1) and caps how
++ * many DISTINCT slots the name map resolves to. The forward name set is
++ * {LAST, LAST2, LAST3, GOLDEN}, so 4 is the ceiling no matter how generous
++ * the budget gets. */
++GST_START_TEST (test_av1_refs_budget)
++{
++  GstAV1EncoderFrame *refs[GST_AV1_NUM_REF_FRAMES];
++  GstAV1EncoderFrame *cur;
++
++  /* budget 1: everything collapses onto LAST */
++  cur = setup_simple_gop (refs);
++  fail_unless (gst_av1_encoder_assign_ref_index (NULL, refs, 1, 4, cur));
++  assert_equals_int (distinct_ref_slots (cur), 1);
++  assert_equals_int (cur->ref_frame_idx[GST_AV1_REF_LAST_FRAME], 3);
++  assert_equals_int (cur->ref_frame_idx[GST_AV1_REF_GOLDEN_FRAME], 3);
++
++  /* budget 4: the full forward set */
++  cur = setup_simple_gop (refs);
++  fail_unless (gst_av1_encoder_assign_ref_index (NULL, refs, 4, 4, cur));
++  assert_equals_int (distinct_ref_slots (cur), 4);
++
++  /* budget 7: still 4 -- there are only four forward names */
++  cur = setup_simple_gop (refs);
++  fail_unless (gst_av1_encoder_assign_ref_index (NULL, refs, 7, 7, cur));
++  assert_equals_int (distinct_ref_slots (cur), 4);
++  assert_equals_int (cur->ref_frame_idx[GST_AV1_REF_LAST_FRAME], 3);
++  assert_equals_int (cur->ref_frame_idx[GST_AV1_REF_LAST2_FRAME], 2);
++  assert_equals_int (cur->ref_frame_idx[GST_AV1_REF_LAST3_FRAME], 1);
++  assert_equals_int (cur->ref_frame_idx[GST_AV1_REF_GOLDEN_FRAME], 0);
++
++  /* the accelerator limit wins over the property */
++  cur = setup_simple_gop (refs);
++  fail_unless (gst_av1_encoder_assign_ref_index (NULL, refs, 4, 1, cur));
++  assert_equals_int (distinct_ref_slots (cur), 1);
++
++  /* a zero budget is floored to 1, never to 0 */
++  cur = setup_simple_gop (refs);
++  fail_unless (gst_av1_encoder_assign_ref_index (NULL, refs, 0, 0, cur));
++  assert_equals_int (distinct_ref_slots (cur), 1);
++  assert_equals_int (cur->ref_frame_idx[GST_AV1_REF_LAST_FRAME], 3);
++
++  /* the shared clamp itself */
++  assert_equals_int (gst_av1_encoder_effective_refs (3, 4), 3);
++  assert_equals_int (gst_av1_encoder_effective_refs (4, 1), 1);
++  assert_equals_int (gst_av1_encoder_effective_refs (0, 0), 1);
++  assert_equals_int (gst_av1_encoder_effective_refs (7, 7), 7);
++
++  /* bug A3: the SAME budget bounds what the VBI holds, not just what a
++   * frame may name. setup_simple_gop() holds four distinct pictures in
++   * slots 0..3 and leaves slots 4..7 free. */
++
++  /* budget 1 -> cap 2 pictures: already over budget, so the free slots stay
++   * free and the oldest non-anchor picture is recycled instead. Before A3
++   * this took slot 4 and the VBI grew to eight regardless of the budget. */
++  cur = setup_simple_gop (refs);
++  gst_av1_encoder_find_ref_to_update (refs, 1, 4, cur);
++  assert_equals_int (cur->update_index, 1);
++  assert_equals_int (cur->refresh_frame_flags, 1 << 1);
++
++  /* budget 4 -> cap 5: there is room for one more picture, so the first
++   * free slot wins */
++  cur = setup_simple_gop (refs);
++  gst_av1_encoder_find_ref_to_update (refs, 4, 4, cur);
++  assert_equals_int (cur->update_index, 4);
++
++  /* budget 7 -> cap 8, i.e. the whole VBI: likewise */
++  cur = setup_simple_gop (refs);
++  gst_av1_encoder_find_ref_to_update (refs, 7, 7, cur);
++  assert_equals_int (cur->update_index, 4);
++}
++
++GST_END_TEST;
++
++/* ------------------------------------------------------------------ */
++/* slot selection / eviction                                           */
++/* ------------------------------------------------------------------ */
++
++GST_START_TEST (test_av1_refs_slot_eviction)
++{
++  GstAV1EncoderFrame *refs[GST_AV1_NUM_REF_FRAMES];
++  GstAV1EncoderFrame *cur, *anchor;
++  gint i;
++
++  /* (a) UNDER the reference budget the first empty slot wins, scanning
++   *     upwards, even though slots with older frames follow it. Seven
++   *     pictures are held, so this needs a budget of 7 (cap 8) to be under
++   *     the cap at all -- see (d) for the same list at a smaller budget. */
++  clear_refs (refs);
++  refs[0] = make_frame (GST_AV1_KEY_FRAME, 0, TRUE);
++  refs[1] = make_frame (GST_AV1_INTER_FRAME, 1, FALSE);
++  refs[2] = make_frame (GST_AV1_INTER_FRAME, 2, FALSE);
++  for (i = 4; i < GST_AV1_NUM_REF_FRAMES; i++)
++    refs[i] = make_frame (GST_AV1_INTER_FRAME, i, FALSE);
++  cur = make_frame (GST_AV1_INTER_FRAME, 9, FALSE);
++
++  gst_av1_encoder_find_ref_to_update (refs, 7, 7, cur);
++  assert_equals_int (cur->update_index, 3);
++  assert_equals_int (cur->refresh_frame_flags, 1 << 3);
++
++  /* (b) full list: evict the non-golden reference with the lowest frame_num,
++   *     wherever it sits; the golden anchor in slot 0 is never a candidate */
++  clear_refs (refs);
++  refs[0] = make_frame (GST_AV1_KEY_FRAME, 0, TRUE);
++  refs[1] = make_frame (GST_AV1_INTER_FRAME, 7, FALSE);
++  refs[2] = make_frame (GST_AV1_INTER_FRAME, 3, FALSE);
++  refs[3] = make_frame (GST_AV1_INTER_FRAME, 5, FALSE);
++  refs[4] = make_frame (GST_AV1_INTER_FRAME, 2, FALSE);
++  refs[5] = make_frame (GST_AV1_INTER_FRAME, 6, FALSE);
++  refs[6] = make_frame (GST_AV1_INTER_FRAME, 4, FALSE);
++  refs[7] = make_frame (GST_AV1_INTER_FRAME, 1, FALSE);
++  cur = make_frame (GST_AV1_INTER_FRAME, 8, FALSE);
++
++  gst_av1_encoder_find_ref_to_update (refs, 3, 4, cur);
++  assert_equals_int (cur->update_index, 7);
++  assert_equals_int (cur->refresh_frame_flags, 1 << 7);
++  fail_unless (refs[0]->is_golden);
++
++  /* (c) nothing evictable (a full list of goldens): the frame is simply not
++   *     kept as a reference, and refreshes nothing */
++  clear_refs (refs);
++  for (i = 0; i < GST_AV1_NUM_REF_FRAMES; i++)
++    refs[i] = make_frame (GST_AV1_INTER_FRAME, i + 1, TRUE);
++  cur = make_frame (GST_AV1_INTER_FRAME, 20, FALSE);
++
++  gst_av1_encoder_find_ref_to_update (refs, 3, 4, cur);
++  assert_equals_int (cur->update_index, -1);
++  assert_equals_int (cur->refresh_frame_flags, 0);
++
++  /* (d) bug A3: AT the cap the free slots are NOT taken. The budget bounds
++   *     occupancy; it is not just a naming limit. Same list as (a) minus
++   *     the trailing frames, so four pictures are held. */
++  clear_refs (refs);
++  refs[0] = make_frame (GST_AV1_KEY_FRAME, 0, TRUE);
++  refs[1] = make_frame (GST_AV1_INTER_FRAME, 1, FALSE);
++  refs[2] = make_frame (GST_AV1_INTER_FRAME, 2, FALSE);
++  refs[3] = make_frame (GST_AV1_INTER_FRAME, 3, FALSE);
++  cur = make_frame (GST_AV1_INTER_FRAME, 4, FALSE);
++
++  /* budget 3 -> cap 4, and four pictures are already held: recycle the
++   * oldest non-anchor rather than growing into slot 4 */
++  gst_av1_encoder_find_ref_to_update (refs, 3, 4, cur);
++  assert_equals_int (cur->update_index, 1);
++
++  /* budget 4 -> cap 5: one more picture fits */
++  cur = make_frame (GST_AV1_INTER_FRAME, 4, FALSE);
++  gst_av1_encoder_find_ref_to_update (refs, 4, 4, cur);
++  assert_equals_int (cur->update_index, 4);
++
++  /* (e) redundant copies are the cheapest victims -- evicting one loses no
++   *     reference at all. This is the state a key frame leaves behind
++   *     (A9): eight slots, one picture. */
++  clear_refs (refs);
++  anchor = make_frame (GST_AV1_KEY_FRAME, 0, TRUE);
++  for (i = 0; i < GST_AV1_NUM_REF_FRAMES; i++)
++    refs[i] = anchor;
++  cur = make_frame (GST_AV1_INTER_FRAME, 1, FALSE);
++
++  gst_av1_encoder_find_ref_to_update (refs, 3, 4, cur);
++  /* not slot 0: that is the copy the model counts, and the anchor at that */
++  assert_equals_int (cur->update_index, 1);
++
++  /* (f) at the cap, a picture held in several slots cannot be retired by a
++   *     refresh that writes one slot, so the victim is the oldest picture
++   *     the VBI holds exactly ONCE. Here: the key frame occupies five
++   *     slots, three rolling references occupy the rest. */
++  clear_refs (refs);
++  anchor = make_frame (GST_AV1_KEY_FRAME, 0, TRUE);
++  refs[0] = anchor;
++  refs[1] = make_frame (GST_AV1_INTER_FRAME, 1, FALSE);
++  refs[2] = make_frame (GST_AV1_INTER_FRAME, 2, FALSE);
++  refs[3] = make_frame (GST_AV1_INTER_FRAME, 3, FALSE);
++  for (i = 4; i < GST_AV1_NUM_REF_FRAMES; i++)
++    refs[i] = anchor;
++  cur = make_frame (GST_AV1_INTER_FRAME, 4, FALSE);
++
++  assert_equals_int (distinct_refs_held (refs), 4);
++  gst_av1_encoder_find_ref_to_update (refs, 3, 4, cur);
++  assert_equals_int (cur->update_index, 1);
++}
++
++GST_END_TEST;
++
++/* ------------------------------------------------------------------ */
++/* golden demotion                                                     */
++/* ------------------------------------------------------------------ */
++
++GST_START_TEST (test_av1_refs_golden_demotion)
++{
++  GstAV1EncoderFrame *refs[GST_AV1_NUM_REF_FRAMES];
++  GstAV1EncoderFrame *anchor, *plain, *inserted;
++  gint i;
++
++  /* a new anchor demotes the previous one and keeps its own flag */
++  clear_refs (refs);
++  anchor = make_frame (GST_AV1_KEY_FRAME, 0, TRUE);
++  plain = make_frame (GST_AV1_INTER_FRAME, 1, FALSE);
++  refs[0] = anchor;
++  refs[1] = plain;
++  refs[2] = make_frame (GST_AV1_INTER_FRAME, 2, FALSE);
++
++  inserted = make_frame (GST_AV1_INTER_FRAME, 8, TRUE);
++  refs[3] = inserted;           /* as gst_av1_encoder_update_ref_list() does */
++
++  gst_av1_encoder_demote_golden (refs, inserted);
++
++  fail_if (anchor->is_golden);
++  fail_unless (inserted->is_golden);
++  fail_if (plain->is_golden);
++  assert_equals_int (count_goldens (refs), 1);
++
++  /* a non-golden insert leaves the anchor alone */
++  clear_refs (refs);
++  anchor = make_frame (GST_AV1_KEY_FRAME, 0, TRUE);
++  refs[0] = anchor;
++  inserted = make_frame (GST_AV1_INTER_FRAME, 1, FALSE);
++  refs[1] = inserted;
++
++  gst_av1_encoder_demote_golden (refs, inserted);
++
++  fail_unless (anchor->is_golden);
++  fail_if (inserted->is_golden);
++  assert_equals_int (count_goldens (refs), 1);
++
++  /* an anchor spread over several slots (the state a key frame leaves, A9)
++   * is demoted everywhere at once: those slots hold ONE picture, and the
++   * flag lives on the picture */
++  clear_refs (refs);
++  anchor = make_frame (GST_AV1_KEY_FRAME, 0, TRUE);
++  for (i = 0; i < GST_AV1_NUM_REF_FRAMES; i++)
++    refs[i] = anchor;
++  inserted = make_frame (GST_AV1_INTER_FRAME, 1, TRUE);
++  refs[1] = inserted;
++
++  gst_av1_encoder_demote_golden (refs, inserted);
++
++  fail_if (anchor->is_golden);
++  fail_unless (inserted->is_golden);
++  assert_equals_int (count_goldens (refs), 1);
++  assert_equals_int (count_distinct_goldens (refs), 1);
++}
++
++GST_END_TEST;
++
++/* ------------------------------------------------------------------ */
++/* order hints                                                         */
++/* ------------------------------------------------------------------ */
++
++GST_START_TEST (test_av1_refs_order_hint_wraparound)
++{
++  /* the base class always runs OrderHintBits == 8 (trap 5) */
++  assert_equals_int (AV1ENC_ORDER_HINT_BITS, 8);
++
++  assert_equals_int (gst_av1_encoder_order_hint (0), 0);
++  assert_equals_int (gst_av1_encoder_order_hint (1), 1);
++  assert_equals_int (gst_av1_encoder_order_hint (254), 254);
++  assert_equals_int (gst_av1_encoder_order_hint (255), 255);
++  /* wraps here */
++  assert_equals_int (gst_av1_encoder_order_hint (256), 0);
++  assert_equals_int (gst_av1_encoder_order_hint (257), 1);
++  assert_equals_int (gst_av1_encoder_order_hint (300), 44);
++  assert_equals_int (gst_av1_encoder_order_hint (511), 255);
++  assert_equals_int (gst_av1_encoder_order_hint (512), 0);
++  assert_equals_int (gst_av1_encoder_order_hint (1000), 232);
++  assert_equals_int (gst_av1_encoder_order_hint (G_MAXUINT32), 255);
++}
++
++GST_END_TEST;
++
++/* Recency is decided on frame_num, never on the masked order_hint: across
++ * the 8-bit wrap the newest frame (order_hint 255) must still beat the
++ * oldest (order_hint 253), and the current frame's own hint is 0. */
++GST_START_TEST (test_av1_refs_recency_survives_wraparound)
++{
++  GstAV1EncoderFrame *refs[GST_AV1_NUM_REF_FRAMES];
++  GstAV1EncoderFrame *cur;
++
++  clear_refs (refs);
++  refs[0] = make_frame (GST_AV1_INTER_FRAME, 253, TRUE);
++  refs[1] = make_frame (GST_AV1_INTER_FRAME, 254, FALSE);
++  refs[2] = make_frame (GST_AV1_INTER_FRAME, 255, FALSE);
++  cur = make_frame (GST_AV1_INTER_FRAME, 256, FALSE);
++
++  assert_equals_int (refs[0]->order_hint, 253);
++  assert_equals_int (refs[2]->order_hint, 255);
++  assert_equals_int (cur->order_hint, 0);
++
++  fail_unless (gst_av1_encoder_assign_ref_index (NULL, refs, 4, 4, cur));
++
++  assert_equals_int (cur->ref_frame_idx[GST_AV1_REF_LAST_FRAME], 2);
++  assert_equals_int (cur->ref_frame_idx[GST_AV1_REF_LAST2_FRAME], 1);
++  /* only the golden is left to skip, so LAST3 aliases LAST */
++  assert_equals_int (cur->ref_frame_idx[GST_AV1_REF_LAST3_FRAME], 2);
++  assert_equals_int (cur->ref_frame_idx[GST_AV1_REF_GOLDEN_FRAME], 0);
++}
++
++GST_END_TEST;
++
++/* ------------------------------------------------------------------ */
++/* simulated GOP walk                                                  */
++/* ------------------------------------------------------------------ */
++
++#define WALK_FRAMES             300
++#define WALK_KEYFRAME_PERIOD    60
++#define WALK_GF_GROUP_SIZE      8
++#define WALK_NUM_REF_FRAMES     3
++#define WALK_MAX_REFS           4
++
++/* Drives the reference model over 300 frames with the same GOP scheduling
++ * gst_av1_encoder_handle_frame() performs, and mirrors
++ * gst_av1_encoder_update_ref_list() (which owns codec-frame refcounting and
++ * so is not part of the seam). Every frame is checked against the model's
++ * invariants. */
++GST_START_TEST (test_av1_refs_gop_walk)
++{
++  GstAV1EncoderFrame *refs[GST_AV1_NUM_REF_FRAMES];
++  guint32 frame_num = 0, frames_since_gf = 0;
++  gint keys = 0, golden_anchors = 0, not_kept = 0;
++  guint cap = gst_av1_encoder_effective_refs (WALK_NUM_REF_FRAMES,
++      WALK_MAX_REFS) + 1;
++  guint n;
++
++  clear_refs (refs);
++
++  for (n = 0; n < WALK_FRAMES; n++) {
++    GstAV1EncoderFrame *frame;
++    gboolean is_golden = FALSE;
++    gint i, occupied_before = 0;
++
++    /* --- mirror of gst_av1_encoder_handle_frame() GOP scheduling --- */
++    if (frame_num >= WALK_KEYFRAME_PERIOD)
++      frame_num = 0;
++
++    if (frame_num == 0) {
++      is_golden = TRUE;
++      frames_since_gf = 0;
++    } else if (frames_since_gf >= WALK_GF_GROUP_SIZE) {
++      is_golden = TRUE;
++      frames_since_gf = 0;
++    }
++
++    frame = make_frame (frame_num == 0 ?
++        GST_AV1_KEY_FRAME : GST_AV1_INTER_FRAME, frame_num, is_golden);
++
++    assert_equals_int (frame->order_hint, frame_num & 0xff);
++
++    for (i = 0; i < GST_AV1_NUM_REF_FRAMES; i++) {
++      if (refs[i])
++        occupied_before++;
++    }
++
++    /* --- the seam --- */
++    fail_unless (gst_av1_encoder_assign_ref_index (NULL, refs,
++            WALK_NUM_REF_FRAMES, WALK_MAX_REFS, frame),
++        "frame %u (frame_num %u): no reference available", n, frame_num);
++
++    gst_av1_encoder_resolve_refs (refs, frame);
++
++    gst_av1_encoder_find_ref_to_update (refs, WALK_NUM_REF_FRAMES,
++        WALK_MAX_REFS, frame);
++
++    /* the resolved view agrees with the name map, slot by slot */
++    for (i = 0; i < GST_AV1_NUM_REF_FRAMES; i++) {
++      assert_equals_int (frame->ref_order_hint[i],
++          refs[i] ? refs[i]->order_hint : 0);
++
++      if (frame->ref_frame_idx[i] < 0) {
++        assert_equals_int (frame->ref_distinct_idx[i], -1);
++      } else {
++        fail_unless (frame->ref_distinct_idx[i] >= 0
++            && frame->ref_distinct_idx[i] < (gint) frame->num_distinct_refs,
++            "frame %u name %d: distinct index %d out of range", n, i,
++            frame->ref_distinct_idx[i]);
++        fail_unless (frame->distinct_refs[frame->ref_distinct_idx[i]] ==
++            refs[frame->ref_frame_idx[i]],
++            "frame %u name %d: distinct entry is not the named picture", n,
++            i);
++      }
++    }
++
++    if (frame->type == GST_AV1_KEY_FRAME) {
++      keys++;
++
++      for (i = 0; i < GST_AV1_NUM_REF_FRAMES; i++) {
++        fail_unless (frame->ref_frame_idx[i] == -1,
++            "frame %u: key frame assigned name %d", n, i);
++      }
++      assert_equals_int (frame->update_index, 0);
++      assert_equals_int (frame->refresh_frame_flags, 0xff);
++      /* a key frame references nothing, so it binds nothing */
++      assert_equals_int (frame->num_distinct_refs, 0);
++    } else {
++      fail_unless (occupied_before > 0);
++
++      /* every name resolves to an occupied slot holding an older frame */
++      for (i = GST_AV1_REF_LAST_FRAME; i < GST_AV1_NUM_REF_FRAMES; i++) {
++        gint idx = frame->ref_frame_idx[i];
++
++        fail_unless (idx >= 0 && idx < GST_AV1_NUM_REF_FRAMES,
++            "frame %u name %d: slot %d out of range", n, i, idx);
++        fail_unless (refs[idx] != NULL,
++            "frame %u name %d: slot %d is empty", n, i, idx);
++        fail_unless (refs[idx]->frame_num < frame->frame_num,
++            "frame %u name %d: slot %d is not in the past", n, i, idx);
++      }
++
++      /* no backward references exist: those three names alias GOLDEN */
++      assert_equals_int (frame->ref_frame_idx[GST_AV1_REF_BWDREF_FRAME],
++          frame->ref_frame_idx[GST_AV1_REF_GOLDEN_FRAME]);
++      assert_equals_int (frame->ref_frame_idx[GST_AV1_REF_ALTREF2_FRAME],
++          frame->ref_frame_idx[GST_AV1_REF_GOLDEN_FRAME]);
++      assert_equals_int (frame->ref_frame_idx[GST_AV1_REF_ALTREF_FRAME],
++          frame->ref_frame_idx[GST_AV1_REF_GOLDEN_FRAME]);
++
++      /* budget 3 always affords a distinct GOLDEN, and it is the anchor */
++      fail_unless (refs[frame->ref_frame_idx[GST_AV1_REF_GOLDEN_FRAME]]->
++          is_golden, "frame %u: GOLDEN does not point at the anchor", n);
++
++      /* the forward name set can never resolve to more than four slots,
++       * and never binds more PICTURES than the budget allows */
++      fail_unless (distinct_ref_slots (frame) <= 4);
++      fail_unless (frame->num_distinct_refs <=
++          gst_av1_encoder_effective_refs (WALK_NUM_REF_FRAMES,
++              WALK_MAX_REFS), "frame %u binds %u pictures", n,
++          frame->num_distinct_refs);
++
++      if (frame->update_index >= 0) {
++        assert_equals_int (frame->refresh_frame_flags,
++            1 << frame->update_index);
++        /* The anchor PICTURE always survives the refresh. It may well be
++         * the frame in the victim slot -- right after a key frame every
++         * slot holds the anchor (A9) -- but only when another slot still
++         * holds it; a single-copy anchor is never the victim. */
++        fail_unless (refs[frame->update_index] == NULL
++            || !refs[frame->update_index]->is_golden
++            || ref_copies (refs, refs[frame->update_index]) > 1,
++            "frame %u: evicted the only copy of the golden anchor from "
++            "slot %d", n, frame->update_index);
++      } else {
++        not_kept++;
++        assert_equals_int (frame->refresh_frame_flags, 0);
++      }
++    }
++
++    /* --- mirror of gst_av1_encoder_update_ref_list() --- */
++    if (frame->type == GST_AV1_KEY_FRAME)
++      clear_refs (refs);
++
++    vbi_update (refs, frame);
++
++    if (frame->update_index >= 0)
++      fail_unless (refs[frame->update_index] == frame);
++
++    /* bug A9: a key frame lands in every slot, not just slot 0 */
++    if (frame->type == GST_AV1_KEY_FRAME) {
++      assert_equals_int (ref_copies (refs, frame), GST_AV1_NUM_REF_FRAMES);
++      assert_equals_int (distinct_refs_held (refs), 1);
++    }
++
++    if (frame->is_golden)
++      golden_anchors++;
++
++    /* exactly one anchor PICTURE is held at all times, and it survives
++     * until the next golden insert demotes it. Counting slots would not do:
++     * a key frame is the anchor in all eight of them. */
++    assert_equals_int (count_distinct_goldens (refs), 1);
++
++    /* bug A3: the standing occupancy invariant. See
++     * test_av1_refs_occupancy_cap() for the exact maxima and for why the
++     * bound is (cap + 1) rather than cap. */
++    fail_unless (distinct_refs_held (refs) <= cap + 1,
++        "frame %u: VBI holds %u distinct pictures, cap %u", n,
++        distinct_refs_held (refs), cap);
++
++    frame_num++;
++    frames_since_gf++;
++  }
++
++  assert_equals_int (keys, WALK_FRAMES / WALK_KEYFRAME_PERIOD);
++  /* with a 60-frame key period and an 8-frame GF group nothing is ever
++   * dropped from the VBI */
++  assert_equals_int (not_kept, 0);
++  fail_unless (golden_anchors > keys);
++}
++
++GST_END_TEST;
++
++/* ------------------------------------------------------------------ */
++/* occupancy cap (bug A3)                                              */
++/* ------------------------------------------------------------------ */
++
++/* Runs the same GOP schedule as the walk above at an arbitrary budget and
++ * returns the largest number of DISTINCT pictures the VBI ever held. */
++static guint
++run_occupancy_walk (guint num_ref_frames, guint max_num_references)
++{
++  GstAV1EncoderFrame *refs[GST_AV1_NUM_REF_FRAMES];
++  guint32 frame_num = 0, frames_since_gf = 0;
++  guint effective = gst_av1_encoder_effective_refs (num_ref_frames,
++      max_num_references);
++  guint cap = effective + 1;
++  guint max_held = 0;
++  guint n;
++
++  clear_refs (refs);
++
++  for (n = 0; n < WALK_FRAMES; n++) {
++    GstAV1EncoderFrame *frame;
++    gboolean is_golden = FALSE;
++    guint held;
++
++    if (frame_num >= WALK_KEYFRAME_PERIOD)
++      frame_num = 0;
++
++    if (frame_num == 0) {
++      is_golden = TRUE;
++      frames_since_gf = 0;
++    } else if (frames_since_gf >= WALK_GF_GROUP_SIZE) {
++      is_golden = TRUE;
++      frames_since_gf = 0;
++    }
++
++    frame = make_frame (frame_num == 0 ?
++        GST_AV1_KEY_FRAME : GST_AV1_INTER_FRAME, frame_num, is_golden);
++
++    fail_unless (gst_av1_encoder_assign_ref_index (NULL, refs,
++            num_ref_frames, max_num_references, frame),
++        "frame %u: no reference available", n);
++    gst_av1_encoder_resolve_refs (refs, frame);
++    gst_av1_encoder_find_ref_to_update (refs, num_ref_frames,
++        max_num_references, frame);
++
++    /* whatever the budget, there is always something to recycle */
++    fail_unless (frame->update_index >= 0, "frame %u was not kept", n);
++
++    /* the names never bind more pictures than the budget allows */
++    fail_unless (frame->num_distinct_refs <= effective,
++        "frame %u binds %u pictures with a budget of %u", n,
++        frame->num_distinct_refs, effective);
++
++    if (frame->type == GST_AV1_KEY_FRAME)
++      clear_refs (refs);
++    vbi_update (refs, frame);
++
++    assert_equals_int (count_distinct_goldens (refs), 1);
++
++    held = distinct_refs_held (refs);
++    fail_unless (held <= cap + 1,
++        "frame %u: VBI holds %u distinct pictures, cap %u", n, held, cap);
++    max_held = MAX (max_held, held);
++
++    frame_num++;
++    frames_since_gf++;
++  }
++
++  return max_held;
++}
++
++/* bug A3: num-ref-frames bounds what the VBI HOLDS, not only what a frame
++ * may name. Before this, slot selection preferred ANY empty slot, so
++ * occupancy grew to eight whatever the budget said.
++ *
++ * The bound is on distinct PICTURES, because that is what costs a DPB image
++ * and a retained codec frame; raw slot occupancy says nothing once a key
++ * frame legitimately fills all eight slots with one picture (A9).
++ *
++ * The expected maxima below are reasoned from the model, not observed:
++ *   cap = effective refs + 1  (the pictures a frame may name, plus the
++ *   rolling slot the current frame lands in).
++ * A budget of 1 (cap 2) reaches 3, not 2, and that is the A3/A9 interaction
++ * the ticket asks to be explicit about: with cap 2 the model holds the
++ * anchor and one rolling reference, and once a later golden anchor has
++ * displaced the key frame there is no single-copy non-golden picture left
++ * to retire -- a refresh that writes ONE slot can never retire a picture
++ * spread over six. The stranded key frame costs exactly one extra held
++ * picture, it never grows, and the next key frame clears it. The named
++ * reference set is still one picture, which is what num-ref-frames=1 asks
++ * for. */
++GST_START_TEST (test_av1_refs_occupancy_cap)
++{
++  /* budget 1 -> cap 2, plus the stranded key frame */
++  assert_equals_int (run_occupancy_walk (1, 4), 3);
++  /* budget 4 -> cap 5, reached and never exceeded */
++  assert_equals_int (run_occupancy_walk (4, 4), 5);
++  /* budget 7 -> cap 8, i.e. the whole VBI: the only budget under which the
++   * pre-A3 "fill every slot" behaviour was correct */
++  assert_equals_int (run_occupancy_walk (7, 7), 8);
++  /* the accelerator limit bounds it too, not just the property */
++  assert_equals_int (run_occupancy_walk (4, 1), 3);
++}
++
++GST_END_TEST;
++
++static Suite *
++av1refs_suite (void)
++{
++  Suite *s = suite_create ("av1refs");
++  TCase *tc_basic = tcase_create ("general");
++
++  suite_add_tcase (s, tc_basic);
++  tcase_add_checked_fixture (tc_basic, setup, teardown);
++
++  tcase_add_test (tc_basic, test_av1_refs_key_frame);
++  tcase_add_test (tc_basic, test_av1_refs_key_frame_ignores_ref_list);
++  tcase_add_test (tc_basic, test_av1_refs_key_frame_fills_vbi);
++  tcase_add_test (tc_basic, test_av1_refs_forward_inter);
++  tcase_add_test (tc_basic, test_av1_refs_no_golden_fallback);
++  tcase_add_test (tc_basic, test_av1_refs_inter_without_references);
++  tcase_add_test (tc_basic, test_av1_refs_resolved_view);
++  tcase_add_test (tc_basic, test_av1_refs_budget);
++  tcase_add_test (tc_basic, test_av1_refs_slot_eviction);
++  tcase_add_test (tc_basic, test_av1_refs_golden_demotion);
++  tcase_add_test (tc_basic, test_av1_refs_order_hint_wraparound);
++  tcase_add_test (tc_basic, test_av1_refs_recency_survives_wraparound);
++  tcase_add_test (tc_basic, test_av1_refs_gop_walk);
++  tcase_add_test (tc_basic, test_av1_refs_occupancy_cap);
++
++  return s;
++}
++
++#ifdef __APPLE__
++GST_CHECK_MAIN_NOFORK (av1refs);
++#else
++GST_CHECK_MAIN (av1refs);
++#endif

--- a/patches/vulkanh265enc.patch
+++ b/patches/vulkanh265enc.patch
@@ -3441,10 +3441,10 @@ index ee93c9c..c01eb11 100644
    'vkvp9dec.c',
 diff --git a/subprojects/gst-plugins-bad/ext/vulkan/vkh265enc.c b/subprojects/gst-plugins-bad/ext/vulkan/vkh265enc.c
 new file mode 100644
-index 0000000..566b622
+index 0000000..8c8367f
 --- /dev/null
 +++ b/subprojects/gst-plugins-bad/ext/vulkan/vkh265enc.c
-@@ -0,0 +1,2632 @@
+@@ -0,0 +1,2862 @@
 +/* GStreamer
 + * Copyright (C) 2025 Igalia, S.L.
 + *     Author: Stéphane Cerveau <scerveau@igalia.com>
@@ -3554,6 +3554,20 @@ index 0000000..566b622
 +  GstH265SPS sps;
 +  GstH265PPS pps;
 +  gsize coded_buffer_size;
++
++  /* Quasar (resolution spec, robust form): the driver's authoritative SPS/PPS
++   * NAL units (Annex B, from vkGetEncodedVideoSessionParametersKHR), emitted
++   * verbatim by _write_headers instead of bit-writing self->sps/pps. Parsing the
++   * driver's SPS and re-bit-writing it round-trips through gst_h265_bit_writer_sps
++   * and malformed the SPS extension (sps_extension_present_flag=1,
++   * sps_extension_4bits=1) - benign to ffmpeg but a strict decoder (macOS
++   * VideoToolbox) reads it as per-frame flicker. Emitting the driver's exact
++   * bytes is round-trip-free (self->sps is retained only for the coded-size
++   * estimate and caps). */
++  guint8 *driver_sps_nal;
++  gsize driver_sps_nal_size;
++  guint8 *driver_pps_nal;
++  gsize driver_pps_nal_size;
 +
 +  struct
 +  {
@@ -4340,6 +4354,12 @@ index 0000000..566b622
 +        && self->profile.profile.chromaBitDepth == bit_depth_chroma
 +        && self->profile.profile.lumaBitDepth == bit_depth_luma
 +        && self->profile.codec.h265enc.stdProfileIdc == vk_profile) {
++      /* Same profile: the session is not restarted, but a reconfigure may have
++       * changed the bitrate (or other rate-control values). Without this the
++       * new values are written into the per-frame rate-control layer info and
++       * never handed to the driver, so a live retarget is silently inert.
++       * Update, not reset — a reset would force an IDR on every retarget. */
++      gst_vulkan_encoder_request_rc_update (self->encoder);
 +      return GST_FLOW_OK;
 +    } else {
 +      GST_DEBUG_OBJECT (self, "Restarting vulkan encoder");
@@ -4370,6 +4390,11 @@ index 0000000..566b622
 +    self->rc.quality = gst_vulkan_encoder_quality_level (self->encoder);
 +    update_property_uint (self, &self->prop.quality, self->rc.quality,
 +        PROP_QUALITY);
++    /* PATCH (rc-fix): push the property-selected rate-control mode into the
++     * freshly started encoder BEFORE reading it back — otherwise the
++     * read-back overwrites the user's cbr/vbr choice with the driver
++     * default and the stream is silently constant-QP. */
++    gst_vulkan_encoder_set_rc_mode (self->encoder, self->prop.ratecontrol);
 +    self->rc.ratecontrol = gst_vulkan_encoder_rc_mode (self->encoder);
 +    update_property_uint (self, &self->prop.ratecontrol, self->rc.ratecontrol,
 +        PROP_RATECONTROL);
@@ -4529,7 +4554,10 @@ index 0000000..566b622
 +
 +  gst_h265_parser_free (parser);
 +
-+  return res == GST_H265_PARSER_OK;
++  /* Quasar: identify_nalu returns NO_NAL_END on the last NAL of the
++   * blob (no trailing start code) - that is a successful full parse,
++   * not a failure. */
++  return res == GST_H265_PARSER_OK || res == GST_H265_PARSER_NO_NAL_END;
 +}
 +
 +static GstFlowReturn
@@ -4664,28 +4692,116 @@ index 0000000..566b622
 +          &overrides, &feedback, &data_size, &data, &err))
 +    return GST_FLOW_ERROR;
 +
-+  /* ignore overrides until we get a use case they are actually needed */
-+  feedback.h265.hasStdPPSOverrides = feedback.h265.hasStdSPSOverrides = 0;
++  /* Quasar (A1, resolution spec
++   * docs/design/plans/2026-07-24-vulkanh265enc-conformance-resolution-spec.md):
++   * honor the driver-returned SPS/PPS for the emitted bitstream.
++   *
++   * NVIDIA (RTX 5090) advertises only VK_VIDEO_ENCODE_H265_CTB_SIZE_32, so the
++   * driver encodes on a 32x32 CTB grid (init_std_sps() derives that from caps).
++   * The *bitstream* SPS is bit-written from the hand-rolled GstH265SPS, whose
++   * gsth265encoder.c sps_init() hardcodes CtbSize=64 (log2_diff_max_min_cb=3),
++   * so the decoder parsed the coding tree / slice data on a 2x-wrong CTB grid ->
++   * garbage cu_qp_delta / alignment bit and a cascading RPS failure
++   * (non-conformant; black on VideoToolbox).
++   *
++   * vkGetEncodedVideoSessionParametersKHR (called above with writeStdSPS/PPS=TRUE)
++   * returns the driver's authoritative SPS/PPS and flags hasStdSPS/PPSOverrides
++   * when they differ from what we uploaded - which they do on NVIDIA (CtbSize 32
++   * vs the hand-rolled 64). The upstream force-zero of those flags discarded the
++   * fix; it is removed so the adopt path runs. (The companion return-value fix in
++   * _h265_parameters_parse() is what actually lets the parse succeed: that helper
++   * was never exercised while the flags were forced to zero, so its
++   * last-NAL-is-NO_NAL_END success case was mis-reported as failure.)
++   *
++   * Gating on the override flags keeps this regression-safe for the driver the
++   * element was tuned on: RADV advertises CTB_SIZE_64, matches the hand-rolled
++   * sets, reports no override, and the bit-written path stays byte-identical. The
++   * VPS is not driver-returned and stays bit-written from self->vps unchanged. */
 +
 +  if (feedback.h265.hasStdSPSOverrides || feedback.h265.hasStdPPSOverrides) {
-+    GstH265SPS new_sps;
-+    GstH265PPS new_pps;
++    GstH265SPS new_sps = *sps;
++    GstH265PPS new_pps = *pps;
 +    GST_LOG_OBJECT (self, "Vulkan driver overrode parameters:%s%s",
 +        feedback.h265.hasStdSPSOverrides ? " SPS" : "",
 +        feedback.h265.hasStdPPSOverrides ? " PPS" : "");
 +
 +    if (_h265_parameters_parse (self, data, data_size, &new_sps, &new_pps)) {
-+      if (feedback.h265.hasStdSPSOverrides)
++      GST_INFO_OBJECT (self, "driver parameter override (%" G_GSIZE_FORMAT
++          " bytes; SPS=%d PPS=%d): CtbSize %u->%u, log2_diff_max_min_cb %u->%u, "
++          "log2_diff_max_min_tb %u->%u, log2_max_poc_lsb_minus4 %u->%u, SAO %u->%u",
++          data_size, feedback.h265.hasStdSPSOverrides,
++          feedback.h265.hasStdPPSOverrides,
++          1u << (sps->log2_min_luma_coding_block_size_minus3 + 3
++              + sps->log2_diff_max_min_luma_coding_block_size),
++          1u << (new_sps.log2_min_luma_coding_block_size_minus3 + 3
++              + new_sps.log2_diff_max_min_luma_coding_block_size),
++          sps->log2_diff_max_min_luma_coding_block_size,
++          new_sps.log2_diff_max_min_luma_coding_block_size,
++          sps->log2_diff_max_min_transform_block_size,
++          new_sps.log2_diff_max_min_transform_block_size,
++          (guint) sps->log2_max_pic_order_cnt_lsb_minus4,
++          (guint) new_sps.log2_max_pic_order_cnt_lsb_minus4,
++          sps->sample_adaptive_offset_enabled_flag,
++          new_sps.sample_adaptive_offset_enabled_flag);
++
++      if (feedback.h265.hasStdSPSOverrides) {
++        /* Consistency audit: _setup_slice() hardcodes slice_sao_luma/chroma=1,
++         * only legal while the now-authoritative SPS keeps SAO enabled. */
++        if (!new_sps.sample_adaptive_offset_enabled_flag)
++          GST_WARNING_OBJECT (self, "driver SPS disables SAO but _setup_slice() "
++              "hardcodes slice_sao_luma/chroma=1 - slice headers may mismatch "
++              "the parameter set; revisit _setup_slice()");
 +        *sps = new_sps;
++      }
 +
 +      if (feedback.h265.hasStdPPSOverrides) {
++        /* _setup_slice() hardcodes cu_chroma_qp_offset_enabled_flag=1 and
++         * deblocking_filter_override_flag=1, each only legal when the PPS
++         * enables the matching tool. Warn (do not fail) on divergence. */
++        if (!new_pps.deblocking_filter_override_enabled_flag)
++          GST_WARNING_OBJECT (self, "driver PPS has deblocking_filter_override_"
++              "enabled_flag=0 but _setup_slice() hardcodes "
++              "deblocking_filter_override_flag=1");
 +        new_pps.sps = sps;
 +        *pps = new_pps;
 +      }
 +
++      /* Re-upload the adopted sets so the driver session parameters and the
++       * emitted bitstream stay in lockstep (init_std_sps re-derives geometry
++       * from caps, so this is grid-idempotent). */
 +      ret = gst_vulkan_h265_encoder_update_parameters (self, vps, sps, pps);
 +      if (ret != GST_FLOW_OK)
 +        return ret;
++    } else {
++      GST_WARNING_OBJECT (self, "failed to parse driver-returned parameter sets "
++          "(%" G_GSIZE_FORMAT " bytes) - keeping hand-rolled SPS/PPS", data_size);
++    }
++  }
++
++  /* Robust form: keep the driver's authoritative SPS/PPS NAL bytes so
++   * _write_headers emits them verbatim. @data is Annex B (SPS NAL then PPS NAL);
++   * split on the second start code (00 00 01, optionally 4-byte). */
++  g_clear_pointer (&self->driver_sps_nal, g_free);
++  g_clear_pointer (&self->driver_pps_nal, g_free);
++  self->driver_sps_nal_size = self->driver_pps_nal_size = 0;
++  if (data && data_size > 4) {
++    const guint8 *d = data;
++    gsize i, split = 0;
++    for (i = 3; i + 3 <= data_size; i++) {
++      if (d[i] == 0 && d[i + 1] == 0 && d[i + 2] == 1) {
++        split = (i > 0 && d[i - 1] == 0) ? i - 1 : i;
++        break;
++      }
++    }
++    if (split > 0 && split < data_size) {
++      self->driver_sps_nal = g_memdup2 (d, split);
++      self->driver_sps_nal_size = split;
++      self->driver_pps_nal = g_memdup2 (d + split, data_size - split);
++      self->driver_pps_nal_size = data_size - split;
++    } else {
++      GST_WARNING_OBJECT (self, "could not split driver SPS/PPS blob (%"
++          G_GSIZE_FORMAT " bytes); _write_headers will bit-write instead",
++          data_size);
 +    }
 +  }
 +
@@ -4716,6 +4832,30 @@ index 0000000..566b622
 +        GST_VIDEO_INFO_WIDTH (info), "height", G_TYPE_INT,
 +        GST_VIDEO_INFO_HEIGHT (info), "alignment", G_TYPE_STRING, "au",
 +        "stream-format", G_TYPE_STRING, "byte-stream", NULL);
++
++    /* Quasar (resolution spec): propagate the input colorimetry (and chroma
++     * siting) onto the coded-video caps, exactly as nvh265enc/vah265enc do.
++     * webrtcbin derives the WebRTC color-space signalling from these caps; with
++     * them absent (the upstream element left them off), a receiver has no
++     * out-of-band color-space and Chrome/VideoToolbox falls back to per-frame
++     * guessing - which renders as whole-image light/dark alternation on the
++     * HEVC path even though the in-band VUI is correct. */
++    {
++      gchar *colorimetry = gst_video_colorimetry_to_string (&info->colorimetry);
++      if (colorimetry) {
++        gst_caps_set_simple (caps, "colorimetry", G_TYPE_STRING, colorimetry,
++            NULL);
++        g_free (colorimetry);
++      }
++      if (info->chroma_site != GST_VIDEO_CHROMA_SITE_UNKNOWN) {
++        gchar *chroma_site = gst_video_chroma_site_to_string (info->chroma_site);
++        if (chroma_site) {
++          gst_caps_set_simple (caps, "chroma-site", G_TYPE_STRING, chroma_site,
++              NULL);
++          g_free (chroma_site);
++        }
++      }
++    }
 +
 +    out_state =
 +        gst_video_encoder_set_output_state (GST_VIDEO_ENCODER_CAST (self),
@@ -4927,23 +5067,33 @@ index 0000000..566b622
 +    nal_size = sizeof (nal_buf);
 +    memset (nal_buf, 0, sizeof (nal_buf));
 +
-+    res = gst_h265_bit_writer_sps (&self->sps, TRUE, nal_buf, &nal_size);
-+    if (res != GST_H265_BIT_WRITER_OK) {
-+      GST_ERROR_OBJECT (self, "Failed to generate the sequence header");
-+      goto bail;
++    /* Quasar robust form: emit the driver's authoritative SPS NAL verbatim
++     * (Annex B, start code included). Fall back to the bit-writer only if the
++     * driver returned nothing. */
++    if (self->driver_sps_nal && self->driver_sps_nal_size > 0
++        && offset + self->driver_sps_nal_size <= (guint) orig_size) {
++      memcpy (info.data + offset, self->driver_sps_nal,
++          self->driver_sps_nal_size);
++      offset += self->driver_sps_nal_size;
++    } else {
++      res = gst_h265_bit_writer_sps (&self->sps, TRUE, nal_buf, &nal_size);
++      if (res != GST_H265_BIT_WRITER_OK) {
++        GST_ERROR_OBJECT (self, "Failed to generate the sequence header");
++        goto bail;
++      }
++
++      data = info.data + offset;
++      size = orig_size - offset;
++
++      res = gst_h265_bit_writer_convert_to_nal (4, FALSE, TRUE, FALSE, nal_buf,
++          nal_size * 8, data, &size);
++      if (res != GST_H265_BIT_WRITER_OK) {
++        GST_ERROR_OBJECT (self, "Failed to generate the SPS bytes");
++        goto bail;
++      }
++
++      offset += size + 1;
 +    }
-+
-+    data = info.data + offset;
-+    size = orig_size - offset;
-+
-+    res = gst_h265_bit_writer_convert_to_nal (4, FALSE, TRUE, FALSE, nal_buf,
-+        nal_size * 8, data, &size);
-+    if (res != GST_H265_BIT_WRITER_OK) {
-+      GST_ERROR_OBJECT (self, "Failed to generate the SPS bytes");
-+      goto bail;
-+    }
-+
-+    offset += size + 1;
 +  }
 +
 +  if (pic_type == STD_VIDEO_H265_PICTURE_TYPE_I
@@ -4951,23 +5101,31 @@ index 0000000..566b622
 +    guint8 nal_buf[4096] = { 0, };
 +    guint nal_size = sizeof (nal_buf);
 +
-+    res = gst_h265_bit_writer_pps (&self->pps, TRUE, nal_buf, &nal_size);
-+    if (res != GST_H265_BIT_WRITER_OK) {
-+      GST_ERROR_OBJECT (self, "Failed to generate the picture header");
-+      goto bail;
++    /* Quasar robust form: emit the driver's authoritative PPS NAL verbatim. */
++    if (self->driver_pps_nal && self->driver_pps_nal_size > 0
++        && offset + self->driver_pps_nal_size <= (guint) orig_size) {
++      memcpy (info.data + offset, self->driver_pps_nal,
++          self->driver_pps_nal_size);
++      offset += self->driver_pps_nal_size;
++    } else {
++      res = gst_h265_bit_writer_pps (&self->pps, TRUE, nal_buf, &nal_size);
++      if (res != GST_H265_BIT_WRITER_OK) {
++        GST_ERROR_OBJECT (self, "Failed to generate the picture header");
++        goto bail;
++      }
++
++      data = info.data + offset;
++      size = orig_size - offset;
++
++      res = gst_h265_bit_writer_convert_to_nal (4, FALSE, TRUE, FALSE, nal_buf,
++          nal_size * 8, data, &size);
++      if (res != GST_H265_BIT_WRITER_OK) {
++        GST_ERROR_OBJECT (self, "Failed to generate the PPS bytes");
++        goto bail;
++      }
++
++      offset += size + 1;
 +    }
-+
-+    data = info.data + offset;
-+    size = orig_size - offset;
-+
-+    res = gst_h265_bit_writer_convert_to_nal (4, FALSE, TRUE, FALSE, nal_buf,
-+        nal_size * 8, data, &size);
-+    if (res != GST_H265_BIT_WRITER_OK) {
-+      GST_ERROR_OBJECT (self, "Failed to generate the PPS bytes");
-+      goto bail;
-+    }
-+
-+    offset += size + 1;
 +  }
 +
 +  /* HDR10 static-metadata prefix SEI, alongside the parameter sets on each IDR.
@@ -5186,15 +5344,32 @@ index 0000000..566b622
 +      .first_slice_segment_in_pic_flag =
 +          slice_hdr->first_slice_segment_in_pic_flag,
 +      .dependent_slice_segment_flag = slice_hdr->dependent_slice_segment_flag,
-+      /* Slice flags match the upstream MR #5739 encoder exactly. */
-+      .slice_sao_luma_flag = 1,
-+      .slice_sao_chroma_flag = 1,
++      /* Quasar (A1 completion, resolution spec
++       * docs/design/plans/2026-07-24-vulkanh265enc-conformance-resolution-spec.md):
++       * source the slice-level in-loop-filter flags FROM the now-authoritative
++       * SPS/PPS instead of hardcoding them. The upstream MR #5739 values
++       * (cu_chroma_qp_offset_enabled_flag=1, deblocking_filter_override_flag=1)
++       * disagree with the parameter sets the encoder actually signals
++       * (self->pps.pps_extension_params.chroma_qp_offset_list_enabled_flag=0,
++       * deblocking_filter_override_enabled_flag=0): those slice flags are only
++       * legal when the PPS enables the matching tool, so passing 1 tells the
++       * driver to reconstruct with an in-loop-filter state the bitstream cannot
++       * carry. A lenient decoder (ffmpeg) reconciles it; a strict one
++       * (VideoToolbox) reconstructs on the signalled state and the mismatch
++       * reads as per-frame flicker. Sourcing from the authoritative sets keeps
++       * the driver's encode-side filter state in lockstep with the bitstream.
++       * slice_sao_luma/chroma follow the SPS SAO flag (ChromaArrayType!=0 for the
++       * 4:2:0 profiles handled here). */
++      .slice_sao_luma_flag = self->sps.sample_adaptive_offset_enabled_flag,
++      .slice_sao_chroma_flag = self->sps.sample_adaptive_offset_enabled_flag,
 +      .num_ref_idx_active_override_flag =
 +          slice_hdr->num_ref_idx_active_override_flag,
 +      .mvd_l1_zero_flag = 0,
 +      .cabac_init_flag = slice_hdr->cabac_init_flag,
-+      .cu_chroma_qp_offset_enabled_flag = 1,
-+      .deblocking_filter_override_flag = 1,
++      .cu_chroma_qp_offset_enabled_flag =
++          self->pps.pps_extension_params.chroma_qp_offset_list_enabled_flag,
++      .deblocking_filter_override_flag =
++          self->pps.deblocking_filter_override_enabled_flag,
 +      .slice_deblocking_filter_disabled_flag = 0,
 +      .collocated_from_l0_flag = 0,
 +      .slice_loop_filter_across_slices_enabled_flag = 0,
@@ -5505,6 +5680,10 @@ index 0000000..566b622
 +{
 +  GstVulkanH265Encoder *self = GST_VULKAN_H265_ENCODER (encoder);
 +
++  g_clear_pointer (&self->driver_sps_nal, g_free);
++  g_clear_pointer (&self->driver_pps_nal, g_free);
++  self->driver_sps_nal_size = self->driver_pps_nal_size = 0;
++
 +  gst_clear_object (&self->encoder);
 +  gst_clear_object (&self->encode_queue);
 +  gst_clear_object (&self->device);
@@ -5737,6 +5916,38 @@ index 0000000..566b622
 +  GST_OBJECT_UNLOCK (self);
 +}
 +
++/* PATCH (rc-fix): apply a bitrate change to an already-STARTED encoder without
++ * a reconfigure. Mirrors the rate half of _configure_rate_control() (clamp to
++ * the driver maximum, then CBR: max == average / VBR: the 66% target
++ * percentage); cpb_size is deliberately left alone, being a ratio of the two and
++ * therefore independent of the setpoint magnitude. */
++static void
++_update_live_bitrate (GstVulkanH265Encoder * self)
++{
++  GstVulkanVideoCapabilities vk_caps;
++  guint max_kbps;
++
++  if (!gst_vulkan_encoder_caps (self->encoder, &vk_caps))
++    return;
++
++  max_kbps = vk_caps.encoder.caps.maxBitrate / 1024;
++
++  GST_OBJECT_LOCK (self);
++  self->rc.bitrate = MIN (self->prop.bitrate, max_kbps);
++  if (self->rc.ratecontrol == VK_VIDEO_ENCODE_RATE_CONTROL_MODE_VBR_BIT_KHR) {
++    self->rc.max_bitrate = MIN ((guint)
++        gst_util_uint64_scale_int (self->rc.bitrate, 100, 66), max_kbps);
++  } else {
++    self->rc.max_bitrate = self->rc.bitrate;
++  }
++  GST_OBJECT_UNLOCK (self);
++
++  GST_DEBUG_OBJECT (self, "live bitrate retarget to %u kbps (max %u): no "
++      "session reset, no reconfigure", self->rc.bitrate, self->rc.max_bitrate);
++
++  gst_vulkan_encoder_request_rc_update (self->encoder);
++}
++
 +static void
 +gst_vulkan_h265_encoder_set_property (GObject * object, guint property_id,
 +    const GValue * value, GParamSpec * pspec)
@@ -5744,12 +5955,13 @@ index 0000000..566b622
 +  GstVulkanH265Encoder *self = GST_VULKAN_H265_ENCODER (object);
 +  GstH265Encoder *h264enc = GST_H265_ENCODER (object);
 +  gboolean reconfigure = FALSE;
++  gboolean bitrate_changed = FALSE;
 +
 +  GST_OBJECT_LOCK (self);
 +  switch (property_id) {
 +    case PROP_BITRATE:
 +      self->prop.bitrate = g_value_get_uint (value);
-+      reconfigure = TRUE;
++      bitrate_changed = TRUE;
 +      break;
 +    case PROP_AUD:
 +      self->prop.aud = g_value_get_boolean (value);
@@ -5787,6 +5999,24 @@ index 0000000..566b622
 +      break;
 +  }
 +  GST_OBJECT_UNLOCK (self);
++
++  /* PATCH (rc-fix): a live bitrate change must NOT go through
++   * gst_h265_encoder_reconfigure(). The base class's configure() drains the
++   * encoder and calls gst_h265_encoder_reset(), which zeroes
++   * gop.cur_frame_index — so the very next frame is an IDR that restarts the
++   * GOP. Measured on Tower with deploy/diag/vulkan_rc_retarget_probe.c: with the
++   * reconfigure, a retarget emits a key frame 0-1 frames later and realigns
++   * idr-period to the retarget point, i.e. under sustained ABR the keyframe
++   * interval collapses to the retarget interval. Removing the video-session
++   * reset alone does not fix that; the reconfigure is the IDR's actual source.
++   * Before start() there is nothing live to update, so the normal reconfigure
++   * path still runs. */
++  if (bitrate_changed) {
++    if (self->encoder && gst_vulkan_encoder_is_started (self->encoder))
++      _update_live_bitrate (self);
++    else
++      reconfigure = TRUE;
++  }
 +
 +  if (reconfigure)
 +    gst_h265_encoder_reconfigure (h264enc, FALSE);


### PR DESCRIPTION
Patch files for this branch's `patches/` set. I run all of these in my streaming stack on an RTX 5090 (driver 610.57.04, gst 1.28.4).

| Patch | What it does |
|---|---|
| `vulkanav1enc.patch` (new) | Vulkan Video AV1 encoder: base class + element + registration. Also adds `av1_encode_caps()` to `gstvkvideocaps.c`. Stock 1.28.4 returns FALSE for AV1 encode there, so nothing registers without it. Includes a GPU-free test suite for the reference model. |
| `gstreamer-vulkan-rc-retarget-no-reset.patch` (new) | A live bitrate retarget raises only `ENCODE_RATE_CONTROL_BIT`, not `RESET_BIT`. Before this, every retarget reset the session and forced a keyframe, on all three codecs. Also fixes DPB slot 0 never being released. |
| `vkh264enc-rc-fix.patch` (new here) | vulkanh264enc rate control is broken as shipped in 1.28 (silently CQP). The retarget patch needs it. |
| `vulkanh265enc.patch` (updated) | Same file plus NVIDIA conformance fixes: adopt driver parameter sets, emit driver SPS/PPS bytes verbatim, colorimetry on output caps. Without these, NVIDIA h265 fails `ffmpeg -err_detect +explode` on 116/120 frames. |

Apply order: dpb-pool (unchanged), vulkanh265enc, rc-fix, rc-retarget, vulkanav1enc.

AV1 evidence:
- 120/120 and 600/600 frames strict-decoded on vulkanav1dec
- Live WebRTC into Chrome at 1080p60 and 1440p120
- CBR tracks within a few percent. Upstream `libs_vkvideoencodeav1` conformance stays green
- Khronos validation layer clean

Scope: 8-bit 4:2:0 Main, intra + forward inter, single tile, CBR/VBR/CQP. No B-frames, no `show_existing_frame`, no 10-bit. All noted as TODOs in the source.

Caveat: NVIDIA only. I have no RADV encode box. Like the existing files these are vendored patches, regenerated per GStreamer bump. I keep them current.


Second commit: `docker/vulkan.Dockerfile` now applies the full chain, so this image build compiles the AV1 element too.
